### PR TITLE
Error response from collection get should be informative

### DIFF
--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -13,10 +13,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.guavamini.Sets;
+import com.github.davidmoten.odata.client.ClientException;
 import com.github.davidmoten.odata.client.CollectionPage;
 import com.github.davidmoten.odata.client.HttpMethod;
 import com.github.davidmoten.odata.client.PathStyle;
@@ -114,6 +116,21 @@ public class GraphServiceTest {
         CollectionPage<Contact> c = client.me().contacts().top(200).skip(3).get();
         assertNotNull(c);
         assertEquals(10, c.currentPage().size());
+    }
+    
+    @Test
+    public void testGetCollectionThrowsInformativeError() {
+        GraphService client = clientBuilder() //
+                .expectResponse("/users", "/response-get-collection-error.json", HttpMethod.GET,
+                        403, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
+                        RequestHeader.ODATA_VERSION) //
+                .build();
+        try {
+            client.users().get().currentPage();
+            Assert.fail();
+        } catch (ClientException e) {
+            assertTrue(e.getMessage().contains("Insufficient privileges"));
+        }
     }
     
     @Test

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -34,6 +34,13 @@ public class MsGraphMain {
                 .clientSecret(System.getProperty("clientSecret")) //
                 .refreshBeforeExpiry(5, TimeUnit.MINUTES) //
                 .build();
+        
+        
+        client.users().stream().forEach(user -> System.out.println(user.getUserPrincipalName()));
+        
+        
+        System.exit(0);
+        System.out.println(client.users().top(200).skip(100).get().currentPage().size());
 
         String mailbox = System.getProperty("mailbox");
         MailFolderRequest drafts = client //

--- a/odata-client-msgraph/src/test/resources/response-get-collection-error.json
+++ b/odata-client-msgraph/src/test/resources/response-get-collection-error.json
@@ -1,0 +1,10 @@
+{
+  "error": {
+    "code": "Authorization_RequestDenied",
+    "message": "Insufficient privileges to complete the operation.",
+    "innerError": {
+      "date": "2020-06-13T00:48:55",
+      "request-id": "31c91f39-f97b-4f8b-8f6f-c4c00c1a8fe9"
+    }
+  }
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPage.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPage.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.github.davidmoten.odata.client.internal.RequestHelper;
 
 //TODO merge CollectionPageNonEntity and CollectionPageEntity into CollectionPage
 @JsonIgnoreType
@@ -44,8 +45,9 @@ public final class CollectionPage<T> implements Paged<T, CollectionPage<T>> {
             // odata 4 says the "value" element of the returned json is an array of
             // serialized T see example at
             // https://www.odata.org/getting-started/basic-tutorial/#entitySet
+            RequestHelper.checkResponseCode(contextPath, response, 200, 299);
             return Optional
-                    .of(contextPath.context().serializer().deserializeCollectionPageNonEntity(
+                    .of(contextPath.context().serializer().deserializeCollectionPage(
                             response.getText(), cls, contextPath, schemaInfo, requestHeaders));
         } else {
             return Optional.empty();

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -30,7 +30,8 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
         List<RequestHeader> h = RequestHelper.cleanAndSupplementRequestHeaders(options, "minimal",
                 false);
         HttpResponse r = cp.context().service().get(cp.toUrl(), h);
-        return cp.context().serializer().deserializeCollectionPageNonEntity(r.getText(), cls, cp,
+        RequestHelper.checkResponseCode(cp, r, 200, 299);
+        return cp.context().serializer().deserializeCollectionPage(r.getText(), cls, cp,
                 schemaInfo, h);
     }
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageNonEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageNonEntityRequest.java
@@ -68,7 +68,7 @@ public class CollectionPageNonEntityRequest<T> {
         return cp //
                 .context() //
                 .serializer() //
-                .deserializeCollectionPageNonEntity( //
+                .deserializeCollectionPage( //
                         r.getText(), //
                         cls, //
                         cp, //

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -147,7 +147,7 @@ public final class Serializer {
         }
     }
 
-    public <T> CollectionPage<T> deserializeCollectionPageNonEntity(String json, Class<T> cls,
+    public <T> CollectionPage<T> deserializeCollectionPage(String json, Class<T> cls,
             ContextPath contextPath, SchemaInfo schemaInfo, List<RequestHeader> requestHeaders) {
         CollectionInfo<T> c = deserializeToCollection(json, cls, contextPath, schemaInfo);
         return new CollectionPage<T>(contextPath, cls, c.list, c.nextLink, schemaInfo,

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -52,6 +52,11 @@ public final class TestingService {
         public Response(String text) {
             this(text, HttpURLConnection.HTTP_OK);
         }
+
+        @Override
+        public String toString() {
+            return "Response [resource=" + resource + ", statusCode=" + statusCode + "]";
+        }
     }
 
     public static abstract class BuilderBase<T extends BuilderBase<?, R>, R> {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -39,9 +39,23 @@ public final class TestingService {
     public static Builder builder() {
         return new Builder();
     }
+    
+    public static final class Response {
+        public String resource;
+        public final int statusCode;
+
+        public Response(String resource, int statusCode) {
+            this.resource = resource;
+            this.statusCode = statusCode;
+        }
+        
+        public Response(String text) {
+            this(text, HttpURLConnection.HTTP_OK);
+        }
+    }
 
     public static abstract class BuilderBase<T extends BuilderBase<?, R>, R> {
-        Map<String, String> responses = new HashMap<>();
+        Map<String, Response> responses = new HashMap<>();
         Map<String, String> requests = new HashMap<>();
 
         String baseUrl = "https://testing.com";
@@ -65,11 +79,16 @@ public final class TestingService {
         }
 
         @SuppressWarnings("unchecked")
-        public T expectResponse(String path, String responseResourceName, HttpMethod method,
+        public T expectResponse(String path, String responseResourceName, HttpMethod method, int statusCode,
                 RequestHeader... requestHeaders) {
             responses.put(toKey(method, baseUrl + path, asList(requestHeaders)),
-                    responseResourceName);
+                    new Response(responseResourceName, statusCode));
             return (T) this;
+        }
+        
+        public T expectResponse(String path, String responseResourceName, HttpMethod method,
+                RequestHeader... requestHeaders) {
+            return expectResponse(path, responseResourceName, method, HttpURLConnection.HTTP_OK, requestHeaders);
         }
 
         @SuppressWarnings("unchecked")
@@ -88,7 +107,7 @@ public final class TestingService {
             requests.put(toKey(method, baseUrl + path, asList(requestHeaders)),
                     requestResourceName);
             responses.put(toKey(method, baseUrl + path, asList(requestHeaders)),
-                    responseResourceName);
+                    new Response(responseResourceName));
             return (T) this;
         }
 
@@ -118,7 +137,8 @@ public final class TestingService {
                     responses.entrySet().forEach(r -> log(r.getKey() + "\n=>" + r.getValue()));
                     String key = BuilderBase.toKey(HttpMethod.GET, url, requestHeaders);
                     log("Getting:\n" + key);
-                    String resourceName = responses.get(key);
+                    Response response = responses.get(key);
+                    String resourceName = response.resource;
                     if (resourceName == null) {
                         throw new RuntimeException("GET response not found for url=" + url
                                 + ", headers=" + requestHeaders);
@@ -130,7 +150,7 @@ public final class TestingService {
                                     "resource not found on classpath: " + resourceName);
                         }
                         String text = new String(Files.readAllBytes(Paths.get(resource.toURI())));
-                        return new HttpResponse(HttpURLConnection.HTTP_OK, text);
+                        return new HttpResponse(response.statusCode, text);
                     } catch (IOException | URISyntaxException e) {
                         throw new RuntimeException(e);
                     }
@@ -192,7 +212,7 @@ public final class TestingService {
                         String requestExpected = readResource(url, requestResourceName);
                         if (Serializer.INSTANCE.matches(requestExpected, text)) {
                             String responseResourceName = responses
-                                    .get(BuilderBase.toKey(HttpMethod.POST, url, requestHeaders));
+                                    .get(BuilderBase.toKey(HttpMethod.POST, url, requestHeaders)).resource;
                             String responseExpected = readResource(url, responseResourceName);
                             int responseCode = url.contains("delta") ? HttpURLConnection.HTTP_OK
                                     : HttpURLConnection.HTTP_CREATED;

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -81,7 +81,7 @@ public final class RequestHelper {
         return cp.context().serializer().deserialize(response.getText(), c, contextPath, false);
     }
 
-    private static void checkResponseCode(String url, HttpResponse response,
+    public static void checkResponseCode(String url, HttpResponse response,
             int expectedResponseCodeMin, int expectedResponseCodeMax) {
         if (response.getResponseCode() < expectedResponseCodeMin
                 || response.getResponseCode() > expectedResponseCodeMax) {

--- a/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
+++ b/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
@@ -81,7 +81,7 @@ public class CollectionPageTest {
         };
 
         Context context = new Context(serializer, service);
-        CollectionPage<Person> c = serializer.deserializeCollectionPageNonEntity(json, Person.class,
+        CollectionPage<Person> c = serializer.deserializeCollectionPage(json, Person.class,
                 new ContextPath(context, service.getBasePath()), schemaInfo,
                 Collections.emptyList());
         assertEquals(2, c.currentPage().size());


### PR DESCRIPTION
As mentioned in #15, testing showed that when a collection get like `client.users().get()` fails with a 403 for example, a NullPointerException is thrown because the value array is not present in the response JSON. In fact the error status code should be detected and an informative error thrown.