### PR TITLE
Use injectable factories so that UnmappedValues and ChangedFields are initialized properly in deserialized lists

### DIFF
--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -668,10 +668,12 @@ public class GraphServiceTest {
     
     @SuppressWarnings("unchecked")
     @Test
-    public void testUnmappedFieldsHaveDistinctValues() {
+    public void testItemsInDeserializedListHaveDistinctUnmappedFieldsInstancesPR35() {
         // NOTE: The following test data is taken from https://developer.microsoft.com/en-us/graph/graph-explorer -- with the first item's "lastModifiedBy" user email hand-modified
         GraphService client = clientBuilder() //
-                .expectResponse("/sites/lists/d7689e2b-941a-4cd3-bb24-55cddee54294/items?$expand=fields", "/response-list-items-expand-fields.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
+                .expectResponse("/sites/lists/d7689e2b-941a-4cd3-bb24-55cddee54294/items?$expand=fields", //
+                        "/response-list-items-expand-fields.json", //
+                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, //
                         RequestHeader.ODATA_VERSION) //
                 .build();
         CollectionPage<ListItem> listItems = client.sites().lists("d7689e2b-941a-4cd3-bb24-55cddee54294").items().expand("fields").get();
@@ -680,12 +682,16 @@ public class GraphServiceTest {
         ListItem firstListItem = listItems.currentPage().get(0);
 
          // Verify UnmappedFields from separate ListItems:
-        assertEquals("Contoso Home", ((Map<String, Object>) firstListItem.getUnmappedFields().get("fields")).get("Title"));
-        assertEquals("Microsoft Demos", ((Map<String, Object>) listItems.currentPage().get(1).getUnmappedFields().get("fields")).get("Title"));
+        assertEquals("Contoso Home", //
+                ((Map<String, Object>) firstListItem.getUnmappedFields().get("fields")).get("Title"));
+        assertEquals("Microsoft Demos", //
+                ((Map<String, Object>) listItems.currentPage().get(1).getUnmappedFields().get("fields")).get("Title"));
 
          // Verify that different UnmappedFields instances from the same ListItem Jackson deserialization call have distinct contents:
-        assertEquals("provisioninguser1@m365x214355.onmicrosoft.com", firstListItem.getCreatedBy().get().getUser().get().getUnmappedFields().get("email"));
-        assertEquals("different.test.email@m365x214355.onmicrosoft.com", firstListItem.getLastModifiedBy().get().getUser().get().getUnmappedFields().get("email"));
+        assertEquals("provisioninguser1@m365x214355.onmicrosoft.com", //
+                firstListItem.getCreatedBy().get().getUser().get().getUnmappedFields().get("email"));
+        assertEquals("different.test.email@m365x214355.onmicrosoft.com", //
+                firstListItem.getLastModifiedBy().get().getUser().get().getUnmappedFields().get("email"));
     }
 
     @Test

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -666,6 +666,7 @@ public class GraphServiceTest {
         assertEquals("editLink1", editLink);
     }
     
+    @SuppressWarnings("unchecked")
     @Test
     public void testUnmappedFieldsHaveDistinctValues() {
         // NOTE: The following test data is taken from https://developer.microsoft.com/en-us/graph/graph-explorer -- with the first item's "lastModifiedBy" user email hand-modified

--- a/odata-client-msgraph/src/test/resources/response-list-items-expand-fields.json
+++ b/odata-client-msgraph/src/test/resources/response-list-items-expand-fields.json
@@ -1,0 +1,182 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items(fields())",
+  "value": [
+    {
+      "@odata.etag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+      "createdDateTime": "2017-09-02T01:44:00Z",
+      "eTag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+      "id": "6",
+      "lastModifiedDateTime": "2017-09-02T01:45:12Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/6_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "different.test.email@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('6')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"c8cf0cd9-826e-4295-8c52-e2c201739dc5,13\"",
+        "id": "6",
+        "ContentType": "Office 365 Demos",
+        "Title": "Contoso Home",
+        "Modified": "2017-09-02T01:45:12Z",
+        "Created": "2017-09-02T01:44:00Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Contoso Home",
+        "LinkTitle": "Contoso Home",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/SiteAssets/DemoHomePageShort1.png",
+          "Url": "https://m365x214355.sharepoint.com/SiteAssets/DemoHomePageShort1.png"
+        },
+        "LinkLocation": {
+          "Description": "https://m365x214355.sharepoint.com/sites/contoso",
+          "Url": "https://m365x214355.sharepoint.com/sites/contoso"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 1
+      }
+    },
+    {
+      "@odata.etag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+      "createdDateTime": "2017-09-02T01:45:14Z",
+      "eTag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+      "id": "7",
+      "lastModifiedDateTime": "2017-09-02T01:46:30Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/7_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('7')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"e99bbad3-17b2-47b4-8b11-b67c7231aaa7,13\"",
+        "id": "7",
+        "ContentType": "Office 365 Demos",
+        "Title": "Microsoft Demos",
+        "Modified": "2017-09-02T01:46:30Z",
+        "Created": "2017-09-02T01:45:14Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Microsoft Demos",
+        "LinkTitle": "Microsoft Demos",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/siteassets/MOD.png",
+          "Url": "https://m365x214355.sharepoint.com/siteassets/MOD.png"
+        },
+        "LinkLocation": {
+          "Description": "https://demos.microsoft.com",
+          "Url": "https://demos.microsoft.com"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 4
+      }
+    },
+    {
+      "@odata.etag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+      "createdDateTime": "2017-09-02T01:46:32Z",
+      "eTag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+      "id": "8",
+      "lastModifiedDateTime": "2017-09-02T01:47:32Z",
+      "webUrl": "https://m365x214355.sharepoint.com/Lists/Office%20365%20Demos/8_.000",
+      "createdBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "lastModifiedBy": {
+        "user": {
+          "email": "provisioninguser1@m365x214355.onmicrosoft.com",
+          "displayName": "Provisioning User"
+        }
+      },
+      "parentReference": {
+        "siteId": "m365x214355.sharepoint.com,5a58bb09-1fba-41c1-8125-69da264370a0,9f2ec1da-0be4-4a74-9254-973f0add78fd"
+      },
+      "contentType": {
+        "id": "0x002B9E68D71A94D34CBB2455CDDEE54294",
+        "name": "Office 365 Demos"
+      },
+      "fields@odata.context": "https://graph.microsoft.com/v1.0/$metadata#sites('root')/lists('d7689e2b-941a-4cd3-bb24-55cddee54294')/items('8')/fields/$entity",
+      "fields": {
+        "@odata.etag": "\"a6de4804-a33e-4f3c-8af7-d09a7a6ee83e,13\"",
+        "id": "8",
+        "ContentType": "Office 365 Demos",
+        "Title": "Office Blogs",
+        "Modified": "2017-09-02T01:47:32Z",
+        "Created": "2017-09-02T01:46:32Z",
+        "AuthorLookupId": "36",
+        "EditorLookupId": "36",
+        "_UIVersionString": "1.0",
+        "Attachments": false,
+        "Edit": "",
+        "LinkTitleNoMenu": "Office Blogs",
+        "LinkTitle": "Office Blogs",
+        "ItemChildCount": "0",
+        "FolderChildCount": "0",
+        "_ComplianceFlags": "",
+        "_ComplianceTag": "",
+        "_ComplianceTagWrittenTime": "",
+        "_ComplianceTagUserId": "",
+        "BackgroundImageLocation": {
+          "Description": "https://m365x214355.sharepoint.com/siteassets/OfficeBlogs.png",
+          "Url": "https://m365x214355.sharepoint.com/siteassets/OfficeBlogs.png"
+        },
+        "LinkLocation": {
+          "Description": "http://blogs.office.com",
+          "Url": "http://blogs.office.com"
+        },
+        "LaunchBehavior": "New tab",
+        "TileOrder": 5
+      }
+    }
+  ]
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
 import com.github.davidmoten.odata.client.internal.ChangedFields;
+import com.github.davidmoten.odata.client.internal.InjectableValuesFromFactories;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
 import com.github.davidmoten.odata.client.internal.UnmappedFields;
 
@@ -75,10 +76,10 @@ public final class Serializer {
         try {
             if (contextPath != null) {
                 ObjectMapper m = MAPPER_EXCLUDE_NULLS.copy();
-                Std iv = new InjectableValues.Std() //
-                        .addValue(ContextPath.class, contextPath) //
-                        .addValue(ChangedFields.class, new ChangedFields()) //
-                        .addValue(UnmappedFields.class, new UnmappedFields());
+                InjectableValuesFromFactories iv = new InjectableValuesFromFactories() //
+                        .addValue(ContextPath.class, () -> contextPath) //
+                        .addValue(ChangedFields.class, ChangedFields::new) //
+                        .addValue(UnmappedFields.class, UnmappedFields::new);
                 m.setInjectableValues(iv);
                 T t = m.readValue(text, cls);
                 if (t instanceof ODataType) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -76,10 +76,7 @@ public final class Serializer {
         try {
             if (contextPath != null) {
                 ObjectMapper m = MAPPER_EXCLUDE_NULLS.copy();
-                InjectableValuesFromFactories iv = new InjectableValuesFromFactories() //
-                        .addValue(ContextPath.class, () -> contextPath) //
-                        .addValue(ChangedFields.class, ChangedFields::new) //
-                        .addValue(UnmappedFields.class, UnmappedFields::new);
+                InjectableValues iv = createInjectableValues(contextPath);
                 m.setInjectableValues(iv);
                 T t = m.readValue(text, cls);
                 if (t instanceof ODataType) {
@@ -94,6 +91,13 @@ public final class Serializer {
         }
     }
 
+    private static InjectableValues createInjectableValues(ContextPath contextPath) {
+        return new InjectableValuesFromFactories() //
+                .addValue(ContextPath.class, () -> contextPath) //
+                .addValue(ChangedFields.class, ChangedFields::new) //
+                .addValue(UnmappedFields.class, UnmappedFields::new);
+    }
+
     public <T, S> T deserializeWithParametricType(String text, Class<? extends T> cls,
             Class<? extends S> parametricTypeClass, ContextPath contextPath,
             boolean addKeysToContextPath) {
@@ -102,10 +106,7 @@ public final class Serializer {
             JavaType type = m.getTypeFactory().constructParametricType(cls,
                     parametricTypeClass);
             if (contextPath != null) {
-                Std iv = new InjectableValues.Std() //
-                        .addValue(ContextPath.class, contextPath) //
-                        .addValue(ChangedFields.class, new ChangedFields()) //
-                        .addValue(UnmappedFields.class, new UnmappedFields());
+                InjectableValues iv = createInjectableValues(contextPath);
                 m.setInjectableValues(iv);
                 T t = m.readValue(text, type);
                 if (t instanceof ODataType) {
@@ -119,7 +120,7 @@ public final class Serializer {
             throw new RuntimeException(e);
         }
     }
-
+    
     public <T> T deserialize(String text, Class<T> cls) {
         return deserialize(text, cls, null, false);
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.InjectableValues.Std;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.github.davidmoten.guavamini.Preconditions;
 
 public final class InjectableValuesFromFactories extends InjectableValues implements java.io.Serializable {
 
@@ -25,11 +26,15 @@ public final class InjectableValuesFromFactories extends InjectableValues implem
     }
 
     public InjectableValuesFromFactories addValue(String key, Callable<?> value) {
+        Preconditions.checkNotNull(key);
+        Preconditions.checkNotNull(value);
         _values.put(key, value);
         return this;
     }
 
     public InjectableValuesFromFactories addValue(Class<?> classKey, Callable<?> value) {
+        Preconditions.checkNotNull(classKey);
+        Preconditions.checkNotNull(value);
         _values.put(classKey.getName(), value);
         return this;
     }
@@ -43,6 +48,10 @@ public final class InjectableValuesFromFactories extends InjectableValues implem
         }
         String key = (String) valueId;
         Callable<?> callable = _values.get(key);
+        if (callable == null) {
+            throw new IllegalArgumentException(
+                    "No injectable id with value '" + key + "' found (for property '" + forProperty.getName() + "')");
+        }
         Object ob;
         try {
             ob = callable.call();

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
@@ -52,7 +52,7 @@ public final class InjectableValuesFromFactories
             try {
                 ob = callable.call();
             } catch (Exception e) {
-                throw new RuntimeException("callable threw when creating value", e);
+                throw JsonMappingException.from(ctxt,"callable threw when creating value for property " + forProperty.getFullName(), e);
             }
             if (ob == null && !_values.containsKey(key)) {
                 throw new IllegalArgumentException("No injectable id with value '"+key+"' found (for property '"+forProperty.getName()+"')");

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
@@ -10,53 +10,50 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 
-public final class InjectableValuesFromFactories
-        extends InjectableValues
-        implements java.io.Serializable
-    {
-        private static final long serialVersionUID = 1L;
+public final class InjectableValuesFromFactories extends InjectableValues implements java.io.Serializable {
 
-        protected final Map<String,Callable<?>> _values;
-        
-        public InjectableValuesFromFactories() {
-            this(new HashMap<String,Callable<?>>());
-        }
+    private static final long serialVersionUID = 6050577234392343535L;
 
-        public InjectableValuesFromFactories(Map<String, Callable<?>> values) {
-            _values = values;
-        }
+    protected final Map<String, Callable<?>> _values;
 
-        public InjectableValuesFromFactories addValue(String key, Callable<?> value) {
-            _values.put(key, value);
-            return this;
-        }
-
-        public InjectableValuesFromFactories addValue(Class<?> classKey, Callable<?> value) {
-            _values.put(classKey.getName(), value);
-            return this;
-        }
-        
-        @Override
-        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
-                BeanProperty forProperty, Object beanInstance) throws JsonMappingException
-        {
-            if (!(valueId instanceof String)) {
-                ctxt.reportBadDefinition(ClassUtil.classOf(valueId),
-                        String.format(
-                        "Unrecognized inject value id type (%s), expecting String",
-                        ClassUtil.classNameOf(valueId)));
-            }
-            String key = (String) valueId;
-            Callable<?> callable = _values.get(key);
-            Object ob;
-            try {
-                ob = callable.call();
-            } catch (Exception e) {
-                throw JsonMappingException.from(ctxt,"callable threw when creating value for property " + forProperty.getFullName(), e);
-            }
-            if (ob == null && !_values.containsKey(key)) {
-                throw new IllegalArgumentException("No injectable id with value '"+key+"' found (for property '"+forProperty.getName()+"')");
-            }
-            return ob;
-        }
+    public InjectableValuesFromFactories() {
+        this(new HashMap<String, Callable<?>>());
     }
+
+    public InjectableValuesFromFactories(Map<String, Callable<?>> values) {
+        _values = values;
+    }
+
+    public InjectableValuesFromFactories addValue(String key, Callable<?> value) {
+        _values.put(key, value);
+        return this;
+    }
+
+    public InjectableValuesFromFactories addValue(Class<?> classKey, Callable<?> value) {
+        _values.put(classKey.getName(), value);
+        return this;
+    }
+
+    @Override
+    public Object findInjectableValue(Object valueId, DeserializationContext ctxt, BeanProperty forProperty,
+            Object beanInstance) throws JsonMappingException {
+        if (!(valueId instanceof String)) {
+            ctxt.reportBadDefinition(ClassUtil.classOf(valueId), String.format(
+                    "Unrecognized inject value id type (%s), expecting String", ClassUtil.classNameOf(valueId)));
+        }
+        String key = (String) valueId;
+        Callable<?> callable = _values.get(key);
+        Object ob;
+        try {
+            ob = callable.call();
+        } catch (Exception e) {
+            throw JsonMappingException.from(ctxt,
+                    "callable threw when creating value for property " + forProperty.getFullName(), e);
+        }
+        if (ob == null && !_values.containsKey(key)) {
+            throw new IllegalArgumentException(
+                    "No injectable id with value '" + key + "' found (for property '" + forProperty.getName() + "')");
+        }
+        return ob;
+    }
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/InjectableValuesFromFactories.java
@@ -1,0 +1,62 @@
+package com.github.davidmoten.odata.client.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+
+public final class InjectableValuesFromFactories
+        extends InjectableValues
+        implements java.io.Serializable
+    {
+        private static final long serialVersionUID = 1L;
+
+        protected final Map<String,Callable<?>> _values;
+        
+        public InjectableValuesFromFactories() {
+            this(new HashMap<String,Callable<?>>());
+        }
+
+        public InjectableValuesFromFactories(Map<String, Callable<?>> values) {
+            _values = values;
+        }
+
+        public InjectableValuesFromFactories addValue(String key, Callable<?> value) {
+            _values.put(key, value);
+            return this;
+        }
+
+        public InjectableValuesFromFactories addValue(Class<?> classKey, Callable<?> value) {
+            _values.put(classKey.getName(), value);
+            return this;
+        }
+        
+        @Override
+        public Object findInjectableValue(Object valueId, DeserializationContext ctxt,
+                BeanProperty forProperty, Object beanInstance) throws JsonMappingException
+        {
+            if (!(valueId instanceof String)) {
+                ctxt.reportBadDefinition(ClassUtil.classOf(valueId),
+                        String.format(
+                        "Unrecognized inject value id type (%s), expecting String",
+                        ClassUtil.classNameOf(valueId)));
+            }
+            String key = (String) valueId;
+            Callable<?> callable = _values.get(key);
+            Object ob;
+            try {
+                ob = callable.call();
+            } catch (Exception e) {
+                throw new RuntimeException("callable threw when creating value", e);
+            }
+            if (ob == null && !_values.containsKey(key)) {
+                throw new IllegalArgumentException("No injectable id with value '"+key+"' found (for property '"+forProperty.getName()+"')");
+            }
+            return ob;
+        }
+    }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -14,9 +14,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.odata.client.ClientException;
 import com.github.davidmoten.odata.client.Context;


### PR DESCRIPTION
As mentioned in #35, serialization of a list of items ends with all items sharing the same instance of `UnmappedValues` and `ChangedFields`. To fix this we could prevent injection of those fields but I'd like to preserve that injection using a factory instead rather than remove injection altogether out of uncertainty that we have test coverage of the original motivation to use injection.

I've copied `InjectableValues.Std` from Jackson lib and made `InjectableValuesFromFactories` and used that in `Serializer.deserialize` and `Serializer.deserializeWithParametricType`.

The test from #35 passes with this change.

Upon reflection I think the injection of UnmappedValues and ChangedFields is explicitly performed because of nervousness about NPEs from uninitialized fields being used (though it does seem Jackson initializes them using default constructor). I'm content with it being explicit.