### PR TITLE
Osgi bundles

### DIFF
--- a/odata-client-generator/pom.xml
+++ b/odata-client-generator/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>odata-client-generator</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>bundle</packaging>
     <description>OData client generator</description>
 
     <dependencies>

--- a/odata-client-msgraph-beta/pom.xml
+++ b/odata-client-msgraph-beta/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>odata-client-msgraph-beta</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>bundle</packaging>
     <description>OData client generator</description>
 
     <dependencies>

--- a/odata-client-msgraph-beta/src/main/java/com/github/davidmoten/msgraph/beta/MsGraph.java
+++ b/odata-client-msgraph-beta/src/main/java/com/github/davidmoten/msgraph/beta/MsGraph.java
@@ -1,7 +1,6 @@
 package com.github.davidmoten.msgraph.beta;
 
-import com.github.davidmoten.msgraph.MsGraphClientBuilder;
-import com.github.davidmoten.msgraph.MsGraphClientBuilder.Builder;
+import com.github.davidmoten.msgraph.builder.MsGraphClientBuilder;
 
 import odata.msgraph.client.beta.container.GraphService;
 
@@ -13,7 +12,7 @@ public final class MsGraph {
         // prevent instantiation
     }
 
-    public static Builder<GraphService> tenantName(String tenantName) {
+    public static MsGraphClientBuilder.Builder<GraphService> tenantName(String tenantName) {
         return new MsGraphClientBuilder<GraphService>(MSGRAPH_BETA_BASE_URL,
                 context -> new GraphService(context)).tenantName(tenantName);
     }

--- a/odata-client-msgraph-client-builder/pom.xml
+++ b/odata-client-msgraph-client-builder/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>odata-client-msgraph-client-builder</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>bundle</packaging>
     <description>Builds client for Microsoft Graph 1.0 and Beta, includes MsGraph authentication support</description>
 
     <dependencies>

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/AccessTokenProvider.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/AccessTokenProvider.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import java.util.function.Supplier;
 

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/AuthenticationEndpoint.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/AuthenticationEndpoint.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import com.github.davidmoten.guavamini.Preconditions;
 

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/Authenticator.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/Authenticator.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import java.util.List;
 

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/BearerAuthenticator.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/BearerAuthenticator.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/ClientCredentialsAccessTokenProvider.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/ClientCredentialsAccessTokenProvider.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/Creator.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/Creator.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import com.github.davidmoten.odata.client.Context;
 

--- a/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/MsGraphClientBuilder.java
+++ b/odata-client-msgraph-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/MsGraphClientBuilder.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.builder;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/odata-client-msgraph/pom.xml
+++ b/odata-client-msgraph/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>odata-client-msgraph</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>bundle</packaging>
     <description>OData client generator</description>
     <properties>
         <log4j.version>2.13.0</log4j.version>

--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/MsGraph.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/MsGraph.java
@@ -1,6 +1,6 @@
 package com.github.davidmoten.msgraph;
 
-import com.github.davidmoten.msgraph.MsGraphClientBuilder.Builder;
+import com.github.davidmoten.msgraph.builder.MsGraphClientBuilder;
 
 import odata.msgraph.client.container.GraphService;
 
@@ -12,7 +12,7 @@ public final class MsGraph {
         // prevent instantiation
     }
 
-    public static Builder<GraphService> tenantName(String tenantName) {
+    public static MsGraphClientBuilder.Builder<GraphService> tenantName(String tenantName) {
         return new MsGraphClientBuilder<GraphService> //
         (MSGRAPH_1_0_BASE_URL, //
                 context -> new GraphService(context)).tenantName(tenantName);

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/AdHocMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/AdHocMain.java
@@ -2,6 +2,8 @@ package com.github.davidmoten.msgraph;
 
 import java.util.concurrent.TimeUnit;
 
+import com.github.davidmoten.msgraph.builder.AuthenticationEndpoint;
+
 import com.github.davidmoten.odata.client.RequestHeader;
 
 import odata.msgraph.client.container.GraphService;

--- a/odata-client-runtime/pom.xml
+++ b/odata-client-runtime/pom.xml
@@ -10,6 +10,7 @@
     </parent>
     <artifactId>odata-client-runtime</artifactId>
     <name>${project.artifactId}</name>
+    <packaging>bundle</packaging>
     <description>OData client runtime for use with generated code</description>
 
     <dependencies>
@@ -89,5 +90,26 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                        <Export-Package>
+                            com.github.davidmoten.odata.client,
+                            com.github.davidmoten.odata.client.annotation,
+                            com.github.davidmoten.odata.client.edm,
+                            com.github.davidmoten.odata.client.internal, <!-- Guess internal doesn't really mean internal -->
+                            com.github.davidmoten.odata.csdl.v4.extras
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <release.plugin.version>2.5.1</release.plugin.version>
         <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
         <spotbugs.plugin.version>3.1.12.2</spotbugs.plugin.version>
+        <bundle.plugin.version>4.2.1</bundle.plugin.version>
     </properties>
 
     <licenses>
@@ -166,7 +167,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>${bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <obrRepository>NONE</obrRepository>


### PR DESCRIPTION
Update packaging to generate OSGI manifest data, to better support deployment in OSGI environments.

Sorry - take #2 on this pull request, there was a missing commit.

The first commit is simple enough, it just uses the maven-bundle-plugin to add the OSGI headers to the manifest of each jar file.

The second commit is more of a breaking change.  OSGI does not like multiple bundles (jar files) providing classes from the same package namespace.  In this case, you're using the same namespace for the odata-client-msgraph and odata-client-msgraph-client-builder packages (com.github.davidmoten.msgraph).   I've moved the builder classes into their own namespace, but this might have implications for client code if people have used any of the builder classes directly.