### PR TITLE
OSGi support: upgrade guava-mini and remove unused jcip-annotations dep

### DIFF
--- a/odata-client-runtime/pom.xml
+++ b/odata-client-runtime/pom.xml
@@ -14,16 +14,11 @@
     <description>OData client runtime for use with generated code</description>
 
     <dependencies>
-        <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
-        </dependency>
 
         <dependency>
             <groupId>com.github.davidmoten</groupId>
             <artifactId>guava-mini</artifactId>
-            <version>0.1.2</version>
+            <version>0.1.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
See discussion in #6 and https://github.com/davidmoten/guava-mini/pull/1.

@badfish69 can you review please.