### PR TITLE
Add support for qualified entity types on entity collection requests

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
@@ -20,6 +20,7 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
     private Optional<Long> top = Optional.empty();
     private Optional<String> select = Optional.empty();
     private Optional<String> expand = Optional.empty();
+    private Optional<String> entityType = Optional.empty();
     private String metadata = "minimal";
 
     CollectionEntityRequestOptionsBuilder(CollectionPageEntityRequest<T, R> request) {
@@ -73,6 +74,11 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
         return this;
     }
 
+    public CollectionEntityRequestOptionsBuilder<T, R> entityType(String entityType) {
+        this.entityType = Optional.of(entityType);
+        return this;
+    }
+
     public CollectionEntityRequestOptionsBuilder<T, R> metadataFull() {
         this.metadata = "full";
         return this;
@@ -91,7 +97,7 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
     CollectionRequestOptions build() {
         requestHeaders.add(RequestHeader.acceptJsonWithMetadata(metadata));
         return new CollectionRequestOptions(requestHeaders, search, filter, orderBy, skip, top,
-                select, expand);
+                select, expand, entityType);
     }
 
     public CollectionPage<T> get() {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -24,7 +24,7 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
     }
 
     CollectionPage<T> get(CollectionRequestOptions options) {
-        ContextPath cp = contextPath.addQueries(options.getQueries());
+        ContextPath cp = options.getEntityType().map(t -> contextPath.addSegment(t)).orElse(contextPath).addQueries(options.getQueries());
         List<RequestHeader> h = RequestHelper.cleanAndSupplementRequestHeaders(options, "minimal",
                 false);
         HttpResponse r = cp.context().service().get(cp.toUrl(), h);
@@ -78,6 +78,10 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
 
     public CollectionEntityRequestOptionsBuilder<T, R> select(String clause) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).select(clause);
+    }
+
+    public CollectionEntityRequestOptionsBuilder<T, R> entityType(String entityType) {
+        return new CollectionEntityRequestOptionsBuilder<T, R>(this).entityType(entityType);
     }
 
     public CollectionEntityRequestOptionsBuilder<T, R> metadataFull() {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionRequestOptions.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionRequestOptions.java
@@ -15,10 +15,12 @@ public final class CollectionRequestOptions implements RequestOptions {
     private final Optional<Long> top;
     private final Optional<String> select;
     private final Optional<String> expand;
+    private final Optional<String> entityType;
 
     public CollectionRequestOptions(List<RequestHeader> requestHeaders, Optional<String> search,
             Optional<String> filter, Optional<String> orderBy, Optional<Long> skip,
-            Optional<Long> top, Optional<String> select, Optional<String> expand) {
+            Optional<Long> top, Optional<String> select, Optional<String> expand,
+            Optional<String> entityType) {
         this.requestHeaders = requestHeaders;
         this.search = search;
         this.filter = filter;
@@ -27,6 +29,13 @@ public final class CollectionRequestOptions implements RequestOptions {
         this.top = top;
         this.select = select;
         this.expand = expand;
+        this.entityType = entityType;
+    }
+
+    public CollectionRequestOptions(List<RequestHeader> requestHeaders, Optional<String> search,
+            Optional<String> filter, Optional<String> orderBy, Optional<Long> skip,
+            Optional<Long> top, Optional<String> select, Optional<String> expand) {
+        this(requestHeaders,search,filter,orderBy,skip,top,select,expand,null);
     }
 
     @Override
@@ -45,6 +54,10 @@ public final class CollectionRequestOptions implements RequestOptions {
         select.ifPresent(x -> map.put("$select", x));
         expand.ifPresent(x -> map.put("$expand", x));
         return map;
+    }
+
+    public Optional<String> getEntityType() {
+        return entityType;
     }
 
 }


### PR DESCRIPTION
Add support for qualified entity types on entity collection requests.

e.g. something like this: https://graph.microsoft.com/v1.0/groups/41a74a0e-3c43-4ee1-9172-9831e84220f1/members/microsoft.graph.user
Can be coded as this: client.groups().id("41a74a0e-3c43-4ee1-9172-9831e84220f1").get().getMembers().entityType("microsoft.graph.user").get()