### PR TITLE
Support extra schema in msgraph v1.0 metadata, improve schema alias support

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -71,6 +71,7 @@ import com.github.davidmoten.odata.client.TestingService.ContainerBuilder;
 import com.github.davidmoten.odata.client.UploadStrategy;
 import com.github.davidmoten.odata.client.annotation.NavigationProperty;
 import com.github.davidmoten.odata.client.annotation.Property;
+import com.github.davidmoten.odata.client.generator.Names.SchemaAndType;
 import com.github.davidmoten.odata.client.generator.model.Action;
 import com.github.davidmoten.odata.client.generator.model.Action.Parameter;
 import com.github.davidmoten.odata.client.generator.model.Action.ReturnType;
@@ -110,6 +111,16 @@ public final class Generator {
         schemas //
                 .stream() //
                 .forEach(s -> log("  " + s.getNamespace()));
+        
+        schemas //
+        .stream() //
+        .flatMap(s -> Util
+                .filter(s.getComplexTypeOrEntityTypeOrTypeDefinition(), TEntityType.class)
+                .map(t -> new SchemaAndType<TEntityType>(s, t))) //
+        .map(x -> names.toTypeWithNamespace(x.schema, x.type.getName())
+                ) //
+        .forEach(System.out::println);
+        
         log("-----------------------------------");
         log("replacing aliases");
         Util.replaceAliases(schemas);

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
@@ -388,7 +388,7 @@ public final class Names {
         return toDirectory(output, o.pkg() + o.packageSuffixEntity());
     }
 
-    private static final class SchemaAndType<T> {
+    static final class SchemaAndType<T> {
         final Schema schema;
         final T type;
 
@@ -494,7 +494,7 @@ public final class Names {
         return Names.toSimpleClassName(name + o.entityRequestClassSuffix());
     }
 
-    private String toTypeWithNamespace(Schema schema, String simpleType) {
+    String toTypeWithNamespace(Schema schema, String simpleType) {
         return schema.getNamespace() + "." + simpleType;
     }
 

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Util.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Util.java
@@ -2,6 +2,7 @@ package com.github.davidmoten.odata.client.generator;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -130,11 +131,12 @@ public final class Util {
     static String replaceAlias(String alias, String namespace, String type) {
         if (type == null || alias == null) {
             return type;
-        }
-        if (type.startsWith("Collection(")) {
+        } else if (Pattern.matches("^Collection\\(" + alias + "\\.[^.]+\\)$", type)) {
             return type.replaceFirst("^Collection\\(" + alias + "\\b", "Collection(" + namespace);
-        } else {
+        } else if (Pattern.matches("^" + alias + "\\.[^.]+$", type)) {
             return type.replaceFirst("^" + alias + "\\b", namespace);
+        } else {
+            return type;
         }
     }
 

--- a/odata-client-generator/src/main/odata/msgraph-metadata.xml
+++ b/odata-client-generator/src/main/odata/msgraph-metadata.xml
@@ -381,6 +381,23 @@
         <Member Name="replyToAll" Value="9"/>
         <Member Name="review" Value="10"/>
       </EnumType>
+      <EnumType Name="riskDetectionTimingType">
+        <Member Name="notDefined" Value="0"/>
+        <Member Name="realtime" Value="1"/>
+        <Member Name="nearRealtime" Value="2"/>
+        <Member Name="offline" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="activityType">
+        <Member Name="signin" Value="0"/>
+        <Member Name="user" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="tokenIssuerType">
+        <Member Name="AzureAD" Value="0"/>
+        <Member Name="ADFederationServices" Value="1"/>
+        <Member Name="UnknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="installIntent">
         <Member Name="available" Value="0"/>
         <Member Name="required" Value="1"/>
@@ -1399,6 +1416,12 @@
         <Member Name="unknownFutureValue" Value="32767"/>
         <Member Name="unknown" Value="-1"/>
       </EnumType>
+      <EnumType Name="securityResourceType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="attacked" Value="1"/>
+        <Member Name="related" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
       <EnumType Name="userAccountSecurityType">
         <Member Name="unknown" Value="0"/>
         <Member Name="standard" Value="1"/>
@@ -1834,6 +1857,8 @@
         <Property Name="department" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="employeeId" Type="Edm.String"/>
+        <Property Name="externalUserState" Type="Edm.String"/>
+        <Property Name="externalUserStateChangeDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="faxNumber" Type="Edm.String"/>
         <Property Name="givenName" Type="Edm.String"/>
         <Property Name="identities" Type="Collection(graph.objectIdentity)"/>
@@ -2390,6 +2415,8 @@
         <Property Name="audioConferencing" Type="graph.audioConferencing"/>
         <Property Name="chatInfo" Type="graph.chatInfo"/>
         <Property Name="videoTeleconferenceId" Type="Edm.String"/>
+        <Property Name="externalId" Type="Edm.String"/>
+        <Property Name="joinInformation" Type="graph.itemBody"/>
       </EntityType>
       <EntityType Name="team" BaseType="graph.entity" OpenType="true">
         <Property Name="webUrl" Type="Edm.String"/>
@@ -2719,17 +2746,21 @@
         <Property Name="appliesTo" Type="Edm.String"/>
       </ComplexType>
       <EntityType Name="group" BaseType="graph.directoryObject" OpenType="true">
+        <Property Name="assignedLabels" Type="Collection(graph.assignedLabel)"/>
         <Property Name="assignedLicenses" Type="Collection(graph.assignedLicense)"/>
         <Property Name="classification" Type="Edm.String"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="hasMembersWithLicenseErrors" Type="Edm.Boolean"/>
         <Property Name="groupTypes" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="licenseProcessingState" Type="graph.licenseProcessingState"/>
         <Property Name="mail" Type="Edm.String"/>
         <Property Name="mailEnabled" Type="Edm.Boolean"/>
         <Property Name="mailNickname" Type="Edm.String"/>
+        <Property Name="membershipRule" Type="Edm.String"/>
+        <Property Name="membershipRuleProcessingState" Type="Edm.String"/>
         <Property Name="onPremisesDomainName" Type="Edm.String"/>
         <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="onPremisesNetBiosName" Type="Edm.String"/>
@@ -2738,10 +2769,12 @@
         <Property Name="onPremisesSecurityIdentifier" Type="Edm.String"/>
         <Property Name="onPremisesSyncEnabled" Type="Edm.Boolean"/>
         <Property Name="preferredDataLocation" Type="Edm.String"/>
+        <Property Name="preferredLanguage" Type="Edm.String"/>
         <Property Name="proxyAddresses" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="renewedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="securityEnabled" Type="Edm.Boolean"/>
         <Property Name="securityIdentifier" Type="Edm.String"/>
+        <Property Name="theme" Type="Edm.String"/>
         <Property Name="visibility" Type="Edm.String"/>
         <Property Name="allowExternalSenders" Type="Edm.Boolean"/>
         <Property Name="autoSubscribeNewMembers" Type="Edm.Boolean"/>
@@ -2777,6 +2810,10 @@
         <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
         <NavigationProperty Name="team" Type="graph.team" ContainsTarget="true"/>
       </EntityType>
+      <ComplexType Name="assignedLabel">
+        <Property Name="labelId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="licenseProcessingState">
         <Property Name="state" Type="Edm.String"/>
       </ComplexType>
@@ -4178,6 +4215,75 @@
         <Property Name="name" Type="Edm.String"/>
         <Property Name="type" Type="Edm.String"/>
       </ComplexType>
+      <EntityType Name="cloudCommunications" BaseType="graph.entity">
+        <NavigationProperty Name="calls" Type="Collection(graph.call)" ContainsTarget="true"/>
+        <NavigationProperty Name="callRecords" Type="Collection(microsoft.graph.callRecords.callRecord)" ContainsTarget="true"/>
+        <NavigationProperty Name="onlineMeetings" Type="Collection(graph.onlineMeeting)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="call" BaseType="graph.entity" OpenType="true">
+        <Property Name="state" Type="graph.callState"/>
+        <Property Name="mediaState" Type="graph.callMediaState"/>
+        <Property Name="resultInfo" Type="graph.resultInfo"/>
+        <Property Name="direction" Type="graph.callDirection"/>
+        <Property Name="subject" Type="Edm.String"/>
+        <Property Name="callbackUri" Type="Edm.String" Nullable="false"/>
+        <Property Name="callRoutes" Type="Collection(graph.callRoute)"/>
+        <Property Name="source" Type="graph.participantInfo"/>
+        <Property Name="targets" Type="Collection(graph.invitationParticipantInfo)"/>
+        <Property Name="requestedModalities" Type="Collection(graph.modality)"/>
+        <Property Name="mediaConfig" Type="graph.mediaConfig"/>
+        <Property Name="chatInfo" Type="graph.chatInfo"/>
+        <Property Name="callOptions" Type="graph.callOptions"/>
+        <Property Name="meetingInfo" Type="graph.meetingInfo"/>
+        <Property Name="tenantId" Type="Edm.String"/>
+        <Property Name="myParticipantId" Type="Edm.String"/>
+        <Property Name="toneInfo" Type="graph.toneInfo"/>
+        <Property Name="callChainId" Type="Edm.String"/>
+        <Property Name="incomingContext" Type="graph.incomingContext"/>
+        <NavigationProperty Name="participants" Type="Collection(graph.participant)" ContainsTarget="true"/>
+        <NavigationProperty Name="operations" Type="Collection(graph.commsOperation)" ContainsTarget="true"/>
+      </EntityType>
+      <ComplexType Name="riskUserActivity">
+        <Property Name="riskEventTypes" Type="Collection(Edm.String)"/>
+        <Property Name="detail" Type="graph.riskDetail"/>
+      </ComplexType>
+      <EntityType Name="riskDetection" BaseType="graph.entity">
+        <Property Name="requestId" Type="Edm.String"/>
+        <Property Name="correlationId" Type="Edm.String"/>
+        <Property Name="riskEventType" Type="Edm.String"/>
+        <Property Name="riskState" Type="graph.riskState"/>
+        <Property Name="riskLevel" Type="graph.riskLevel"/>
+        <Property Name="riskDetail" Type="graph.riskDetail"/>
+        <Property Name="source" Type="Edm.String"/>
+        <Property Name="detectionTimingType" Type="graph.riskDetectionTimingType"/>
+        <Property Name="activity" Type="graph.activityType"/>
+        <Property Name="tokenIssuerType" Type="graph.tokenIssuerType"/>
+        <Property Name="ipAddress" Type="Edm.String"/>
+        <Property Name="location" Type="graph.signInLocation"/>
+        <Property Name="activityDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="detectedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="userId" Type="Edm.String"/>
+        <Property Name="userDisplayName" Type="Edm.String"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+        <Property Name="additionalInfo" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="riskyUser" BaseType="graph.entity">
+        <Property Name="isDeleted" Type="Edm.Boolean"/>
+        <Property Name="isProcessing" Type="Edm.Boolean"/>
+        <Property Name="riskLastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="riskLevel" Type="graph.riskLevel"/>
+        <Property Name="riskState" Type="graph.riskState"/>
+        <Property Name="riskDetail" Type="graph.riskDetail"/>
+        <Property Name="userDisplayName" Type="Edm.String"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+        <NavigationProperty Name="history" Type="Collection(graph.riskyUserHistoryItem)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="riskyUserHistoryItem" BaseType="graph.riskyUser">
+        <Property Name="userId" Type="Edm.String"/>
+        <Property Name="initiatedBy" Type="Edm.String"/>
+        <Property Name="activity" Type="graph.riskUserActivity"/>
+      </EntityType>
       <EntityType Name="deviceAppManagement" BaseType="graph.entity">
         <Property Name="microsoftStoreForBusinessLastSuccessfulSyncDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="isEnabledForMicrosoftStoreForBusiness" Type="Edm.Boolean" Nullable="false"/>
@@ -6671,12 +6777,14 @@
         <Property Name="fileStates" Type="Collection(graph.fileSecurityState)"/>
         <Property Name="historyStates" Type="Collection(graph.alertHistoryState)"/>
         <Property Name="hostStates" Type="Collection(graph.hostSecurityState)"/>
+        <Property Name="incidentIds" Type="Collection(Edm.String)"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="malwareStates" Type="Collection(graph.malwareState)"/>
         <Property Name="networkConnections" Type="Collection(graph.networkConnection)"/>
         <Property Name="processes" Type="Collection(graph.process)"/>
         <Property Name="recommendedActions" Type="Collection(Edm.String)"/>
         <Property Name="registryKeyStates" Type="Collection(graph.registryKeyState)"/>
+        <Property Name="securityResources" Type="Collection(graph.securityResource)"/>
         <Property Name="severity" Type="graph.alertSeverity" Nullable="false"/>
         <Property Name="sourceMaterials" Type="Collection(Edm.String)"/>
         <Property Name="status" Type="graph.alertStatus" Nullable="false"/>
@@ -6766,6 +6874,7 @@
         <Property Name="applicationName" Type="Edm.String"/>
         <Property Name="destinationAddress" Type="Edm.String"/>
         <Property Name="destinationDomain" Type="Edm.String"/>
+        <Property Name="destinationLocation" Type="Edm.String"/>
         <Property Name="destinationPort" Type="Edm.String"/>
         <Property Name="destinationUrl" Type="Edm.String"/>
         <Property Name="direction" Type="graph.connectionDirection"/>
@@ -6778,6 +6887,7 @@
         <Property Name="protocol" Type="graph.securityNetworkProtocol"/>
         <Property Name="riskScore" Type="Edm.String"/>
         <Property Name="sourceAddress" Type="Edm.String"/>
+        <Property Name="sourceLocation" Type="Edm.String"/>
         <Property Name="sourcePort" Type="Edm.String"/>
         <Property Name="status" Type="graph.connectionStatus"/>
         <Property Name="urlParameters" Type="Edm.String"/>
@@ -6807,6 +6917,10 @@
         <Property Name="valueData" Type="Edm.String"/>
         <Property Name="valueName" Type="Edm.String"/>
         <Property Name="valueType" Type="graph.registryValueType"/>
+      </ComplexType>
+      <ComplexType Name="securityResource">
+        <Property Name="resource" Type="Edm.String"/>
+        <Property Name="resourceType" Type="graph.securityResourceType"/>
       </ComplexType>
       <ComplexType Name="alertTrigger">
         <Property Name="name" Type="Edm.String"/>
@@ -6865,33 +6979,6 @@
         <Property Name="updatedBy" Type="Edm.String"/>
         <Property Name="updatedDateTime" Type="Edm.DateTimeOffset"/>
       </ComplexType>
-      <EntityType Name="cloudCommunications" BaseType="graph.entity">
-        <NavigationProperty Name="calls" Type="Collection(graph.call)" ContainsTarget="true"/>
-        <NavigationProperty Name="onlineMeetings" Type="Collection(graph.onlineMeeting)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="call" BaseType="graph.entity" OpenType="true">
-        <Property Name="state" Type="graph.callState"/>
-        <Property Name="mediaState" Type="graph.callMediaState"/>
-        <Property Name="resultInfo" Type="graph.resultInfo"/>
-        <Property Name="direction" Type="graph.callDirection"/>
-        <Property Name="subject" Type="Edm.String"/>
-        <Property Name="callbackUri" Type="Edm.String" Nullable="false"/>
-        <Property Name="callRoutes" Type="Collection(graph.callRoute)"/>
-        <Property Name="source" Type="graph.participantInfo"/>
-        <Property Name="targets" Type="Collection(graph.invitationParticipantInfo)"/>
-        <Property Name="requestedModalities" Type="Collection(graph.modality)"/>
-        <Property Name="mediaConfig" Type="graph.mediaConfig"/>
-        <Property Name="chatInfo" Type="graph.chatInfo"/>
-        <Property Name="callOptions" Type="graph.callOptions"/>
-        <Property Name="meetingInfo" Type="graph.meetingInfo"/>
-        <Property Name="tenantId" Type="Edm.String"/>
-        <Property Name="myParticipantId" Type="Edm.String"/>
-        <Property Name="toneInfo" Type="graph.toneInfo"/>
-        <Property Name="callChainId" Type="Edm.String"/>
-        <Property Name="incomingContext" Type="graph.incomingContext"/>
-        <NavigationProperty Name="participants" Type="Collection(graph.participant)" ContainsTarget="true"/>
-        <NavigationProperty Name="operations" Type="Collection(graph.commsOperation)" ContainsTarget="true"/>
-      </EntityType>
       <ComplexType Name="callMediaState">
         <Property Name="audio" Type="graph.mediaState"/>
       </ComplexType>
@@ -10603,6 +10690,14 @@
         <Parameter Name="groupId" Type="Edm.String" Nullable="false" Unicode="false"/>
         <ReturnType Type="Edm.Boolean" Nullable="false"/>
       </Action>
+      <Action Name="dismiss" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.riskyUser)"/>
+        <Parameter Name="userIds" Type="Collection(Edm.String)" Unicode="false"/>
+      </Action>
+      <Action Name="confirmCompromised" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.riskyUser)"/>
+        <Parameter Name="userIds" Type="Collection(Edm.String)" Unicode="false"/>
+      </Action>
       <Action Name="assign" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.mobileApp"/>
         <Parameter Name="mobileAppAssignments" Type="Collection(graph.mobileAppAssignment)"/>
@@ -11340,6 +11435,16 @@
         <Parameter Name="clientContext" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.updateRecordingStatusOperation"/>
       </Action>
+      <Action Name="createOrGet" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.onlineMeeting)"/>
+        <Parameter Name="chatInfo" Type="graph.chatInfo"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="externalId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="participants" Type="graph.meetingParticipants"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="subject" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="graph.onlineMeeting"/>
+      </Action>
       <Action Name="invite" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.participant)"/>
         <Parameter Name="participants" Type="Collection(graph.invitationParticipantInfo)" Nullable="false"/>
@@ -11467,6 +11572,8 @@
         <EntitySet Name="sites" EntityType="microsoft.graph.site"/>
         <EntitySet Name="schemaExtensions" EntityType="microsoft.graph.schemaExtension"/>
         <EntitySet Name="groupLifecyclePolicies" EntityType="microsoft.graph.groupLifecyclePolicy"/>
+        <EntitySet Name="riskDetections" EntityType="microsoft.graph.riskDetection"/>
+        <EntitySet Name="riskyUsers" EntityType="microsoft.graph.riskyUser"/>
         <EntitySet Name="dataPolicyOperations" EntityType="microsoft.graph.dataPolicyOperation"/>
         <EntitySet Name="subscriptions" EntityType="microsoft.graph.subscription"/>
         <EntitySet Name="teams" EntityType="microsoft.graph.team"/>
@@ -11498,12 +11605,12 @@
           <NavigationPropertyBinding Path="items/createdByUser" Target="users"/>
           <NavigationPropertyBinding Path="items/lastModifiedByUser" Target="users"/>
         </Singleton>
+        <Singleton Name="communications" Type="microsoft.graph.cloudCommunications"/>
         <Singleton Name="deviceAppManagement" Type="microsoft.graph.deviceAppManagement"/>
         <Singleton Name="deviceManagement" Type="microsoft.graph.deviceManagement"/>
         <Singleton Name="reports" Type="microsoft.graph.reportRoot"/>
         <Singleton Name="planner" Type="microsoft.graph.planner"/>
         <Singleton Name="Security" Type="microsoft.graph.security"/>
-        <Singleton Name="communications" Type="microsoft.graph.cloudCommunications"/>
         <Singleton Name="appCatalogs" Type="microsoft.graph.appCatalogs"/>
         <Singleton Name="teamwork" Type="microsoft.graph.teamwork"/>
         <Singleton Name="informationProtection" Type="microsoft.graph.informationProtection"/>
@@ -12859,6 +12966,54 @@
         <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
           <Record>
             <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.riskDetection">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.riskyUser">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.riskyUserHistoryItem">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -18867,6 +19022,251 @@
       <Annotations Target="microsoft.graph.offerShiftRequest/recipientActionDateTime">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
       </Annotations>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph.callRecords">
+      <EnumType Name="callType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="groupCall" Value="1"/>
+        <Member Name="peerToPeer" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="clientPlatform">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="windows" Value="1"/>
+        <Member Name="macOS" Value="2"/>
+        <Member Name="iOS" Value="3"/>
+        <Member Name="android" Value="4"/>
+        <Member Name="web" Value="5"/>
+        <Member Name="ipPhone" Value="6"/>
+        <Member Name="roomSystem" Value="7"/>
+        <Member Name="surfaceHub" Value="8"/>
+        <Member Name="holoLens" Value="9"/>
+        <Member Name="unknownFutureValue" Value="10"/>
+      </EnumType>
+      <EnumType Name="failureStage">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="callSetup" Value="1"/>
+        <Member Name="midcall" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="mediaStreamDirection">
+        <Member Name="callerToCallee" Value="0"/>
+        <Member Name="calleeToCaller" Value="1"/>
+      </EnumType>
+      <EnumType Name="networkConnectionType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="wired" Value="1"/>
+        <Member Name="wifi" Value="2"/>
+        <Member Name="mobile" Value="3"/>
+        <Member Name="tunnel" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+      </EnumType>
+      <EnumType Name="productFamily">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="teams" Value="1"/>
+        <Member Name="skypeForBusiness" Value="2"/>
+        <Member Name="lync" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="serviceRole">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="customBot" Value="1"/>
+        <Member Name="skypeForBusinessMicrosoftTeamsGateway" Value="2"/>
+        <Member Name="skypeForBusinessAudioVideoMcu" Value="3"/>
+        <Member Name="skypeForBusinessApplicationSharingMcu" Value="4"/>
+        <Member Name="skypeForBusinessCallQueues" Value="5"/>
+        <Member Name="skypeForBusinessAutoAttendant" Value="6"/>
+        <Member Name="mediationServer" Value="7"/>
+        <Member Name="mediationServerCloudConnectorEdition" Value="8"/>
+        <Member Name="exchangeUnifiedMessagingService" Value="9"/>
+        <Member Name="mediaController" Value="10"/>
+        <Member Name="conferencingAnnouncementService" Value="11"/>
+        <Member Name="conferencingAttendant" Value="12"/>
+        <Member Name="audioTeleconferencerController" Value="13"/>
+        <Member Name="skypeForBusinessUnifiedCommunicationApplicationPlatform" Value="14"/>
+        <Member Name="responseGroupServiceAnnouncementService" Value="15"/>
+        <Member Name="gateway" Value="16"/>
+        <Member Name="skypeTranslator" Value="17"/>
+        <Member Name="skypeForBusinessAttendant" Value="18"/>
+        <Member Name="responseGroupService" Value="19"/>
+        <Member Name="unknownFutureValue" Value="20"/>
+      </EnumType>
+      <EnumType Name="userFeedbackRating">
+        <Member Name="notRated" Value="0"/>
+        <Member Name="bad" Value="1"/>
+        <Member Name="poor" Value="2"/>
+        <Member Name="fair" Value="3"/>
+        <Member Name="good" Value="4"/>
+        <Member Name="excellent" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
+      </EnumType>
+      <EnumType Name="wifiBand">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="frequency24GHz" Value="1"/>
+        <Member Name="frequency50GHz" Value="2"/>
+        <Member Name="frequency60GHz" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="wifiRadioType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="wifi80211a" Value="1"/>
+        <Member Name="wifi80211b" Value="2"/>
+        <Member Name="wifi80211g" Value="3"/>
+        <Member Name="wifi80211n" Value="4"/>
+        <Member Name="wifi80211ac" Value="5"/>
+        <Member Name="wifi80211ax" Value="6"/>
+        <Member Name="unknownFutureValue" Value="7"/>
+      </EnumType>
+      <EnumType Name="modality">
+        <Member Name="audio" Value="0"/>
+        <Member Name="video" Value="1"/>
+        <Member Name="videoBasedScreenSharing" Value="2"/>
+        <Member Name="data" Value="3"/>
+        <Member Name="screenSharing" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+      </EnumType>
+      <EntityType Name="callRecord" BaseType="graph.entity">
+        <Property Name="version" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="type" Type="microsoft.graph.callRecords.callType" Nullable="false"/>
+        <Property Name="modalities" Type="Collection(microsoft.graph.callRecords.modality)" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="organizer" Type="graph.identitySet"/>
+        <Property Name="participants" Type="Collection(graph.identitySet)"/>
+        <Property Name="joinWebUrl" Type="Edm.String"/>
+        <NavigationProperty Name="sessions" Type="Collection(microsoft.graph.callRecords.session)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="session" BaseType="graph.entity">
+        <Property Name="modalities" Type="Collection(microsoft.graph.callRecords.modality)" Nullable="false"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="caller" Type="microsoft.graph.callRecords.endpoint"/>
+        <Property Name="callee" Type="microsoft.graph.callRecords.endpoint"/>
+        <Property Name="failureInfo" Type="microsoft.graph.callRecords.failureInfo"/>
+        <NavigationProperty Name="segments" Type="Collection(microsoft.graph.callRecords.segment)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="segment" BaseType="graph.entity">
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="caller" Type="microsoft.graph.callRecords.endpoint"/>
+        <Property Name="callee" Type="microsoft.graph.callRecords.endpoint"/>
+        <Property Name="failureInfo" Type="microsoft.graph.callRecords.failureInfo"/>
+        <Property Name="media" Type="Collection(microsoft.graph.callRecords.media)"/>
+      </EntityType>
+      <ComplexType Name="endpoint">
+        <Property Name="userAgent" Type="microsoft.graph.callRecords.userAgent"/>
+      </ComplexType>
+      <ComplexType Name="userAgent" Abstract="true">
+        <Property Name="headerValue" Type="Edm.String"/>
+        <Property Name="applicationVersion" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="failureInfo">
+        <Property Name="stage" Type="microsoft.graph.callRecords.failureStage" Nullable="false"/>
+        <Property Name="reason" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="media">
+        <Property Name="label" Type="Edm.String"/>
+        <Property Name="callerNetwork" Type="microsoft.graph.callRecords.networkInfo"/>
+        <Property Name="calleeNetwork" Type="microsoft.graph.callRecords.networkInfo"/>
+        <Property Name="callerDevice" Type="microsoft.graph.callRecords.deviceInfo"/>
+        <Property Name="calleeDevice" Type="microsoft.graph.callRecords.deviceInfo"/>
+        <Property Name="streams" Type="Collection(microsoft.graph.callRecords.mediaStream)"/>
+      </ComplexType>
+      <ComplexType Name="networkInfo">
+        <Property Name="ipAddress" Type="Edm.String"/>
+        <Property Name="subnet" Type="Edm.String"/>
+        <Property Name="linkSpeed" Type="Edm.Int64"/>
+        <Property Name="connectionType" Type="microsoft.graph.callRecords.networkConnectionType" Nullable="false"/>
+        <Property Name="port" Type="Edm.Int32"/>
+        <Property Name="reflexiveIPAddress" Type="Edm.String"/>
+        <Property Name="relayIPAddress" Type="Edm.String"/>
+        <Property Name="relayPort" Type="Edm.Int32"/>
+        <Property Name="macAddress" Type="Edm.String"/>
+        <Property Name="wifiMicrosoftDriver" Type="Edm.String"/>
+        <Property Name="wifiMicrosoftDriverVersion" Type="Edm.String"/>
+        <Property Name="wifiVendorDriver" Type="Edm.String"/>
+        <Property Name="wifiVendorDriverVersion" Type="Edm.String"/>
+        <Property Name="wifiChannel" Type="Edm.Int32"/>
+        <Property Name="wifiBand" Type="microsoft.graph.callRecords.wifiBand" Nullable="false"/>
+        <Property Name="basicServiceSetIdentifier" Type="Edm.String"/>
+        <Property Name="wifiRadioType" Type="microsoft.graph.callRecords.wifiRadioType" Nullable="false"/>
+        <Property Name="wifiSignalStrength" Type="Edm.Int32"/>
+        <Property Name="wifiBatteryCharge" Type="Edm.Int32"/>
+        <Property Name="dnsSuffix" Type="Edm.String"/>
+        <Property Name="sentQualityEventRatio" Type="Edm.Single"/>
+        <Property Name="receivedQualityEventRatio" Type="Edm.Single"/>
+        <Property Name="delayEventRatio" Type="Edm.Single"/>
+        <Property Name="bandwidthLowEventRatio" Type="Edm.Single"/>
+      </ComplexType>
+      <ComplexType Name="deviceInfo">
+        <Property Name="captureDeviceName" Type="Edm.String"/>
+        <Property Name="captureDeviceDriver" Type="Edm.String"/>
+        <Property Name="renderDeviceName" Type="Edm.String"/>
+        <Property Name="renderDeviceDriver" Type="Edm.String"/>
+        <Property Name="sentSignalLevel" Type="Edm.Int32"/>
+        <Property Name="receivedSignalLevel" Type="Edm.Int32"/>
+        <Property Name="sentNoiseLevel" Type="Edm.Int32"/>
+        <Property Name="receivedNoiseLevel" Type="Edm.Int32"/>
+        <Property Name="initialSignalLevelRootMeanSquare" Type="Edm.Single"/>
+        <Property Name="cpuInsufficentEventRatio" Type="Edm.Single"/>
+        <Property Name="renderNotFunctioningEventRatio" Type="Edm.Single"/>
+        <Property Name="captureNotFunctioningEventRatio" Type="Edm.Single"/>
+        <Property Name="deviceGlitchEventRatio" Type="Edm.Single"/>
+        <Property Name="lowSpeechToNoiseEventRatio" Type="Edm.Single"/>
+        <Property Name="lowSpeechLevelEventRatio" Type="Edm.Single"/>
+        <Property Name="deviceClippingEventRatio" Type="Edm.Single"/>
+        <Property Name="howlingEventCount" Type="Edm.Int32"/>
+        <Property Name="renderZeroVolumeEventRatio" Type="Edm.Single"/>
+        <Property Name="renderMuteEventRatio" Type="Edm.Single"/>
+        <Property Name="micGlitchRate" Type="Edm.Single"/>
+        <Property Name="speakerGlitchRate" Type="Edm.Single"/>
+      </ComplexType>
+      <ComplexType Name="mediaStream">
+        <Property Name="streamId" Type="Edm.String"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="streamDirection" Type="microsoft.graph.callRecords.mediaStreamDirection" Nullable="false"/>
+        <Property Name="averageAudioDegradation" Type="Edm.Single"/>
+        <Property Name="averageJitter" Type="Edm.Duration"/>
+        <Property Name="maxJitter" Type="Edm.Duration"/>
+        <Property Name="averagePacketLossRate" Type="Edm.Single"/>
+        <Property Name="maxPacketLossRate" Type="Edm.Single"/>
+        <Property Name="averageRatioOfConcealedSamples" Type="Edm.Single"/>
+        <Property Name="maxRatioOfConcealedSamples" Type="Edm.Single"/>
+        <Property Name="averageRoundTripTime" Type="Edm.Duration"/>
+        <Property Name="maxRoundTripTime" Type="Edm.Duration"/>
+        <Property Name="packetUtilization" Type="Edm.Int64"/>
+        <Property Name="averageBandwidthEstimate" Type="Edm.Int64"/>
+        <Property Name="wasMediaBypassed" Type="Edm.Boolean"/>
+        <Property Name="postForwardErrorCorrectionPacketLossRate" Type="Edm.Single"/>
+        <Property Name="averageVideoFrameLossPercentage" Type="Edm.Single"/>
+        <Property Name="averageReceivedFrameRate" Type="Edm.Single"/>
+        <Property Name="lowFrameRateRatio" Type="Edm.Single"/>
+        <Property Name="averageVideoPacketLossRate" Type="Edm.Single"/>
+        <Property Name="averageVideoFrameRate" Type="Edm.Single"/>
+        <Property Name="lowVideoProcessingCapabilityRatio" Type="Edm.Single"/>
+        <Property Name="averageAudioNetworkJitter" Type="Edm.Duration"/>
+        <Property Name="maxAudioNetworkJitter" Type="Edm.Duration"/>
+      </ComplexType>
+      <ComplexType Name="participantEndpoint" BaseType="microsoft.graph.callRecords.endpoint">
+        <Property Name="identity" Type="graph.identitySet"/>
+        <Property Name="feedback" Type="microsoft.graph.callRecords.userFeedback"/>
+      </ComplexType>
+      <ComplexType Name="userFeedback">
+        <Property Name="text" Type="Edm.String"/>
+        <Property Name="rating" Type="microsoft.graph.callRecords.userFeedbackRating" Nullable="false"/>
+        <Property Name="tokens" Type="microsoft.graph.callRecords.feedbackTokenSet"/>
+      </ComplexType>
+      <ComplexType Name="feedbackTokenSet" OpenType="true"/>
+      <ComplexType Name="serviceEndpoint" BaseType="microsoft.graph.callRecords.endpoint"/>
+      <ComplexType Name="clientUserAgent" BaseType="microsoft.graph.callRecords.userAgent">
+        <Property Name="platform" Type="microsoft.graph.callRecords.clientPlatform" Nullable="false"/>
+        <Property Name="productFamily" Type="microsoft.graph.callRecords.productFamily" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="serviceUserAgent" BaseType="microsoft.graph.callRecords.userAgent">
+        <Property Name="role" Type="microsoft.graph.callRecords.serviceRole" Nullable="false"/>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
+++ b/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
@@ -33,7 +33,7 @@ public class GeneratorTest {
                 "microsoft.graph.generated");
         Options options = new Options(GENERATED, Collections.singletonList(schemaOptions));
         Generator g = new Generator(options,
-                Collections.singletonList(t.getDataServices().getSchema().get(0)));
+                t.getDataServices().getSchema());
         g.generate();
         File file = new File(GENERATED + "/microsoft/graph/generated/entity/FileAttachment.java");
         Files.copy(file.toPath(), new File("../src/docs/FileAttachment.java").toPath(),

--- a/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
+++ b/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.oasisopen.odata.csdl.v4.TDataServices;
 import org.oasisopen.odata.csdl.v4.TEdmx;
 
+import com.github.davidmoten.guavamini.Lists;
+
 public class GeneratorTest {
 
     private static final String GENERATED = "target/generated-sources/odata";
@@ -29,9 +31,11 @@ public class GeneratorTest {
         TEdmx t = unmarshaller.unmarshal(
                 new StreamSource(new FileInputStream("src/main/odata/msgraph-metadata.xml")),
                 TEdmx.class).getValue();
-        SchemaOptions schemaOptions = new SchemaOptions("microsoft.graph",
+        SchemaOptions schemaOptions1 = new SchemaOptions("microsoft.graph",
                 "microsoft.graph.generated");
-        Options options = new Options(GENERATED, Collections.singletonList(schemaOptions));
+        SchemaOptions schemaOptions2 = new SchemaOptions("microsoft.graph.callRecords",
+                "microsoft.graph.callrecords.generated");
+        Options options = new Options(GENERATED, Lists.newArrayList(schemaOptions1, schemaOptions2));
         Generator g = new Generator(options,
                 t.getDataServices().getSchema());
         g.generate();

--- a/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/UtilTest.java
+++ b/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/UtilTest.java
@@ -19,8 +19,20 @@ public class UtilTest {
     }
 
     @Test
-    public void test3() {
+    public void testCollectionReplace() {
         assertEquals("Collection(microsoft.graph.call)",
                 Util.replaceAlias("graph", "microsoft.graph", "Collection(graph.call)"));
+    }
+
+    @Test
+    public void testDontReplaceIfAliasHasExtraQualifier() {
+        assertEquals("graph.extra.call",
+                Util.replaceAlias("graph", "microsoft.graph", "graph.extra.call"));
+    }
+
+    @Test
+    public void testCollectionDontReplaceIfAliasHasExtraQualifier() {
+        assertEquals("Collection(graph.extra.call)",
+                Util.replaceAlias("graph", "microsoft.graph", "Collection(graph.extra.call)"));
     }
 }

--- a/odata-client-msgraph-beta/src/main/odata/msgraph-beta-metadata.xml
+++ b/odata-client-msgraph-beta/src/main/odata/msgraph-beta-metadata.xml
@@ -379,6 +379,16 @@
         <Member Name="unifiedGroup" Value="4"/>
         <Member Name="unknownFutureValue" Value="8"/>
       </EnumType>
+      <EnumType Name="classificationMethod">
+        <Member Name="patternMatch" Value="0"/>
+        <Member Name="exactDataMatch" Value="1"/>
+        <Member Name="fingerprint" Value="2"/>
+        <Member Name="machineLearning" Value="3"/>
+      </EnumType>
+      <EnumType Name="sensitiveTypeSource">
+        <Member Name="outOfBox" Value="0"/>
+        <Member Name="tenant" Value="1"/>
+      </EnumType>
       <EnumType Name="permissionClassificationType">
         <Member Name="low" Value="1"/>
         <Member Name="medium" Value="2"/>
@@ -726,7 +736,7 @@
         <Member Name="review" Value="10"/>
       </EnumType>
       <EnumType Name="onPremisesPublishingType">
-        <Member Name="appProxy" Value="0"/>
+        <Member Name="applicationProxy" Value="0"/>
         <Member Name="exchangeOnline" Value="1"/>
         <Member Name="authentication" Value="2"/>
         <Member Name="provisioning" Value="3"/>
@@ -743,6 +753,37 @@
         <Member Name="seamlessSso" Value="1"/>
         <Member Name="passwordHashSync" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="connectorGroupType">
+        <Member Name="applicationProxy" Value="0"/>
+      </EnumType>
+      <EnumType Name="externalAuthenticationType">
+        <Member Name="passthru" Value="0"/>
+        <Member Name="aadPreAuthentication" Value="1"/>
+      </EnumType>
+      <EnumType Name="connectorStatus">
+        <Member Name="active" Value="0"/>
+        <Member Name="inactive" Value="1"/>
+      </EnumType>
+      <EnumType Name="singleSignOnMode">
+        <Member Name="none" Value="0"/>
+        <Member Name="onPremisesKerberos" Value="1"/>
+        <Member Name="saml" Value="3"/>
+      </EnumType>
+      <EnumType Name="kerberosSignOnMappingAttributeType">
+        <Member Name="userPrincipalName" Value="0"/>
+        <Member Name="onPremisesUserPrincipalName" Value="1"/>
+        <Member Name="userPrincipalUsername" Value="2"/>
+        <Member Name="onPremisesUserPrincipalUsername" Value="3"/>
+        <Member Name="onPremisesSAMAccountName" Value="4"/>
+      </EnumType>
+      <EnumType Name="connectorGroupRegion">
+        <Member Name="nam" Value="0"/>
+        <Member Name="eur" Value="1"/>
+        <Member Name="aus" Value="2"/>
+        <Member Name="asia" Value="3"/>
+        <Member Name="ind" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
       </EnumType>
       <EnumType Name="attributeFlowType">
         <Member Name="Always" Value="0"/>
@@ -906,6 +947,7 @@
         <Member Name="easSupported" Value="5"/>
         <Member Name="easUnsupported" Value="6"/>
         <Member Name="other" Value="7"/>
+        <Member Name="unknownFutureValue" Value="8"/>
       </EnumType>
       <EnumType Name="conditionalAccessGrantControl">
         <Member Name="block" Value="0"/>
@@ -914,11 +956,14 @@
         <Member Name="domainJoinedDevice" Value="3"/>
         <Member Name="approvedApplication" Value="4"/>
         <Member Name="compliantApplication" Value="5"/>
+        <Member Name="passwordChange" Value="6"/>
+        <Member Name="unknownFutureValue" Value="7"/>
       </EnumType>
       <EnumType Name="cloudAppSecuritySessionControlType">
         <Member Name="mcasConfigured" Value="0"/>
         <Member Name="monitorOnly" Value="1"/>
         <Member Name="blockDownloads" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="signinFrequencyType">
         <Member Name="days" Value="0"/>
@@ -935,6 +980,7 @@
         <Member Name="windowsPhone" Value="3"/>
         <Member Name="macOS" Value="4"/>
         <Member Name="all" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
       </EnumType>
       <EnumType Name="riskDetectionTimingType">
         <Member Name="notDefined" Value="0"/>
@@ -4127,6 +4173,12 @@
         <Member Name="unknownFutureValue" Value="32767"/>
         <Member Name="unknown" Value="-1"/>
       </EnumType>
+      <EnumType Name="securityResourceType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="attacked" Value="1"/>
+        <Member Name="related" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
       <EnumType Name="tiAction">
         <Member Name="unknown" Value="0"/>
         <Member Name="allow" Value="1"/>
@@ -5517,6 +5569,7 @@
       <EntityType Name="userSettings" BaseType="graph.entity">
         <Property Name="contributionToContentDiscoveryDisabled" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="contributionToContentDiscoveryAsOrganizationDisabled" Type="Edm.Boolean" Nullable="false"/>
+        <NavigationProperty Name="regionalAndLanguageSettings" Type="graph.regionalAndLanguageSettings" ContainsTarget="true"/>
         <NavigationProperty Name="shiftPreferences" Type="graph.shiftPreferences" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="onenote" BaseType="graph.entity">
@@ -5529,6 +5582,7 @@
       </EntityType>
       <EntityType Name="profile" BaseType="graph.entity">
         <NavigationProperty Name="account" Type="Collection(graph.userAccountInformation)" ContainsTarget="true"/>
+        <NavigationProperty Name="addresses" Type="Collection(graph.itemAddress)" ContainsTarget="true"/>
         <NavigationProperty Name="anniversaries" Type="Collection(graph.personAnniversary)" ContainsTarget="true"/>
         <NavigationProperty Name="educationalActivities" Type="Collection(graph.educationalActivity)" ContainsTarget="true"/>
         <NavigationProperty Name="emails" Type="Collection(graph.itemEmail)" ContainsTarget="true"/>
@@ -5538,6 +5592,7 @@
         <NavigationProperty Name="phones" Type="Collection(graph.itemPhone)" ContainsTarget="true"/>
         <NavigationProperty Name="positions" Type="Collection(graph.workPosition)" ContainsTarget="true"/>
         <NavigationProperty Name="projects" Type="Collection(graph.projectParticipation)" ContainsTarget="true"/>
+        <NavigationProperty Name="notes" Type="Collection(graph.personAnnotation)" ContainsTarget="true"/>
         <NavigationProperty Name="skills" Type="Collection(graph.skillProficiency)" ContainsTarget="true"/>
         <NavigationProperty Name="webAccounts" Type="Collection(graph.webAccount)" ContainsTarget="true"/>
         <NavigationProperty Name="websites" Type="Collection(graph.personWebsite)" ContainsTarget="true"/>
@@ -5567,6 +5622,7 @@
         <Property Name="deviceMetadata" Type="Edm.String"/>
         <Property Name="deviceVersion" Type="Edm.Int32"/>
         <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="extensionAttributes" Type="graph.onPremisesExtensionAttributes"/>
         <Property Name="isCompliant" Type="Edm.Boolean"/>
         <Property Name="isManaged" Type="Edm.Boolean"/>
         <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset"/>
@@ -5896,6 +5952,7 @@
         <Property Name="appId" Type="Edm.String"/>
         <Property Name="appRoles" Type="Collection(graph.appRole)" Nullable="false"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
         <Property Name="isFallbackPublicClient" Type="Edm.Boolean"/>
         <Property Name="identifierUris" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="displayName" Type="Edm.String"/>
@@ -5904,6 +5961,7 @@
         <Property Name="isDeviceOnlyAuthSupported" Type="Edm.Boolean"/>
         <Property Name="keyCredentials" Type="Collection(graph.keyCredential)" Nullable="false"/>
         <Property Name="logo" Type="Edm.Stream" Nullable="false"/>
+        <Property Name="notes" Type="Edm.String"/>
         <Property Name="optionalClaims" Type="graph.optionalClaims"/>
         <Property Name="parentalControlSettings" Type="graph.parentalControlSettings"/>
         <Property Name="passwordCredentials" Type="Collection(graph.passwordCredential)" Nullable="false"/>
@@ -5914,6 +5972,7 @@
         <Property Name="tags" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="tokenEncryptionKeyId" Type="Edm.Guid"/>
         <Property Name="web" Type="graph.webApplication"/>
+        <Property Name="onPremisesPublishing" Type="graph.onPremisesPublishing"/>
         <NavigationProperty Name="extensionProperties" Type="Collection(graph.extensionProperty)" ContainsTarget="true"/>
         <NavigationProperty Name="claimsMappingPolicies" Type="Collection(graph.claimsMappingPolicy)"/>
         <NavigationProperty Name="createdOnBehalfOf" Type="graph.directoryObject"/>
@@ -5921,6 +5980,7 @@
         <NavigationProperty Name="homeRealmDiscoveryPolicies" Type="Collection(graph.homeRealmDiscoveryPolicy)"/>
         <NavigationProperty Name="tokenIssuancePolicies" Type="Collection(graph.tokenIssuancePolicy)"/>
         <NavigationProperty Name="tokenLifetimePolicies" Type="Collection(graph.tokenLifetimePolicy)"/>
+        <NavigationProperty Name="connectorGroup" Type="graph.connectorGroup"/>
         <NavigationProperty Name="synchronization" Type="graph.synchronization" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="apiApplication">
@@ -6037,6 +6097,48 @@
       <EntityType Name="homeRealmDiscoveryPolicy" BaseType="graph.stsPolicy"/>
       <EntityType Name="tokenIssuancePolicy" BaseType="graph.stsPolicy"/>
       <EntityType Name="tokenLifetimePolicy" BaseType="graph.stsPolicy"/>
+      <ComplexType Name="onPremisesPublishing">
+        <Property Name="externalUrl" Type="Edm.String"/>
+        <Property Name="internalUrl" Type="Edm.String"/>
+        <Property Name="externalAuthenticationType" Type="graph.externalAuthenticationType"/>
+        <Property Name="isTranslateHostHeaderEnabled" Type="Edm.Boolean"/>
+        <Property Name="isTranslateLinksInBodyEnabled" Type="Edm.Boolean"/>
+        <Property Name="isOnPremPublishingEnabled" Type="Edm.Boolean"/>
+        <Property Name="applicationServerTimeout" Type="Edm.String"/>
+        <Property Name="verifiedCustomDomainKeyCredential" Type="graph.keyCredential"/>
+        <Property Name="verifiedCustomDomainPasswordCredential" Type="graph.passwordCredential"/>
+        <Property Name="verifiedCustomDomainCertificatesMetadata" Type="graph.verifiedCustomDomainCertificatesMetadata"/>
+        <Property Name="singleSignOnSettings" Type="graph.onPremisesPublishingSingleSignOn"/>
+        <Property Name="applicationType" Type="Edm.String"/>
+        <Property Name="isHttpOnlyCookieEnabled" Type="Edm.Boolean"/>
+        <Property Name="isSecureCookieEnabled" Type="Edm.Boolean"/>
+        <Property Name="isPersistentCookieEnabled" Type="Edm.Boolean"/>
+        <Property Name="alternateUrl" Type="Edm.String"/>
+        <Property Name="useAlternateUrlForTranslationAndRedirect" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="verifiedCustomDomainCertificatesMetadata">
+        <Property Name="thumbprint" Type="Edm.String"/>
+        <Property Name="subjectName" Type="Edm.String"/>
+        <Property Name="issuerName" Type="Edm.String"/>
+        <Property Name="issueDate" Type="Edm.DateTimeOffset"/>
+        <Property Name="expiryDate" Type="Edm.DateTimeOffset"/>
+      </ComplexType>
+      <ComplexType Name="onPremisesPublishingSingleSignOn">
+        <Property Name="SingleSignOnMode" Type="graph.singleSignOnMode"/>
+        <Property Name="KerberosSignOnSettings" Type="graph.kerberosSignOnSettings"/>
+      </ComplexType>
+      <ComplexType Name="kerberosSignOnSettings">
+        <Property Name="KerberosServicePrincipalName" Type="Edm.String"/>
+        <Property Name="KerberosSignOnMappingAttributeType" Type="graph.kerberosSignOnMappingAttributeType"/>
+      </ComplexType>
+      <EntityType Name="connectorGroup" BaseType="graph.entity">
+        <Property Name="name" Type="Edm.String" Nullable="false"/>
+        <Property Name="connectorGroupType" Type="graph.connectorGroupType" Nullable="false"/>
+        <Property Name="isDefault" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="region" Type="graph.connectorGroupRegion"/>
+        <NavigationProperty Name="members" Type="Collection(graph.connector)"/>
+        <NavigationProperty Name="applications" Type="Collection(graph.application)"/>
+      </EntityType>
       <EntityType Name="synchronization" BaseType="graph.entity">
         <Property Name="secrets" Type="Collection(graph.synchronizationSecretKeyStringValuePair)"/>
         <NavigationProperty Name="jobs" Type="Collection(graph.synchronizationJob)" ContainsTarget="true"/>
@@ -6046,12 +6148,14 @@
         <Property Name="accountEnabled" Type="Edm.Boolean"/>
         <Property Name="addIns" Type="Collection(graph.addIn)" Nullable="false"/>
         <Property Name="alternativeNames" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="appDescription" Type="Edm.String"/>
         <Property Name="appDisplayName" Type="Edm.String"/>
         <Property Name="appId" Type="Edm.String"/>
         <Property Name="applicationTemplateId" Type="Edm.String"/>
         <Property Name="appOwnerOrganizationId" Type="Edm.Guid"/>
         <Property Name="appRoleAssignmentRequired" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="appRoles" Type="Collection(graph.appRole)" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="errorUrl" Type="Edm.String"/>
         <Property Name="homepage" Type="Edm.String"/>
@@ -6059,6 +6163,7 @@
         <Property Name="keyCredentials" Type="Collection(graph.keyCredential)" Nullable="false"/>
         <Property Name="loginUrl" Type="Edm.String"/>
         <Property Name="logoutUrl" Type="Edm.String"/>
+        <Property Name="notes" Type="Edm.String"/>
         <Property Name="notificationEmailAddresses" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="publishedPermissionScopes" Type="Collection(graph.permissionScope)" Nullable="false"/>
         <Property Name="passwordCredentials" Type="Collection(graph.passwordCredential)" Nullable="false"/>
@@ -6144,6 +6249,7 @@
         <Property Name="minAuthMethodsToReset" Type="Edm.Int32"/>
       </ComplexType>
       <EntityType Name="policyRoot" BaseType="graph.entity">
+        <NavigationProperty Name="authenticationFlowsPolicy" Type="graph.authenticationFlowsPolicy" ContainsTarget="true"/>
         <NavigationProperty Name="activityBasedTimeoutPolicies" Type="Collection(graph.activityBasedTimeoutPolicy)" ContainsTarget="true"/>
         <NavigationProperty Name="claimsMappingPolicies" Type="Collection(graph.claimsMappingPolicy)" ContainsTarget="true"/>
         <NavigationProperty Name="homeRealmDiscoveryPolicies" Type="Collection(graph.homeRealmDiscoveryPolicy)" ContainsTarget="true"/>
@@ -6152,6 +6258,11 @@
         <NavigationProperty Name="adminConsentRequestPolicy" Type="graph.adminConsentRequestPolicy" ContainsTarget="true"/>
         <NavigationProperty Name="identitySecurityDefaultsEnforcementPolicy" Type="graph.identitySecurityDefaultsEnforcementPolicy" ContainsTarget="true"/>
         <NavigationProperty Name="conditionalAccessPolicies" Type="Collection(graph.conditionalAccessPolicy)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="authenticationFlowsPolicy" BaseType="graph.entity">
+        <Property Name="selfServiceSignUp" Type="graph.selfServiceSignUpAuthenticationFlowConfiguration"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="activityBasedTimeoutPolicy" BaseType="graph.stsPolicy"/>
       <EntityType Name="adminConsentRequestPolicy" BaseType="graph.entity">
@@ -6322,6 +6433,9 @@
         <Property Name="userFlowType" Type="graph.userFlowType" Nullable="false"/>
         <Property Name="userFlowTypeVersion" Type="Edm.Single" Nullable="false"/>
       </EntityType>
+      <ComplexType Name="selfServiceSignUpAuthenticationFlowConfiguration">
+        <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
       <EntityType Name="identityProvider" BaseType="graph.entity">
         <Property Name="type" Type="Edm.String"/>
         <Property Name="name" Type="Edm.String"/>
@@ -6415,6 +6529,8 @@
         <Property Name="publisherName" Type="Edm.String"/>
         <Property Name="state" Type="Edm.String"/>
         <Property Name="scope" Type="graph.sensitiveTypeScope"/>
+        <Property Name="sensitiveTypeSource" Type="graph.sensitiveTypeSource"/>
+        <Property Name="classificationMethod" Type="graph.classificationMethod"/>
       </EntityType>
       <EntityType Name="jobResponseBase" BaseType="graph.entity">
         <Property Name="type" Type="Edm.String"/>
@@ -6565,7 +6681,7 @@
       <ComplexType Name="detectedSensitiveContentWrapper">
         <Property Name="classification" Type="Collection(graph.detectedSensitiveContent)"/>
       </ComplexType>
-      <ComplexType Name="detectedSensitiveContent">
+      <ComplexType Name="detectedSensitiveContentBase">
         <Property Name="id" Type="Edm.Guid"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="uniqueCount" Type="Edm.Int32"/>
@@ -6583,6 +6699,9 @@
         <Property Name="match" Type="Edm.String"/>
         <Property Name="offset" Type="Edm.Int32"/>
         <Property Name="length" Type="Edm.Int32"/>
+      </ComplexType>
+      <ComplexType Name="detectedSensitiveContent" BaseType="graph.detectedSensitiveContentBase">
+        <Property Name="scope" Type="graph.sensitiveTypeScope"/>
       </ComplexType>
       <EntityType Name="dlpEvaluatePoliciesJobResponse" BaseType="graph.jobResponseBase">
         <Property Name="result" Type="graph.dlpPoliciesJobResult"/>
@@ -7523,9 +7642,10 @@
         <Property Name="offset" Type="Edm.Int32"/>
       </ComplexType>
       <ComplexType Name="exactMatchClassificationResult">
-        <Property Name="classification" Type="Collection(graph.detectedSensitiveContent)"/>
+        <Property Name="classification" Type="Collection(graph.exactMatchDetectedSensitiveContent)"/>
         <Property Name="errors" Type="Collection(graph.classificationError)"/>
       </ComplexType>
+      <ComplexType Name="exactMatchDetectedSensitiveContent" BaseType="graph.detectedSensitiveContentBase"/>
       <ComplexType Name="root"/>
       <ComplexType Name="sharepointIds">
         <Property Name="listId" Type="Edm.String"/>
@@ -8813,10 +8933,13 @@
         <NavigationProperty Name="agentGroups" Type="Collection(graph.onPremisesAgentGroup)"/>
       </EntityType>
       <EntityType Name="onPremisesPublishingProfile" BaseType="graph.entity">
+        <Property Name="isEnabled" Type="Edm.Boolean"/>
         <Property Name="hybridAgentUpdaterConfiguration" Type="graph.hybridAgentUpdaterConfiguration"/>
         <NavigationProperty Name="agents" Type="Collection(graph.onPremisesAgent)" ContainsTarget="true"/>
         <NavigationProperty Name="agentGroups" Type="Collection(graph.onPremisesAgentGroup)" ContainsTarget="true"/>
         <NavigationProperty Name="publishedResources" Type="Collection(graph.publishedResource)" ContainsTarget="true"/>
+        <NavigationProperty Name="connectors" Type="Collection(graph.connector)" ContainsTarget="true"/>
+        <NavigationProperty Name="connectorGroups" Type="Collection(graph.connectorGroup)" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="hybridAgentUpdaterConfiguration">
         <Property Name="deferUpdateDateTime" Type="Edm.DateTimeOffset"/>
@@ -8827,6 +8950,12 @@
         <Property Name="updateWindowStartTime" Type="Edm.TimeOfDay"/>
         <Property Name="updateWindowEndTime" Type="Edm.TimeOfDay"/>
       </ComplexType>
+      <EntityType Name="connector" BaseType="graph.entity">
+        <Property Name="machineName" Type="Edm.String" Nullable="false"/>
+        <Property Name="externalIp" Type="Edm.String" Nullable="false"/>
+        <Property Name="status" Type="graph.connectorStatus" Nullable="false"/>
+        <NavigationProperty Name="memberOf" Type="Collection(graph.connectorGroup)"/>
+      </EntityType>
       <ComplexType Name="propertyToEvaluate">
         <Property Name="propertyName" Type="Edm.String"/>
         <Property Name="propertyValue" Type="Edm.String"/>
@@ -9541,6 +9670,7 @@
         <Property Name="applications" Type="graph.conditionalAccessApplications"/>
         <Property Name="users" Type="graph.conditionalAccessUsers" Nullable="false"/>
         <Property Name="signInRiskLevels" Type="Collection(graph.riskLevel)" Nullable="false"/>
+        <Property Name="userRiskLevels" Type="Collection(graph.riskLevel)" Nullable="false"/>
         <Property Name="platforms" Type="graph.conditionalAccessPlatforms"/>
         <Property Name="locations" Type="graph.conditionalAccessLocations"/>
         <Property Name="clientAppTypes" Type="Collection(graph.conditionalAccessClientApp)" Nullable="false"/>
@@ -17873,6 +18003,7 @@
         <Property Name="postedCount" Type="Edm.Int64"/>
         <Property Name="readCount" Type="Edm.Int64"/>
         <Property Name="likedCount" Type="Edm.Int64"/>
+        <Property Name="networkDisplayName" Type="Edm.String"/>
         <Property Name="reportPeriod" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="yammerGroupsActivityGroupCounts" BaseType="graph.entity">
@@ -18081,6 +18212,14 @@
         <Property Name="category6" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="plannerPlanContextDetailsCollection" OpenType="true"/>
+      <EntityType Name="regionalAndLanguageSettings" BaseType="graph.entity">
+        <Property Name="defaultDisplayLanguage" Type="graph.localeInfo"/>
+        <Property Name="authoringLanguages" Type="Collection(graph.localeInfo)"/>
+        <Property Name="defaultTranslationLanguage" Type="graph.localeInfo"/>
+        <Property Name="defaultSpeechInputLanguage" Type="graph.localeInfo"/>
+        <Property Name="defaultRegionalFormat" Type="graph.localeInfo"/>
+        <Property Name="regionalFormatOverrides" Type="graph.regionalFormatOverrides"/>
+      </EntityType>
       <EntityType Name="changeTrackedEntity" BaseType="graph.entity" Abstract="true">
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
@@ -18483,12 +18622,18 @@
         <Property Name="createdBy" Type="graph.identitySet" Nullable="false"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="lastModifiedBy" Type="graph.identitySet" Nullable="false"/>
+        <Property Name="source" Type="graph.personDataSource"/>
       </EntityType>
       <EntityType Name="userAccountInformation" BaseType="graph.itemFacet">
         <Property Name="ageGroup" Type="Edm.String" Nullable="false"/>
         <Property Name="countryCode" Type="Edm.String" Nullable="false"/>
         <Property Name="preferredLanguageTag" Type="graph.localeInfo" Nullable="false"/>
         <Property Name="userPrincipalName" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="itemAddress" BaseType="graph.itemFacet">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="detail" Type="graph.physicalAddress" Nullable="false"/>
+        <Property Name="geoCoordinates" Type="graph.geoCoordinates"/>
       </EntityType>
       <EntityType Name="personAnniversary" BaseType="graph.itemFacet">
         <Property Name="type" Type="graph.anniversaryType"/>
@@ -18511,11 +18656,15 @@
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="webUrl" Type="Edm.String"/>
+        <Property Name="collaborationTags" Type="Collection(Edm.String)"/>
       </EntityType>
       <EntityType Name="languageProficiency" BaseType="graph.itemFacet">
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="tag" Type="Edm.String" Nullable="false"/>
         <Property Name="proficiency" Type="graph.languageProficiencyLevel"/>
+        <Property Name="spoken" Type="graph.languageProficiencyLevel"/>
+        <Property Name="written" Type="graph.languageProficiencyLevel"/>
+        <Property Name="reading" Type="graph.languageProficiencyLevel"/>
       </EntityType>
       <EntityType Name="personName" BaseType="graph.itemFacet">
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
@@ -18538,6 +18687,9 @@
       <EntityType Name="workPosition" BaseType="graph.itemFacet">
         <Property Name="categories" Type="Collection(Edm.String)"/>
         <Property Name="detail" Type="graph.positionDetail" Nullable="false"/>
+        <Property Name="manager" Type="graph.relatedPerson"/>
+        <Property Name="colleagues" Type="Collection(graph.relatedPerson)"/>
+        <Property Name="isCurrent" Type="Edm.Boolean"/>
       </EntityType>
       <EntityType Name="projectParticipation" BaseType="graph.itemFacet">
         <Property Name="categories" Type="Collection(Edm.String)"/>
@@ -18546,12 +18698,18 @@
         <Property Name="detail" Type="graph.positionDetail"/>
         <Property Name="colleagues" Type="Collection(graph.relatedPerson)"/>
         <Property Name="sponsors" Type="Collection(graph.relatedPerson)"/>
+        <Property Name="collaborationTags" Type="Collection(Edm.String)"/>
+      </EntityType>
+      <EntityType Name="personAnnotation" BaseType="graph.itemFacet">
+        <Property Name="detail" Type="graph.itemBody"/>
+        <Property Name="displayName" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="skillProficiency" BaseType="graph.itemFacet">
         <Property Name="categories" Type="Collection(Edm.String)"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="proficiency" Type="graph.skillProficiencyLevel"/>
         <Property Name="webUrl" Type="Edm.String"/>
+        <Property Name="collaborationTags" Type="Collection(Edm.String)"/>
       </EntityType>
       <EntityType Name="webAccount" BaseType="graph.itemFacet">
         <Property Name="description" Type="Edm.String"/>
@@ -18594,6 +18752,12 @@
         <Property Name="notes" Type="Edm.String"/>
         <Property Name="webUrl" Type="Edm.String"/>
       </ComplexType>
+      <EntityType Name="personResponsibility" BaseType="graph.itemFacet">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+        <Property Name="collaborationTags" Type="Collection(Edm.String)"/>
+      </EntityType>
       <ComplexType Name="companyDetail">
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="pronunciation" Type="Edm.String"/>
@@ -18619,6 +18783,15 @@
       <ComplexType Name="serviceInformation">
         <Property Name="name" Type="Edm.String" Nullable="false"/>
         <Property Name="webUrl" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="regionalFormatOverrides">
+        <Property Name="calendar" Type="Edm.String"/>
+        <Property Name="firstDayOfWeek" Type="Edm.String"/>
+        <Property Name="shortDateFormat" Type="Edm.String"/>
+        <Property Name="longDateFormat" Type="Edm.String"/>
+        <Property Name="shortTimeFormat" Type="Edm.String"/>
+        <Property Name="longTimeFormat" Type="Edm.String"/>
+        <Property Name="timeZone" Type="Edm.String"/>
       </ComplexType>
       <EntityType Name="presentation" BaseType="graph.entity">
         <NavigationProperty Name="comments" Type="Collection(graph.documentComment)" ContainsTarget="true"/>
@@ -18906,12 +19079,14 @@
         <Property Name="fileStates" Type="Collection(graph.fileSecurityState)"/>
         <Property Name="historyStates" Type="Collection(graph.alertHistoryState)"/>
         <Property Name="hostStates" Type="Collection(graph.hostSecurityState)"/>
+        <Property Name="incidentIds" Type="Collection(Edm.String)"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="malwareStates" Type="Collection(graph.malwareState)"/>
         <Property Name="networkConnections" Type="Collection(graph.networkConnection)"/>
         <Property Name="processes" Type="Collection(graph.process)"/>
         <Property Name="recommendedActions" Type="Collection(Edm.String)"/>
         <Property Name="registryKeyStates" Type="Collection(graph.registryKeyState)"/>
+        <Property Name="securityResources" Type="Collection(graph.securityResource)"/>
         <Property Name="severity" Type="graph.alertSeverity" Nullable="false"/>
         <Property Name="sourceMaterials" Type="Collection(Edm.String)"/>
         <Property Name="status" Type="graph.alertStatus" Nullable="false"/>
@@ -19184,6 +19359,7 @@
         <Property Name="applicationName" Type="Edm.String"/>
         <Property Name="destinationAddress" Type="Edm.String"/>
         <Property Name="destinationDomain" Type="Edm.String"/>
+        <Property Name="destinationLocation" Type="Edm.String"/>
         <Property Name="destinationPort" Type="Edm.String"/>
         <Property Name="destinationUrl" Type="Edm.String"/>
         <Property Name="direction" Type="graph.connectionDirection"/>
@@ -19196,6 +19372,7 @@
         <Property Name="protocol" Type="graph.securityNetworkProtocol"/>
         <Property Name="riskScore" Type="Edm.String"/>
         <Property Name="sourceAddress" Type="Edm.String"/>
+        <Property Name="sourceLocation" Type="Edm.String"/>
         <Property Name="sourcePort" Type="Edm.String"/>
         <Property Name="status" Type="graph.connectionStatus"/>
         <Property Name="urlParameters" Type="Edm.String"/>
@@ -19225,6 +19402,10 @@
         <Property Name="valueData" Type="Edm.String"/>
         <Property Name="valueName" Type="Edm.String"/>
         <Property Name="valueType" Type="graph.registryValueType"/>
+      </ComplexType>
+      <ComplexType Name="securityResource">
+        <Property Name="resource" Type="Edm.String"/>
+        <Property Name="resourceType" Type="graph.securityResourceType"/>
       </ComplexType>
       <ComplexType Name="alertTrigger">
         <Property Name="name" Type="Edm.String"/>
@@ -19563,6 +19744,8 @@
         <Property Name="encryptionCertificateThumbprint" Type="Edm.String" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="changeNotification">
+        <Property Name="id" Type="Edm.String"/>
+        <Property Name="sequenceNumber" Type="Edm.Int32" Nullable="false"/>
         <Property Name="subscriptionId" Type="Edm.Guid" Nullable="false"/>
         <Property Name="subscriptionExpirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="clientState" Type="Edm.String"/>
@@ -25450,16 +25633,14 @@
       <Action Name="upgrade" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.teamsAppInstallation"/>
       </Action>
-      <Action Name="generateActivityNotification" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.teamwork"/>
-        <Parameter Name="about" Type="Edm.String" Unicode="false"/>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.team"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
         <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="aggregationId" Type="Edm.Int64"/>
-        <Parameter Name="onClickWebUrl" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="previewText" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="teamsAppId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
         <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
-        <Parameter Name="recipient" Type="graph.teamworkNotificationAudience"/>
+        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
       </Action>
       <Action Name="clone" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.team"/>
@@ -25476,6 +25657,23 @@
       </Action>
       <Action Name="unarchive" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.team"/>
+      </Action>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.chat"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
+        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
+        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
+        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
+      </Action>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.userTeamwork"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
+        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
+        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
       </Action>
       <Function Name="allMessages" IsBound="true">
         <Parameter Name="teams" Type="Collection(graph.team)"/>
@@ -25599,6 +25797,8 @@
         <EntitySet Name="sites" EntityType="microsoft.graph.site"/>
         <EntitySet Name="schemaExtensions" EntityType="microsoft.graph.schemaExtension"/>
         <EntitySet Name="onPremisesPublishingProfiles" EntityType="microsoft.graph.onPremisesPublishingProfile"/>
+        <EntitySet Name="connectors" EntityType="microsoft.graph.connector"/>
+        <EntitySet Name="connectorGroups" EntityType="microsoft.graph.connectorGroup"/>
         <EntitySet Name="groupLifecyclePolicies" EntityType="microsoft.graph.groupLifecyclePolicy"/>
         <EntitySet Name="functions" EntityType="microsoft.graph.attributeMappingFunctionSchema"/>
         <EntitySet Name="filterOperators" EntityType="microsoft.graph.filterOperatorSchema"/>
@@ -26413,6 +26613,40 @@
             <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.connectorGroup">
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
       </Annotations>
       <Annotations Target="microsoft.graph.servicePrincipal">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
@@ -27756,6 +27990,35 @@
             <PropertyValue Property="Updatable" Bool="false"/>
           </Record>
         </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.connector">
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
       </Annotations>
       <Annotations Target="microsoft.graph.agreement">
         <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
@@ -46916,6 +47179,8 @@
         <Member Name="unknown" Value="0"/>
         <Member Name="frequency24GHz" Value="1"/>
         <Member Name="frequency50GHz" Value="2"/>
+        <Member Name="frequency60GHz" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="wifiRadioType">
         <Member Name="unknown" Value="0"/>

--- a/odata-client-msgraph/pom.xml
+++ b/odata-client-msgraph/pom.xml
@@ -75,6 +75,10 @@
                                     <namespace>microsoft.graph</namespace>
                                     <packageName>odata.msgraph.client</packageName>
                                 </schema>
+                                <schema>
+                                    <namespace>microsoft.graph.callRecords</namespace>
+                                    <packageName>odata.msgraph.client.callrecords</packageName>
+                                </schema>
                             </schemas>
                         </configuration>
                     </execution>

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -13,7 +13,6 @@ import odata.msgraph.client.complex.EmailAddress;
 import odata.msgraph.client.complex.ItemBody;
 import odata.msgraph.client.complex.Recipient;
 import odata.msgraph.client.container.GraphService;
-import odata.msgraph.client.entity.DriveItem;
 import odata.msgraph.client.entity.Message;
 import odata.msgraph.client.entity.request.MailFolderRequest;
 import odata.msgraph.client.enums.BodyType;


### PR DESCRIPTION
Aliases are replaced with full namespaces as an early step in metadata processing and this needed to be tightened up generally for when one alias contains another alias in a String sense. This wasn't necessary to support the new v1.0 metadata for msgraph but was noticed along the way. 

The unit test that processes metadata in odata-client-generator project needed to be supplied with extra SchemaOptions to handle the extra schema now present in v1.0 metadata.