### PR TITLE
ensure socket timeout honoured during SSL handshake

### DIFF
--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/AdHocMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/AdHocMain.java
@@ -25,6 +25,8 @@ public final class AdHocMain {
                 .refreshBeforeExpiry(5, TimeUnit.MINUTES) //
                 .authenticationEndpoint(AuthenticationEndpoint.GLOBAL) // is default
                 .build();
+        
+        client.users(mailbox).messages().get().currentPage().stream().forEach(System.out::println);
 
         // if (false) {
         // String url =


### PR DESCRIPTION
If the SSL handshake with MsGraph hung then the configured timeout did not apply (see bug report in Apache httpclient https://issues.apache.org/jira/browse/HTTPCLIENT-2090).

The workaround is to use a PoolingHttpConnectionManager with the read timeout specified in the SocketConfig.

@superevensteven