### PR TITLE
Stop using InjectableValues with UnmappedFields - bug with distinct map values overwritten

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1423,8 +1423,7 @@ public final class Generator {
 	}
 
 	private static void addUnmappedFieldsField(Imports imports, Indent indent, PrintWriter p) {
-		p.format("\n%s@%s\n", indent, imports.add(JacksonInject.class));
-		p.format("%s@%s\n", indent, imports.add(JsonIgnore.class));
+		p.format("\n%s@%s\n", indent, imports.add(JsonIgnore.class));
 		p.format("%sprotected %s unmappedFields;\n", indent, imports.add(UnmappedFields.class));
 	}
 

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -61,6 +62,7 @@ import odata.msgraph.client.entity.DriveItem;
 import odata.msgraph.client.entity.FileAttachment;
 import odata.msgraph.client.entity.Group;
 import odata.msgraph.client.entity.ItemAttachment;
+import odata.msgraph.client.entity.ListItem;
 import odata.msgraph.client.entity.Message;
 import odata.msgraph.client.entity.User;
 import odata.msgraph.client.entity.request.MailFolderRequest;
@@ -259,6 +261,27 @@ public class GraphServiceTest {
     }
 
     @Test
+    public void testUnmappedFieldsHaveDistinctValues() {
+        // NOTE: The following test data is taken from https://developer.microsoft.com/en-us/graph/graph-explorer -- with the first item's "lastModifiedBy" user email hand-modified
+        GraphService client = clientBuilder() //
+                .expectResponse("/sites/lists/d7689e2b-941a-4cd3-bb24-55cddee54294/items?$expand=fields", "/response-list-items-expand-fields.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
+                        RequestHeader.ODATA_VERSION) //
+                .build();
+        CollectionPage<ListItem> listItems = client.sites().lists("d7689e2b-941a-4cd3-bb24-55cddee54294").items().expand("fields").get();
+        assertNotNull(listItems);
+        assertEquals(3, listItems.currentPage().size());
+        ListItem firstListItem = listItems.currentPage().get(0);
+
+        // Verify UnmappedFields from separate ListItems:
+        assertEquals("Contoso Home", ((Map<String, Object>) firstListItem.getUnmappedFields().get("fields")).get("Title"));
+        assertEquals("Microsoft Demos", ((Map<String, Object>) listItems.currentPage().get(1).getUnmappedFields().get("fields")).get("Title"));
+
+        // Verify that different UnmappedFields instances from the same ListItem Jackson deserialization call have distinct contents:
+        assertEquals("provisioninguser1@m365x214355.onmicrosoft.com", firstListItem.getCreatedBy().get().getUser().get().getUnmappedFields().get("email"));
+        assertEquals("different.test.email@m365x214355.onmicrosoft.com", firstListItem.getLastModifiedBy().get().getUser().get().getUnmappedFields().get("email"));
+    }
+
+    @Test
     public void testGetUploadUrl() {
         GraphService client = clientBuilder() //
                 .expectRequestAndResponse("/users/me/messages/1/attachments/createUploadSession", //
@@ -323,7 +346,7 @@ public class GraphServiceTest {
         //https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345
         u.putChunked().readTimeout(10, TimeUnit.SECONDS).uploadUtf8("hello", 2);
     }
-    
+
     @Test
     @Ignore
     public void testSendEmailWithAttachmentCompiles() {

--- a/odata-client-msgraph/src/test/resources/response-list-items-expand-fields.json
+++ b/odata-client-msgraph/src/test/resources/response-list-items-expand-fields.json
@@ -1,0 +1,182 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items(fields())",
+  "value": [
+    {
+      "@odata.etag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+      "createdDateTime": "2017-09-02T01:44:00Z",
+      "eTag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+      "id": "6",
+      "lastModifiedDateTime": "2017-09-02T01:45:12Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/6_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "different.test.email@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('6')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+        "id": "6",
+        "ContentType": "Office 365 Demos",
+        "Title": "Contoso Home",
+        "Modified": "2017-09-02T01:45:12Z",
+        "Created": "2017-09-02T01:44:00Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Contoso Home",
+        "LinkTitle": "Contoso Home",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/SiteAssets/DemoHomePageShort1.png",
+          "Url": "https://m365x214355.sharepoint.com/SiteAssets/DemoHomePageShort1.png"
+        },
+        "LinkLocation": {
+          "Description": "https://m365x214355.sharepoint.com/sites/contoso",
+          "Url": "https://m365x214355.sharepoint.com/sites/contoso"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 1
+      }
+    },
+    {
+      "@odata.etag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+      "createdDateTime": "2017-09-02T01:45:14Z",
+      "eTag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+      "id": "7",
+      "lastModifiedDateTime": "2017-09-02T01:46:30Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/7_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('7')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+        "id": "7",
+        "ContentType": "Office 365 Demos",
+        "Title": "Microsoft Demos",
+        "Modified": "2017-09-02T01:46:30Z",
+        "Created": "2017-09-02T01:45:14Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Microsoft Demos",
+        "LinkTitle": "Microsoft Demos",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/siteassets/MOD.png",
+          "Url": "https://m365x214355.sharepoint.com/siteassets/MOD.png"
+        },
+        "LinkLocation": {
+          "Description": "https://demos.microsoft.com",
+          "Url": "https://demos.microsoft.com"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 4
+      }
+    },
+    {
+      "@odata.etag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+      "createdDateTime": "2017-09-02T01:46:32Z",
+      "eTag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+      "id": "8",
+      "lastModifiedDateTime": "2017-09-02T01:47:32Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/8_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('8')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+        "id": "8",
+        "ContentType": "Office 365 Demos",
+        "Title": "Office Blogs",
+        "Modified": "2017-09-02T01:47:32Z",
+        "Created": "2017-09-02T01:46:32Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Office Blogs",
+        "LinkTitle": "Office Blogs",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/siteassets/OfficeBlogs.png",
+          "Url": "https://m365x214355.sharepoint.com/siteassets/OfficeBlogs.png"
+        },
+        "LinkLocation": {
+          "Description": "http://blogs.office.com",
+          "Url": "http://blogs.office.com"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 5
+      }
+    }
+  ]
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -77,8 +77,7 @@ public final class Serializer {
                 ObjectMapper m = MAPPER_EXCLUDE_NULLS.copy();
                 Std iv = new InjectableValues.Std() //
                         .addValue(ContextPath.class, contextPath) //
-                        .addValue(ChangedFields.class, new ChangedFields()) //
-                        .addValue(UnmappedFields.class, new UnmappedFields());
+                        .addValue(ChangedFields.class, new ChangedFields());
                 m.setInjectableValues(iv);
                 T t = m.readValue(text, cls);
                 if (t instanceof ODataType) {


### PR DESCRIPTION
Stop using InjectableValues with UnmappedFields, to fix problem with all distinct UnmappedFields in a deserialization call sharing the same map instance, overwriting prior values