### PR TITLE
add support for filtering on derived types to entity collection requests

### DIFF
--- a/odata-client-msgraph/src/test/resources/response-attachments-one-item.json
+++ b/odata-client-msgraph/src/test/resources/response-attachments-one-item.json
@@ -1,0 +1,19 @@
+{
+	"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('user001%40mycompany.com')/mailFolders('Inbox')/messages('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAA%3D%3D')/attachments",
+	"value": [
+		{
+			"@odata.type": "#microsoft.graph.itemAttachment",
+			"@odata.id": "users('user001%40mycompany.com')/mailFolders('Inbox')/messages('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAA%3D%3D')/attachments('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAAESABAAYI_9no28PU_8T27UrnPn-Q%3D%3D')",
+			"@odata.editLink": "editLink1",
+			"id": "AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAAESABAAYI_9no28PU_8T27UrnPn-Q==",
+			"lastModifiedDateTime@odata.type": "#DateTimeOffset",
+			"lastModifiedDateTime": "2020-02-07T05:25:37Z",
+			"name": "Something",
+			"contentType": null,
+			"size": 18697,
+			"isInline": false,
+			"item@odata.associationLink": "https://graph.microsoft.com/v1.0/users('user001%40mycompany.com')/mailFolders('Inbox')/messages('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAA%3D%3D')/attachments('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAAESABAAYI_9no28PU_8T27UrnPn-Q%3D%3D')/microsoft.graph.itemAttachment/item/$ref",
+			"item@odata.navigationLink": "https://graph.microsoft.com/v1.0/users('user001%40mycompany.com')/mailFolders('Inbox')/messages('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAA%3D%3D')/attachments('AQMkADQ3YjdiNWUxLTBmYWQtNDMwYy04Yzc0LTI0MDdmOWQ4NDFjNgBGAAAD4Rwe0e6XOE6Ck412HUUUTwcAUb5I0z9LnUy3cpFj0m9MUgAAAgEMAAAA3NEVJKXfYEuEjYE7msyHXwACufIe7gAAAAESABAAYI_9no28PU_8T27UrnPn-Q%3D%3D')/microsoft.graph.itemAttachment/item"
+		}
+	]
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
@@ -133,4 +133,8 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
         return request.post(build(), entity);
     }
 
+    public List<T> toList() {
+        return get().toList();
+    }
+
 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
@@ -13,18 +13,35 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
 
     private final CollectionPageEntityRequest<T, R> request;
     private final List<RequestHeader> requestHeaders = new ArrayList<>();
-    private Optional<String> search = Optional.empty();
-    private Optional<String> filter = Optional.empty();
-    private Optional<String> orderBy = Optional.empty();
-    private Optional<Long> skip = Optional.empty();
-    private Optional<Long> top = Optional.empty();
-    private Optional<String> select = Optional.empty();
-    private Optional<String> expand = Optional.empty();
-    private String metadata = "minimal";
+    private Optional<String> search;
+    private Optional<String> filter;
+    private Optional<String> orderBy;
+    private Optional<Long> skip;
+    private Optional<Long> top;
+    private Optional<String> select;
+    private Optional<String> expand;
+    private String metadata;
 
     CollectionEntityRequestOptionsBuilder(CollectionPageEntityRequest<T, R> request) {
-        this.request = request;
+        this(request, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), "minimal");
     }
+    
+    private CollectionEntityRequestOptionsBuilder(CollectionPageEntityRequest<T, R> request, Optional<String> search,
+            Optional<String> filter, Optional<String> orderBy, Optional<Long> skip, Optional<Long> top,
+            Optional<String> select, Optional<String> expand, String metadata) {
+        this.request = request;
+        this.search = search;
+        this.filter = filter;
+        this.orderBy = orderBy;
+        this.skip = skip;
+        this.top = top;
+        this.select = select;
+        this.expand = expand;
+        this.metadata = metadata;
+    }
+
+
 
     public CollectionEntityRequestOptionsBuilder<T, R> requestHeader(String name, String value) {
         requestHeaders.add(new RequestHeader(name, value));
@@ -87,7 +104,12 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
         this.metadata = "none";
         return this;
     }
