### PR TITLE
fix default namespace to package name mapping

### DIFF
--- a/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
+++ b/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
@@ -4,12 +4,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.lang.model.SourceVersion;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
@@ -32,7 +34,7 @@ import com.github.davidmoten.odata.client.generator.SchemaOptions;
 
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class GeneratorMojo extends AbstractMojo {
-
+    
     @Parameter(name = "metadata", required = true)
     String metadata;
 
@@ -161,6 +163,19 @@ public class GeneratorMojo extends AbstractMojo {
         while (result.endsWith(".")) {
             result = result.substring(0, result.length() - 1);
         }
-        return result;
+        return result = replaceReservedWordsInPackageName(result);
     }
+
+    private static String replaceReservedWordsInPackageName(String pkg) {
+        return Arrays.stream(pkg.split("\\.")) //
+                .map(x -> {
+                    if (SourceVersion.isKeyword(x)) {
+                        return x + "_";
+                    } else {
+                        return x;
+                    }
+                }).collect(Collectors.joining("."));
+        
+    }
+    
 }

--- a/odata-client-maven-plugin/src/test/java/org/davidmoten/odata/client/maven/GeneratorMojoTest.java
+++ b/odata-client-maven-plugin/src/test/java/org/davidmoten/odata/client/maven/GeneratorMojoTest.java
@@ -18,5 +18,11 @@ public class GeneratorMojoTest {
         assertEquals("abc.de123", toPackage("abc.de123"));
         assertEquals("abc.de123", toPackage("abc.de123;:=+"));
     }
+    
+    @Test
+    public void testToPackageOfJavaReservedWord() {
+        assertEquals("default_", toPackage("default"));
+        assertEquals("a.default_.b", toPackage("a.default.b"));
+    }
 
 }


### PR DESCRIPTION
.. so that it handles reserved words properly. 

See discussion in #39.

With this change a namespace of `blah.default.blah` will map by default to `blah.default_.blah` to ensure that no java reserved words are used in the package name.