-
+    
+    public <S extends T> CollectionEntityRequestOptionsBuilder<S, EntityRequest<S>> filter(Class<S> cls) {
+        return new CollectionEntityRequestOptionsBuilder<S, EntityRequest<S>>(request.filter(cls), search, filter,
+                orderBy, skip, top, select, expand, metadata);
+    }
+    
     CollectionRequestOptions build() {
         requestHeaders.add(RequestHeader.acceptJsonWithMetadata(metadata));
         return new CollectionRequestOptions(requestHeaders, search, filter, orderBy, skip, top,

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -51,6 +51,21 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
     public T post(T entity) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).post(entity);
     }
+    
+    @SuppressWarnings("unchecked")
+    public <S extends T> CollectionPageEntityRequest<S, EntityRequest<S>> filter(Class<S> cls) {
+        //TODO should not allow multiple calls to filter?
+        return new CollectionPageEntityRequest<S, EntityRequest<S>>(contextPath.addSegment(odataTypeName(cls)), cls,
+                (EntityRequestFactory<S, EntityRequest<S>>) entityRequestFactory, schemaInfo);
+    }
+    
+    private static <T extends ODataEntityType> String odataTypeName(Class<T> cls) {
+        try {
+            return cls.newInstance().odataTypeName();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new ClientException(e);
+        }
+    }
 
     public CollectionEntityRequestOptionsBuilder<T, R> requestHeader(String key, String value) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).requestHeader(key, value);

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -1,5 +1,7 @@
 package com.github.davidmoten.odata.client;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -47,6 +49,10 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
     public Stream<T> stream() {
         return get().stream();
     }
+    
+    public List<T> toList() {
+        return get().toList();
+    }
 
     public T post(T entity) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).post(entity);
@@ -61,8 +67,12 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
     
     private static <T extends ODataEntityType> String odataTypeName(Class<T> cls) {
         try {
-            return cls.newInstance().odataTypeName();
-        } catch (InstantiationException | IllegalAccessException e) {
+            Constructor<T> constructor = cls.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            T o = constructor.newInstance();
+            return o.odataTypeName();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
             throw new ClientException(e);
         }
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -59,13 +59,15 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
     }
     
     /**
-     * Returns a request for only those members of the collection that are of the requested type.
-     * This is referred to in the <a href=
+     * Returns a request for only those members of the collection that are of the
+     * requested type. This is referred to in the <a href=
      * "http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html">OData
      * 4.01 specification</a> as a "restriction to instances of the derived type".
      * 
-     * @param <S> the class ("derived type") to be restricting to
-     * @param cls the class of S
+     * @param <S>
+     *            the type ("derived type") to be restricting to
+     * @param cls
+     *            the Class of the type to restrict to
      * @return a request for a collection of instances with the given type
      */
     @SuppressWarnings("unchecked")

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -58,9 +58,18 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).post(entity);
     }
     
+    /**
+     * Returns a request for only those members of the collection that are of the requested type.
+     * This is referred to in the <a href=
+     * "http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html">OData
+     * 4.01 specification</a> as a "restriction to instances of the derived type".
+     * 
+     * @param <S> the class ("derived type") to be restricting to
+     * @param cls the class of S
+     * @return a request for a collection of instances with the given type
+     */
     @SuppressWarnings("unchecked")
     public <S extends T> CollectionPageEntityRequest<S, EntityRequest<S>> filter(Class<S> cls) {
-        //TODO should not allow multiple calls to filter?
         return new CollectionPageEntityRequest<S, EntityRequest<S>>(contextPath.addSegment(odataTypeName(cls)), cls,
                 (EntityRequestFactory<S, EntityRequest<S>>) entityRequestFactory, schemaInfo);
     }


### PR DESCRIPTION
as discussed in #8 this should work. I'll confirm when I write a unit test for it. I already have a unit test somewhere that returns a collection of Attachment and the objects returned in the list are of type ItemAttachment,  FileAttachment so I should be able to reuse that data.