### PR TITLE
Support expand for entity requests and entity collection requests

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -228,7 +228,7 @@ public final class Generator {
 					indent, //
 					t.getSimpleClassNameEntitySet(), //
 					imports.add(ContextPath.class));
-			p.format("%ssuper(contextPath);\n", indent.right());
+					p.format("%ssuper(contextPath, %s.empty());\n", indent.right(), imports.add(Optional.class));
 			p.format("%s}\n", indent.left());
 
 			// write navigation property bindings
@@ -1080,8 +1080,8 @@ public final class Generator {
 								Names.getGetterMethodWithoutGet(x.getName()));
 						if (isCollection(x)) {
 							p.format("%sreturn new %s(\n", indent.right(), toClassName(x, imports));
-							p.format("%scontextPath.addSegment(\"%s\"));\n", indent.right().right().right().right(),
-									x.getName());
+							p.format("%scontextPath.addSegment(\"%s\"), %s.empty());\n", indent.right().right().right().right(),
+									x.getName(), imports.add(Optional.class));
 							indent.left().left().left().left();
 						} else {
 							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"));\n", indent.right(), returnClass,
@@ -1321,11 +1321,19 @@ public final class Generator {
 			addContextPathField(imports, indent, p);
 
 			// add constructor
-			p.format("\n%spublic %s(%s contextPath) {\n", indent, simpleClassName, imports.add(ContextPath.class));
-			p.format("%ssuper(contextPath, %s.class, cp -> new %s(cp), %s.INSTANCE);\n", indent.right(),
+			p.format("\n%spublic %s(%s contextPath, %s<%s> value) {\n", //
+			        indent, //
+			        simpleClassName, //
+			        imports.add(ContextPath.class), //
+			        imports.add(Optional.class), //
+			        imports.add(Object.class));
+			p.format("%ssuper(contextPath, %s.class, cp -> new %s(cp), %s.INSTANCE, value);\n", //
+			        indent.right(), //
 					imports.add(names.getFullClassNameFromTypeWithoutNamespace(schema, t.getName())), //
 					imports.add(names.getFullClassNameEntityRequestFromTypeWithoutNamespace(schema, t.getName())), //
-					imports.add(names.getFullClassNameSchemaInfo(schema)));
+					imports.add(names.getFullClassNameSchemaInfo(schema)), //
+					imports.add(RequestHelper.class), //
+					t.getName());
 			p.format("%sthis.contextPath = contextPath;\n", indent);
 			p.format("%s}\n", indent.left());
 
@@ -1340,10 +1348,11 @@ public final class Generator {
 									imports.add(names.getFullClassNameCollectionRequestFromTypeWithNamespace(sch, y)), //
 									Names.getIdentifier(x.getName()));
 
-							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"));\n", //
+							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"), %s.empty());\n", //
 									indent.right(), //
 									imports.add(names.getFullClassNameCollectionRequestFromTypeWithNamespace(sch, y)), //
-									x.getName());
+									x.getName(), //
+									imports.add(Optional.class));
 							p.format("%s}\n", indent.left());
 
 							if (names.isEntityWithNamespace(y)) {
@@ -1779,8 +1788,8 @@ public final class Generator {
 					if (isCollection(x)) {
 						if (names.isEntityWithNamespace(names.getType(x))) {
 							p.format("%sreturn new %s(\n", indent.right(), toClassName(x, imports));
-							p.format("%scontextPath.addSegment(\"%s\"));\n", //
-									indent.right().right().right().right(), x.getName());
+							p.format("%scontextPath.addSegment(\"%s\"), %s.getValue(unmappedFields, \"%s\"));\n", //
+									indent.right().right().right().right(), x.getName(), imports.add(RequestHelper.class), x.getName());
 							indent.left().left().left().left();
 						} else {
 							throw new RuntimeException("unexpected");

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -74,6 +74,7 @@ import com.github.davidmoten.odata.client.StreamUploaderChunked;
 import com.github.davidmoten.odata.client.StreamUploaderSingleCall;
 import com.github.davidmoten.odata.client.TestingService.BuilderBase;
 import com.github.davidmoten.odata.client.TestingService.ContainerBuilder;
+import com.github.davidmoten.odata.client.UnmappedFields;
 import com.github.davidmoten.odata.client.UploadStrategy;
 import com.github.davidmoten.odata.client.annotation.NavigationProperty;
 import com.github.davidmoten.odata.client.annotation.Property;
@@ -98,7 +99,6 @@ import com.github.davidmoten.odata.client.internal.EdmSchemaInfo;
 import com.github.davidmoten.odata.client.internal.ParameterMap;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
 import com.github.davidmoten.odata.client.internal.TypedObject;
-import com.github.davidmoten.odata.client.internal.UnmappedFields;
 
 public final class Generator {
 

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1043,8 +1043,10 @@ public final class Generator {
 			indent.right();
 
 			// add constructor
-			p.format("%spublic %s(%s contextPath) {\n", indent, simpleClassName, imports.add(ContextPath.class));
-			p.format("%ssuper(%s.class, contextPath, %s.INSTANCE);\n", //
+			p.format("%spublic %s(%s contextPath, %s<%s> value) {\n", indent, //
+			        simpleClassName, imports.add(ContextPath.class), //
+			        imports.add(Optional.class), imports.add(Object.class));
+			p.format("%ssuper(%s.class, contextPath, %s.INSTANCE, value);\n", //
 					indent.right(), //
 					imports.add(t.getFullClassNameEntity()), //
 					imports.add(names.getFullClassNameSchemaInfo(schema)));
@@ -1084,8 +1086,8 @@ public final class Generator {
 									x.getName(), imports.add(Optional.class));
 							indent.left().left().left().left();
 						} else {
-							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"));\n", indent.right(), returnClass,
-									x.getName());
+							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"), %s.empty());\n", indent.right(), returnClass,
+									x.getName(), imports.add(Optional.class));
 						}
 						p.format("%s}\n", indent.left());
 
@@ -1102,8 +1104,8 @@ public final class Generator {
 
 								p.format("\n%spublic %s %s(%s) {\n", indent, imports.add(entityRequestType),
 										Names.getIdentifier(x.getName()), k.typedParams);
-								p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s);\n", indent.right(),
-										imports.add(entityRequestType), x.getName(), k.addKeys);
+								p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s, %s.empty());\n", indent.right(),
+										imports.add(entityRequestType), x.getName(), k.addKeys, imports.add(Optional.class));
 								p.format("%s}\n", indent.left());
 							}
 						}
@@ -1260,8 +1262,8 @@ public final class Generator {
 
 							p.format("\n%spublic %s %s(%s) {\n", indent, imports.add(entityRequestType),
 									Names.getIdentifier(x.getName()), k.typedParams);
-							p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s);\n", indent.right(),
-									imports.add(entityRequestType), x.getName(), k.addKeys);
+							p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s, %s.empty());\n", indent.right(),
+									imports.add(entityRequestType), x.getName(), k.addKeys, imports.add(Optional.class));
 							p.format("%s}\n", indent.left());
 						}
 					});
@@ -1271,8 +1273,8 @@ public final class Generator {
 					.forEach(x -> {
 						String importedType = toClassName(x, imports);
 						p.format("\n%spublic %s %s() {\n", indent, importedType, Names.getIdentifier(x.getName()));
-						p.format("%sreturn new %s(contextPath.addSegment(\"%s\"));\n", indent.right(), importedType,
-								x.getName());
+						p.format("%sreturn new %s(contextPath.addSegment(\"%s\"), %s.empty());\n", indent.right(), importedType,
+								x.getName(), imports.add(Optional.class));
 						p.format("%s}\n", indent.left());
 					});
 
@@ -1327,7 +1329,7 @@ public final class Generator {
 			        imports.add(ContextPath.class), //
 			        imports.add(Optional.class), //
 			        imports.add(Object.class));
-			p.format("%ssuper(contextPath, %s.class, cp -> new %s(cp), %s.INSTANCE, value);\n", //
+			p.format("%ssuper(contextPath, %s.class, cp -> new %s(cp, Optional.empty()), %s.INSTANCE, value);\n", //
 			        indent.right(), //
 					imports.add(names.getFullClassNameFromTypeWithoutNamespace(schema, t.getName())), //
 					imports.add(names.getFullClassNameEntityRequestFromTypeWithoutNamespace(schema, t.getName())), //
@@ -1363,8 +1365,8 @@ public final class Generator {
 
 								p.format("\n%spublic %s %s(%s) {\n", indent, imports.add(entityRequestType),
 										Names.getIdentifier(x.getName()), k.typedParams);
-								p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s);\n", indent.right(),
-										imports.add(entityRequestType), x.getName(), k.addKeys);
+								p.format("%sreturn new %s(contextPath.addSegment(\"%s\")%s, %s.empty());\n", indent.right(),
+										imports.add(entityRequestType), x.getName(), k.addKeys, imports.add(Optional.class));
 								p.format("%s}\n", indent.left());
 							}
 						}
@@ -1797,10 +1799,12 @@ public final class Generator {
 					} else {
 						if (names.isEntityWithNamespace(names.getType(x))) {
 							Schema sch = names.getSchema(names.getInnerType(names.getType(x)));
-							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"));\n", //
+							p.format("%sreturn new %s(contextPath.addSegment(\"%s\"), %s.getValue(unmappedFields, \"%s\"));\n", //
 									indent.right(), //
 									imports.add(names.getFullClassNameEntityRequestFromTypeWithNamespace(sch,
 											names.getInnerType(names.getType(x)))),
+									x.getName(), //
+									imports.add(RequestHelper.class), //
 									x.getName());
 						} else {
 							throw new RuntimeException("unexpected");

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1469,7 +1469,7 @@ public final class Generator {
 		p.format("\n%s@%s\n", indent, imports.add(Override.class));
 		p.format("%s@%s\n", indent, imports.add(JsonIgnore.class));
 		p.format("%spublic %s getUnmappedFields() {\n", indent, imports.add(UnmappedFields.class));
-		p.format("%sreturn unmappedFields == null ? new %s() : unmappedFields;\n", indent.right(),
+		p.format("%sreturn unmappedFields == null ? %s.EMPTY : unmappedFields;\n", indent.right(),
 				imports.add(UnmappedFields.class));
 		p.format("%s}\n", indent.left());
 	}

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
@@ -10,6 +10,7 @@ import com.github.davidmoten.odata.client.Serializer;
 import odata.msgraph.client.complex.ObjectIdentity;
 import odata.msgraph.client.container.GraphService;
 import odata.msgraph.client.entity.DirectoryObject;
+import odata.msgraph.client.entity.Drive;
 import odata.msgraph.client.entity.FileAttachment;
 import odata.msgraph.client.entity.User;
 
@@ -18,6 +19,11 @@ public class GraphExplorerMain {
     public static void main(String[] args) {
 
         GraphService client = MsGraph.explorer().build();
+        {
+            Drive drive = client.me().metadataMinimal().get().getDrive().get();
+            System.out.println(Serializer.INSTANCE.serialize(drive));
+            System.exit(0);
+        }
         {
             User delta = client.users().delta().streamWithDeltaLink().findFirst().get().object().get();
             System.out.println(Serializer.INSTANCE.serialize(delta));

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -242,48 +242,48 @@ public class GraphServiceTest {
             assertEquals(403, (int) e.getStatusCode().get());
         }
     }
-    
-	@Test
-	public void testUsersDeltaTokenLatest() {
-		GraphService client = clientBuilder() //
-				.expectResponse("/users/delta?$deltaToken=latest", "/response-users-delta-latest.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$deltatoken=1234", "/response-users-delta-latest-next.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$skiptoken=4567", "/response-users-delta-latest-next-2.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$deltatoken=789", "/response-users-delta-latest-next-3.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.build();
-		CollectionPage<User> p = client.users().delta().deltaTokenLatest().get();
-		assertTrue(p.toList().isEmpty());
-		p = p.nextDelta().get();
-		assertEquals(4, p.toList().size());
-		p = p.nextDelta().get();
-		List<User> list = p.toList();
-		assertEquals(1, list.size());
-		assertEquals("Fred", list.get(0).getGivenName().get());
-	}
-	
-	@Test
-	public void testUsersDeltaNextDeltaWorsWithoutReadingStreamFully() {
-		GraphService client = clientBuilder() //
-				.expectResponse("/users/delta?$deltaToken=latest", "/response-users-delta-latest.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$deltatoken=1234", "/response-users-delta-latest-next.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$skiptoken=4567", "/response-users-delta-latest-next-2.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.expectResponse("/users/delta?$deltatoken=789", "/response-users-delta-latest-next-3.json", HttpMethod.GET,
-						200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
-				.build();
-		CollectionPage<User> p = client.users().delta().deltaTokenLatest().get();
-		p = p.nextDelta().get();
-		p = p.nextDelta().get();
-		List<User> list = p.toList();
-		assertEquals(1, list.size());
-		assertEquals("Fred", list.get(0).getGivenName().get());
-	}
+
+    @Test
+    public void testUsersDeltaTokenLatest() {
+        GraphService client = clientBuilder() //
+                .expectResponse("/users/delta?$deltaToken=latest", "/response-users-delta-latest.json", HttpMethod.GET,
+                        200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$deltatoken=1234", "/response-users-delta-latest-next.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$skiptoken=4567", "/response-users-delta-latest-next-2.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$deltatoken=789", "/response-users-delta-latest-next-3.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .build();
+        CollectionPage<User> p = client.users().delta().deltaTokenLatest().get();
+        assertTrue(p.toList().isEmpty());
+        p = p.nextDelta().get();
+        assertEquals(4, p.toList().size());
+        p = p.nextDelta().get();
+        List<User> list = p.toList();
+        assertEquals(1, list.size());
+        assertEquals("Fred", list.get(0).getGivenName().get());
+    }
+
+    @Test
+    public void testUsersDeltaNextDeltaWorsWithoutReadingStreamFully() {
+        GraphService client = clientBuilder() //
+                .expectResponse("/users/delta?$deltaToken=latest", "/response-users-delta-latest.json", HttpMethod.GET,
+                        200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$deltatoken=1234", "/response-users-delta-latest-next.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$skiptoken=4567", "/response-users-delta-latest-next-2.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/delta?$deltatoken=789", "/response-users-delta-latest-next-3.json",
+                        HttpMethod.GET, 200, RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .build();
+        CollectionPage<User> p = client.users().delta().deltaTokenLatest().get();
+        p = p.nextDelta().get();
+        p = p.nextDelta().get();
+        List<User> list = p.toList();
+        assertEquals(1, list.size());
+        assertEquals("Fred", list.get(0).getGivenName().get());
+    }
 
     @SuppressWarnings("unused")
     @Test
@@ -314,31 +314,30 @@ public class GraphServiceTest {
         GraphService client = clientBuilder() //
                 .expectRequestAndResponse("/users/me/messages/1/attachments/createUploadSession", //
                         "/request-create-upload.json", //
-                        "/response-create-upload.json",  //
-                        HttpMethod.POST,  //
+                        "/response-create-upload.json", //
+                        HttpMethod.POST, //
                         HttpURLConnection.HTTP_CREATED, //
                         RequestHeader.ACCEPT_JSON, //
-                        RequestHeader.CONTENT_TYPE_JSON, // 
+                        RequestHeader.CONTENT_TYPE_JSON, //
                         RequestHeader.ODATA_VERSION)
-                .expectRequest("https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345", //
-                        "/request-upload-bytes.txt",
-                        HttpMethod.PUT, //
-                        RequestHeader.ODATA_VERSION , //
+                .expectRequest(
+                        "https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345", //
+                        "/request-upload-bytes.txt", HttpMethod.PUT, //
+                        RequestHeader.ODATA_VERSION, //
                         RequestHeader.ACCEPT_JSON, //
-                        RequestHeader.CONTENT_TYPE_OCTET_STREAM, 
-                        RequestHeader.contentRange(0, 4, 5))
+                        RequestHeader.CONTENT_TYPE_OCTET_STREAM, RequestHeader.contentRange(0, 4, 5))
                 .build();
         AttachmentItem item = AttachmentItem.builder().attachmentType(AttachmentType.FILE).contentType("text/plain")
                 .name("att.txt").size(5000000L).build();
         UploadSession u = client.users("me").messages("1").attachments().createUploadSession(item).get();
         assertNotNull(u);
         assertTrue(u.getUploadUrl().isPresent());
-        
+
         // perform upload using new method
-        //https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345
+        // https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345
         u.put().readTimeout(10, TimeUnit.SECONDS).uploadUtf8("hello");
     }
-    
+
     @Test
     public void testGetUploadUrlChunked() {
         String uploadUrl = "https://outlook.office.com/api/v2.0/Users('123')/Messages('ABC')/AttachmentSessions('ABC123')?authtoken=abc12345";
@@ -385,7 +384,7 @@ public class GraphServiceTest {
                 .readTimeout(10, TimeUnit.SECONDS) //
                 .uploadUtf8("hello", 2);
     }
-    
+
     @Test
     @Ignore
     public void testSendEmailWithAttachmentCompiles() {
@@ -413,7 +412,7 @@ public class GraphServiceTest {
                         .build()) //
                 .build();
         m = drafts.messages().post(m);
-        
+
         AttachmentItem a = AttachmentItem //
                 .builder() //
                 .attachmentType(AttachmentType.FILE) //
@@ -421,8 +420,8 @@ public class GraphServiceTest {
                 .name(file.getName()) //
                 .size(file.length()) //
                 .build();
-        
-        int chunkSize = 500*1024;
+
+        int chunkSize = 500 * 1024;
         client //
                 .users(mailbox) //
                 .messages(m.getId().get()) //
@@ -435,7 +434,7 @@ public class GraphServiceTest {
 
         m.send().call();
     }
-    
+
     @Test
     public void testGetCollectionWithSelect() {
         GraphService client = clientBuilder() //
@@ -483,24 +482,25 @@ public class GraphServiceTest {
                 .getByIds(Arrays.asList("a", "b"), Arrays.asList("c", "d")).get();
         assertTrue(page.currentPage().get(0).getId().get().startsWith("84b80893"));
     }
-    
+
     @Test
     public void testActionReturnsEdmTypeShouldReturnWrappedInODataValue() {
-        // note that graph docs and metadata clash about the return for this! I'll stick to the metadata definition but have raised
+        // note that graph docs and metadata clash about the return for this! I'll stick
+        // to the metadata definition but have raised
         // https://github.com/microsoftgraph/microsoft-graph-docs/issues/9211
         GraphService client = clientBuilder() //
                 .expectRequestAndResponse("/users/me/revokeSignInSessions", //
                         "/empty.json", //
                         "/response-revoke-sign-in-sessions.json", //
                         HttpMethod.POST, //
-                        HttpURLConnection.HTTP_CREATED, // 
+                        HttpURLConnection.HTTP_CREATED, //
                         RequestHeader.ODATA_VERSION, //
                         RequestHeader.CONTENT_TYPE_JSON, //
                         RequestHeader.ACCEPT_JSON) //
                 .build();
         assertTrue(client.users("me").revokeSignInSessions().get().value());
     }
-    
+
     @Test
     public void testEntityCollectionNotFromEntityContainer() {
         GraphService client = createClient("/me/messages/1/attachments", "/response-me-messages-1-attachments.json",
@@ -549,8 +549,8 @@ public class GraphServiceTest {
         GraphService client = clientBuilder() //
                 .expectResponse(
                         "/users/fred/mailFolders/inbox/messages?$filter=isRead%20eq%20false&$orderBy=createdDateTime",
-                        "/response-messages.json",
-                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                        "/response-messages.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
+                        RequestHeader.ODATA_VERSION) //
                 .expectResponse(
                         "/users/fred/mailFolders/inbox/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEJAAAiIsqMbYjsT5e-T7KzowPTAAAYbvZDAAA%3D/attachments",
                         "/response-message-attachments.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
@@ -568,39 +568,35 @@ public class GraphServiceTest {
         assertEquals(Arrays.asList("lamp_thin.png"),
                 m.getAttachments().stream().map(x -> x.getName().orElse("?")).collect(Collectors.toList()));
     }
-    
+
     @Test
     public void testSupplementWithDeltaLinkWhenCollectionEmpty() {
         GraphService client = clientBuilder() //
-                .expectResponse(
-                        "/users/delta?$deltaToken=latest",
-                        "/response-users-delta-empty.json",
+                .expectResponse("/users/delta?$deltaToken=latest", "/response-users-delta-empty.json",
                         RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
                 .build();
-        List<ObjectOrDeltaLink<User>> list = client.users().delta().deltaTokenLatest().get().streamWithDeltaLink().collect(Collectors.toList());
+        List<ObjectOrDeltaLink<User>> list = client.users().delta().deltaTokenLatest().get().streamWithDeltaLink()
+                .collect(Collectors.toList());
         assertEquals(1, list.size());
         ObjectOrDeltaLink<User> x = list.get(0);
         assertFalse(x.object().isPresent());
         assertEquals("https://graph.microsoft.com/v1.0/users/delta?$deltatoken=3enys", x.deltaLink().get());
     }
-    
+
     @Test
     public void testSupplementWithDeltaLinkWhenCollectionNonEmptyAndHasNoDeltaLink() {
         GraphService client = clientBuilder() //
-                .expectResponse(
-                        "/users",
-                        "/response-users-one-page.json",
-                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users", "/response-users-one-page.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
+                        RequestHeader.ODATA_VERSION) //
                 .build();
         assertEquals(31, client.users().stream().count());
         List<ObjectOrDeltaLink<User>> list = client.users().get().streamWithDeltaLink().collect(Collectors.toList());
         assertEquals(32, list.size());
-        ObjectOrDeltaLink<User> x = list.get(list.size() -1);
+        ObjectOrDeltaLink<User> x = list.get(list.size() - 1);
         assertFalse(x.object().isPresent());
         assertFalse(x.deltaLink().isPresent());
     }
-    
-    
+
     @Test
     public void testGetStreamOnItemAttachment() throws IOException {
         GraphService client = clientBuilder() //
@@ -631,33 +627,17 @@ public class GraphServiceTest {
         String s = new String(read(a.getStream().get().get()));
         assertEquals(60, s.length());
     }
-    
+
     @Test
     public void testExpandAttachments() {
         GraphService client = clientBuilder() //
-                .expectResponse(
-                        "/users/fred/messages/12345?$expand=attachments",
-                        "/response-expand-attachments.json", RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
-                        RequestHeader.ODATA_VERSION) //
+                .expectResponse("/users/fred/messages/12345?$expand=attachments", "/response-expand-attachments.json",
+                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
                 .build();
         Message m = client.users("fred").messages("12345").expand("attachments").get();
         Object attachments = m.getUnmappedFields().get("attachments");
         assertTrue(attachments instanceof ArrayList);
-        
-        // test how an expand attachments field can be converted into CollectionPage
-        Map<String, Object> map = new HashMap<String, Object>();
-        map.put("value",  attachments);
-        String json = Serializer.INSTANCE.serialize(map);
-        System.out.println(json);
-        CollectionPage<Attachment> a = Serializer.INSTANCE.deserializeCollectionPage( //
-                json, //
-                Attachment.class, //
-                new ContextPath(client._context(),new Path("attachments", PathStyle.IDENTIFIERS_AS_SEGMENTS)), //
-                SchemaInfo.INSTANCE, 
-                Collections.emptyList(), //
-                HttpRequestOptions.EMPTY
-                , null);
-        List<Attachment> list = a.toList();
+        List<Attachment> list = m.getAttachments().toList();
         assertEquals(1, list.size());
         assertEquals(2016, (int) list.get(0).getSize().orElse(0));
     }
@@ -777,29 +757,33 @@ public class GraphServiceTest {
         String editLink = a.getUnmappedFields().get("@odata.editLink").toString();
         assertEquals("editLink1", editLink);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test
     public void testItemsInDeserializedListHaveDistinctUnmappedFieldsInstancesPR35() {
-        // NOTE: The following test data is taken from https://developer.microsoft.com/en-us/graph/graph-explorer -- with the first item's "lastModifiedBy" user email hand-modified
+        // NOTE: The following test data is taken from
+        // https://developer.microsoft.com/en-us/graph/graph-explorer -- with the first
+        // item's "lastModifiedBy" user email hand-modified
         GraphService client = clientBuilder() //
                 .expectResponse("/sites/lists/d7689e2b-941a-4cd3-bb24-55cddee54294/items?$expand=fields", //
                         "/response-list-items-expand-fields.json", //
                         RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, //
                         RequestHeader.ODATA_VERSION) //
                 .build();
-        CollectionPage<ListItem> listItems = client.sites().lists("d7689e2b-941a-4cd3-bb24-55cddee54294").items().expand("fields").get();
+        CollectionPage<ListItem> listItems = client.sites().lists("d7689e2b-941a-4cd3-bb24-55cddee54294").items()
+                .expand("fields").get();
         assertNotNull(listItems);
         assertEquals(3, listItems.currentPage().size());
         ListItem firstListItem = listItems.currentPage().get(0);
 
-         // Verify UnmappedFields from separate ListItems:
+        // Verify UnmappedFields from separate ListItems:
         assertEquals("Contoso Home", //
                 ((Map<String, Object>) firstListItem.getUnmappedFields().get("fields")).get("Title"));
         assertEquals("Microsoft Demos", //
                 ((Map<String, Object>) listItems.currentPage().get(1).getUnmappedFields().get("fields")).get("Title"));
 
-         // Verify that different UnmappedFields instances from the same ListItem Jackson deserialization call have distinct contents:
+        // Verify that different UnmappedFields instances from the same ListItem Jackson
+        // deserialization call have distinct contents:
         assertEquals("provisioninguser1@m365x214355.onmicrosoft.com", //
                 firstListItem.getCreatedBy().get().getUser().get().getUnmappedFields().get("email"));
         assertEquals("different.test.email@m365x214355.onmicrosoft.com", //
@@ -1006,7 +990,7 @@ public class GraphServiceTest {
                 .build();
         client.communications().calls().post(call);
     }
-    
+
     @Test
     @Ignore
     public void testAddAttachmentToCalendarEventCompiles() {
@@ -1030,7 +1014,7 @@ public class GraphServiceTest {
                 .readTimeout(10, TimeUnit.MINUTES) //
                 .upload(file, 512 * 1024);
     }
-    
+
     // test paged complex type
     //
 

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -34,11 +34,9 @@ import com.github.davidmoten.guavamini.Sets;
 import com.github.davidmoten.microsoft.client.builder.MicrosoftClientBuilder;
 import com.github.davidmoten.odata.client.ClientException;
 import com.github.davidmoten.odata.client.CollectionPage;
-import com.github.davidmoten.odata.client.ContextPath;
 import com.github.davidmoten.odata.client.HttpMethod;
 import com.github.davidmoten.odata.client.HttpRequestOptions;
 import com.github.davidmoten.odata.client.ObjectOrDeltaLink;
-import com.github.davidmoten.odata.client.Path;
 import com.github.davidmoten.odata.client.PathStyle;
 import com.github.davidmoten.odata.client.RequestHeader;
 import com.github.davidmoten.odata.client.Retries;
@@ -62,6 +60,7 @@ import odata.msgraph.client.entity.Call;
 import odata.msgraph.client.entity.Contact;
 import odata.msgraph.client.entity.Device;
 import odata.msgraph.client.entity.DirectoryObject;
+import odata.msgraph.client.entity.Drive;
 import odata.msgraph.client.entity.DriveItem;
 import odata.msgraph.client.entity.FileAttachment;
 import odata.msgraph.client.entity.Group;
@@ -74,7 +73,6 @@ import odata.msgraph.client.enums.AttachmentType;
 import odata.msgraph.client.enums.BodyType;
 import odata.msgraph.client.enums.Importance;
 import odata.msgraph.client.enums.Modality;
-import odata.msgraph.client.schema.SchemaInfo;
 
 public class GraphServiceTest {
 
@@ -629,7 +627,7 @@ public class GraphServiceTest {
     }
 
     @Test
-    public void testExpandAttachments() {
+    public void testExpandCollectionRequest() {
         GraphService client = clientBuilder() //
                 .expectResponse("/users/fred/messages/12345?$expand=attachments", "/response-expand-attachments.json",
                         RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
@@ -640,6 +638,19 @@ public class GraphServiceTest {
         List<Attachment> list = m.getAttachments().toList();
         assertEquals(1, list.size());
         assertEquals(2016, (int) list.get(0).getSize().orElse(0));
+    }
+    
+    @Test
+    public void testExpandEntityRequest() {
+        GraphService client = clientBuilder() //
+                .expectResponse("/users/fred?$expand=drive", "/response-user-expand-with-drive.json",
+                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
+                .build();
+        User user = client.users("fred").expand("drive").get();
+        Object object = user.getUnmappedFields().get("drive");
+        assertTrue(object instanceof HashMap);
+        Drive drive = user.getDrive().get();
+        assertEquals("OneDrive", drive.getName().get());
     }
 
     @Test

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -549,7 +549,7 @@ public class GraphServiceTest {
         GraphService client = clientBuilder() //
                 .expectResponse(
                         "/users/fred/mailFolders/inbox/messages?$filter=isRead%20eq%20false&$orderBy=createdDateTime",
-                        "/response-messages-expand-attachments-minimal-metadata.json",
+                        "/response-messages.json",
                         RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION) //
                 .expectResponse(
                         "/users/fred/mailFolders/inbox/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEJAAAiIsqMbYjsT5e-T7KzowPTAAAYbvZDAAA%3D/attachments",

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -33,7 +33,9 @@ public class MsGraphMain {
                 .build();
         {
             String mailbox = System.getProperty("mailbox");
-            client.users(mailbox).messages().stream().limit(10).map(x-> x.getSubject().get()).forEach(System.out::println);
+            String messageId = "AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQBGAAAAAABCSTzSpYOXTJf5ExxfstMvBwD0q8bfcZ7QQry5SG484keOAAAACjNfAADh3MOyvFF4RJgQOjzBK-sdAAOBakhvAAA=";
+            Message m = client.users(mailbox).messages(messageId).expand("attachments").get();
+            System.out.println(m.getUnmappedFields());
             System.exit(0);
         }
         {

--- a/odata-client-msgraph/src/test/resources/response-expand-attachments.json
+++ b/odata-client-msgraph/src/test/resources/response-expand-attachments.json
@@ -1,0 +1,77 @@
+{
+	"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('david.moten%40amsa.gov.au')/messages(attachments())/$entity",
+	"@odata.etag": "W/\"CQAAABYAAADh3MOyvFF4RJgQOjzBK/sdAAOAhgDj\"",
+	"id": "AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQBGAAAAAABCSTzSpYOXTJf5ExxfstMvBwD0q8bfcZ7QQry5SG484keOAAAACjNfAADh3MOyvFF4RJgQOjzBK-sdAAOBakhvAAA=",
+	"createdDateTime": "2020-09-09T21:00:21Z",
+	"lastModifiedDateTime": "2020-09-09T21:00:21Z",
+	"changeKey": "CQAAABYAAADh3MOyvFF4RJgQOjzBK/sdAAOAhgDj",
+	"categories": [],
+	"receivedDateTime": "2020-09-09T21:00:21Z",
+	"sentDateTime": "2020-09-09T21:00:14Z",
+	"hasAttachments": true,
+	"internetMessageId": "<b0a88dcb-1044-441d-9f12-20141b0bfbb3@APVWEXC01R.amsa.gov.au>",
+	"subject": "WebJobs Print Log Errors and Warnings",
+	"bodyPreview": "Some WebJobs Print logs have had warning or error events in the last 24 hours. See attached table.\r\n_time   sourcetype      log_level       message\r\n\r\nWed Sep  9 15:30:33 2020\r\n\r\nwebjobs:print:dynamics:response:processor\r\n\r\nERROR\r\n\r\nAMSA.Process.Print.Pri",
+	"importance": "normal",
+	"parentFolderId": "AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQAuAAAAAABCSTzSpYOXTJf5ExxfstMvAQD0q8bfcZ7QQry5SG484keOAAAACjNfAAA=",
+	"conversationId": "AAQkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQAQAGC9vcV4qX9MnRiUKWXnkfA=",
+	"conversationIndex": "AQHWhuw6YL29xXipf0ydGJQpZeeR8A==",
+	"isDeliveryReceiptRequested": null,
+	"isReadReceiptRequested": false,
+	"isRead": false,
+	"isDraft": false,
+	"webLink": "https://outlook.office365.com/owa/?ItemID=AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQBGAAAAAABCSTzSpYOXTJf5ExxfstMvBwD0q8bfcZ7QQry5SG484keOAAAACjNfAADh3MOyvFF4RJgQOjzBK%2FsdAAOBakhvAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+	"inferenceClassification": "focused",
+	"body": {
+		"contentType": "html",
+		"content": "<html><head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"><meta content=\"text/html; charset=utf-8\"></head><body style=\"font-size:14px; font-family:helvetica,arial,sans-serif; padding:20px 0; margin:0; color:#333\"><div style=\"margin:0 20px\">Some WebJobs Print logs have had warning or error events in the last 24 hours. See attached table.</div><table cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"summary\" style=\"margin:20px\"><tbody></tbody></table><div style=\"margin-top:10px; padding-top:20px; border-top:1px solid #c3cbd4\"></div><div style=\"margin:0\"><div style=\"overflow:auto; width:100%\"><table cellpadding=\"0\" cellspacing=\"0\" border=\"0\" class=\"results\" style=\"margin:20px\"><tbody><tr><th style=\"text-align:left; padding:4px 8px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\">_time</th><th style=\"text-align:left; padding:4px 8px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\">sourcetype</th><th style=\"text-align:left; padding:4px 8px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\">log_level</th><th style=\"text-align:left; padding:4px 8px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\">message</th></tr><tr valign=\"top\"><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">Wed Sep  9 15:30:33 2020</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">webjobs:print:dynamics:response:processor</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">ERROR</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">AMSA.Process.Print.PrintProcess - GetFileSftpAsync: Permission denied (password).   NOTE: THIS EXCEPTION IS NOT BEING RETHROWN.\n Renci.SshNet.Common.SshAuthenticationException: Permission denied (password).\n   at Renci.SshNet.ClientAuthentication.Authenticate(IConnectionInfoInternal connectionInfo, ISession session)\n   at Renci.SshNet.ConnectionInfo.Authenticate(ISession session, IServiceFactory serviceFactory)\n   at Renci.SshNet.Session.Connect()\n   at Renci.SshNet.BaseClient.Connect()\n   at AMSA.Process.Print.PrintProcess.&lt;GetFileSftpAsync&gt;d__29.MoveNext() in d:\\a\\1\\s\\AMSA.Process\\AMSA.Process.Print\\PrintProcess.cs:line 1183</pre></td></tr><tr valign=\"top\"><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">Wed Sep  9 14:30:06 2020</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">webjobs:print:dynamics:response:processor</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">ERROR</pre></td><td style=\"text-align:left; padding:4px 8px; margin-top:0px; margin-bottom:0px; border-bottom:1px dotted #c3cbd4\"><pre style=\"font-family:helvetica,arial,sans-serif; white-space:pre-wrap; margin:0\">AMSA.Process.Print.PrintProcess - GetFileSftpAsync: Permission denied (password).   NOTE: THIS EXCEPTION IS NOT BEING RETHROWN.\n Renci.SshNet.Common.SshAuthenticationException: Permission denied (password).\n   at Renci.SshNet.ClientAuthentication.Authenticate(IConnectionInfoInternal connectionInfo, ISession session)\n   at Renci.SshNet.ConnectionInfo.Authenticate(ISession session, IServiceFactory serviceFactory)\n   at Renci.SshNet.Session.Connect()\n   at Renci.SshNet.BaseClient.Connect()\n   at AMSA.Process.Print.PrintProcess.&lt;GetFileSftpAsync&gt;d__29.MoveNext() in d:\\a\\1\\s\\AMSA.Process\\AMSA.Process.Print\\PrintProcess.cs:line 1183</pre></td></tr></tbody></table></div></div><div style=\"margin-top:10px; border-top:1px solid #c3cbd4\"></div><p style=\"margin:20px; font-size:11px; color:#999\">If you believe you've received this email in error, please see your Splunk administrator.</p></body></html>"
+	},
+	"sender": {
+		"emailAddress": {
+			"name": "Splunk@amsa.gov.au",
+			"address": "Splunk@amsa.gov.au"
+		}
+	},
+	"from": {
+		"emailAddress": {
+			"name": "Splunk@amsa.gov.au",
+			"address": "Splunk@amsa.gov.au"
+		}
+	},
+	"toRecipients": [
+		{
+			"emailAddress": {
+				"name": "ITS Applications Development Team",
+				"address": "isappdev@amsa.gov.au"
+			}
+		},
+		{
+			"emailAddress": {
+				"name": "Operations Mars Support",
+				"address": "mars.support@amsa.gov.au"
+			}
+		}
+	],
+	"ccRecipients": [],
+	"bccRecipients": [],
+	"replyTo": [],
+	"flag": {
+		"flagStatus": "notFlagged"
+	},
+	"attachments@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('david.moten%40amsa.gov.au')/messages('AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQBGAAAAAABCSTzSpYOXTJf5ExxfstMvBwD0q8bfcZ7QQry5SG484keOAAAACjNfAADh3MOyvFF4RJgQOjzBK-sdAAOBakhvAAA%3D')/attachments",
+	"attachments": [
+		{
+			"@odata.type": "#microsoft.graph.fileAttachment",
+			"@odata.mediaContentType": "text/csv",
+			"id": "AAMkADRiMjI2ZmQwLTJkZmUtNDQ0NS1iZGVmLWE1ZjBjYjBiYmUzZQBGAAAAAABCSTzSpYOXTJf5ExxfstMvBwD0q8bfcZ7QQry5SG484keOAAAACjNfAADh3MOyvFF4RJgQOjzBK-sdAAOBakhvAAABEgAQANS3LLY7QahIlU9iTorpXbk=",
+			"lastModifiedDateTime": "2020-09-09T21:00:21Z",
+			"name": "APPS_WebJobs_Alert_WarningErrorEventsReceived_Dail-2020-09-10.csv",
+			"contentType": "text/csv",
+			"size": 2016,
+			"isInline": false,
+			"contentId": "E3DE782B57C1AF49AD3109E6A420DB6B@AUSP282.PROD.OUTLOOK.COM",
+			"contentLocation": null,
+			"contentBytes": "X3RpbWUsc291cmNldHlwZSxsb2dfbGV2ZWwsbWVzc2FnZQ0KV2VkIFNlcCAgOSAxNTozMDozMyAyMDIwLHdlYmpvYnM6cHJpbnQ6ZHluYW1pY3M6cmVzcG9uc2U6cHJvY2Vzc29yLEVSUk9SLCJBTVNBLlByb2Nlc3MuUHJpbnQuUHJpbnRQcm9jZXNzIC0gR2V0RmlsZVNmdHBBc3luYzogUGVybWlzc2lvbiBkZW5pZWQgKHBhc3N3b3JkKS4gICBOT1RFOiBUSElTIEVYQ0VQVElPTiBJUyBOT1QgQkVJTkcgUkVUSFJPV04uXG4gUmVuY2kuU3NoTmV0LkNvbW1vbi5Tc2hBdXRoZW50aWNhdGlvbkV4Y2VwdGlvbjogUGVybWlzc2lvbiBkZW5pZWQgKHBhc3N3b3JkKS5cbiAgIGF0IFJlbmNpLlNzaE5ldC5DbGllbnRBdXRoZW50aWNhdGlvbi5BdXRoZW50aWNhdGUoSUNvbm5lY3Rpb25JbmZvSW50ZXJuYWwgY29ubmVjdGlvbkluZm8sIElTZXNzaW9uIHNlc3Npb24pXG4gICBhdCBSZW5jaS5Tc2hOZXQuQ29ubmVjdGlvbkluZm8uQXV0aGVudGljYXRlKElTZXNzaW9uIHNlc3Npb24sIElTZXJ2aWNlRmFjdG9yeSBzZXJ2aWNlRmFjdG9yeSlcbiAgIGF0IFJlbmNpLlNzaE5ldC5TZXNzaW9uLkNvbm5lY3QoKVxuICAgYXQgUmVuY2kuU3NoTmV0LkJhc2VDbGllbnQuQ29ubmVjdCgpXG4gICBhdCBBTVNBLlByb2Nlc3MuUHJpbnQuUHJpbnRQcm9jZXNzLjxHZXRGaWxlU2Z0cEFzeW5jPmRfXzI5Lk1vdmVOZXh0KCkgaW4gZDpcYVwxXHNcQU1TQS5Qcm9jZXNzXEFNU0EuUHJvY2Vzcy5QcmludFxQcmludFByb2Nlc3MuY3M6bGluZSAxMTgzIg0KV2VkIFNlcCAgOSAxNDozMDowNiAyMDIwLHdlYmpvYnM6cHJpbnQ6ZHluYW1pY3M6cmVzcG9uc2U6cHJvY2Vzc29yLEVSUk9SLCJBTVNBLlByb2Nlc3MuUHJpbnQuUHJpbnRQcm9jZXNzIC0gR2V0RmlsZVNmdHBBc3luYzogUGVybWlzc2lvbiBkZW5pZWQgKHBhc3N3b3JkKS4gICBOT1RFOiBUSElTIEVYQ0VQVElPTiBJUyBOT1QgQkVJTkcgUkVUSFJPV04uXG4gUmVuY2kuU3NoTmV0LkNvbW1vbi5Tc2hBdXRoZW50aWNhdGlvbkV4Y2VwdGlvbjogUGVybWlzc2lvbiBkZW5pZWQgKHBhc3N3b3JkKS5cbiAgIGF0IFJlbmNpLlNzaE5ldC5DbGllbnRBdXRoZW50aWNhdGlvbi5BdXRoZW50aWNhdGUoSUNvbm5lY3Rpb25JbmZvSW50ZXJuYWwgY29ubmVjdGlvbkluZm8sIElTZXNzaW9uIHNlc3Npb24pXG4gICBhdCBSZW5jaS5Tc2hOZXQuQ29ubmVjdGlvbkluZm8uQXV0aGVudGljYXRlKElTZXNzaW9uIHNlc3Npb24sIElTZXJ2aWNlRmFjdG9yeSBzZXJ2aWNlRmFjdG9yeSlcbiAgIGF0IFJlbmNpLlNzaE5ldC5TZXNzaW9uLkNvbm5lY3QoKVxuICAgYXQgUmVuY2kuU3NoTmV0LkJhc2VDbGllbnQuQ29ubmVjdCgpXG4gICBhdCBBTVNBLlByb2Nlc3MuUHJpbnQuUHJpbnRQcm9jZXNzLjxHZXRGaWxlU2Z0cEFzeW5jPmRfXzI5Lk1vdmVOZXh0KCkgaW4gZDpcYVwxXHNcQU1TQS5Qcm9jZXNzXEFNU0EuUHJvY2Vzcy5QcmludFxQcmludFByb2Nlc3MuY3M6bGluZSAxMTgzIg0K"
+		}
+	]
+}

--- a/odata-client-msgraph/src/test/resources/response-messages.json
+++ b/odata-client-msgraph/src/test/resources/response-messages.json
@@ -1,0 +1,130 @@
+
+{
+	"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('48d31887-5fad-4d73-a9f5-3c356e68a038')/messages",
+	"@odata.nextLink": "https://graph.microsoft.com/v1.0/me/messages?$expand=attachments&$orderby=createdDateTime&$skip=156",
+	"value": [
+		{
+			"@odata.type": "#microsoft.graph.eventMessage",
+			"id": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEJAAAiIsqMbYjsT5e-T7KzowPTAAAYbvZDAAA=",
+			"createdDateTime": "2017-09-04T15:58:21Z",
+			"lastModifiedDateTime": "2018-03-05T02:49:40Z",
+			"changeKey": "DAAAABYAAAAiIsqMbYjsT5e/T7KzowPTAACQC18f",
+			"categories": [],
+			"receivedDateTime": "2017-09-04T15:58:22Z",
+			"sentDateTime": "2017-09-04T15:58:21Z",
+			"hasAttachments": false,
+			"internetMessageId": "<CY1PR15MB08423E7A7199535BA67852D0CD910@CY1PR15MB0842.namprd15.prod.outlook.com>",
+			"subject": "Accepted: Tailspin Toys Proposal Review + Lunch",
+			"bodyPreview": "",
+			"importance": "normal",
+			"parentFolderId": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEJAAA=",
+			"conversationId": "AAQkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAQAKQNFnncVNxLu15dISfDoM0=",
+			"isDeliveryReceiptRequested": null,
+			"isReadReceiptRequested": false,
+			"isRead": true,
+			"isDraft": false,
+			"webLink": "https://outlook.office365.com/owa/?ItemID=AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e%2FT7KzowPTAAAAAAEJAAAiIsqMbYjsT5e%2FT7KzowPTAAAYbvZDAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+			"inferenceClassification": "focused",
+			"meetingMessageType": "meetingAccepted",
+			"body": {
+				"@odata.type": "#microsoft.graph.itemBody",
+				"contentType": "text",
+				"content": ""
+			},
+			"sender": {
+				"@odata.type": "#microsoft.graph.recipient",
+				"emailAddress": {
+					"@odata.type": "#microsoft.graph.emailAddress",
+					"name": "Megan Bowen",
+					"address": "MeganB@M365x214355.onmicrosoft.com"
+				}
+			},
+			"from": {
+				"@odata.type": "#microsoft.graph.recipient",
+				"emailAddress": {
+					"@odata.type": "#microsoft.graph.emailAddress",
+					"name": "Megan Bowen",
+					"address": "MeganB@M365x214355.onmicrosoft.com"
+				}
+			},
+			"toRecipients": [
+				{
+					"@odata.type": "#microsoft.graph.recipient",
+					"emailAddress": {
+						"@odata.type": "#microsoft.graph.emailAddress",
+						"name": "Lidia Holloway",
+						"address": "LidiaH@M365x214355.onmicrosoft.com"
+					}
+				}
+			],
+			"ccRecipients": [],
+			"bccRecipients": [],
+			"replyTo": [],
+			"flag": {
+				"@odata.type": "#microsoft.graph.followupFlag",
+				"flagStatus": "notFlagged"
+			}
+		},
+		{
+			"@odata.type": "#microsoft.graph.message",
+			"id": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAAAYbsdJAAA=",
+			"createdDateTime": "2017-09-04T16:49:49Z",
+			"lastModifiedDateTime": "2017-09-04T16:49:49Z",
+			"changeKey": "CQAAABYAAAAiIsqMbYjsT5e/T7KzowPTAAAYc6aO",
+			"categories": [],
+			"receivedDateTime": "2017-09-04T16:16:21Z",
+			"sentDateTime": "2017-09-04T16:16:21Z",
+			"hasAttachments": false,
+			"internetMessageId": "<4e36069da4cc44df9ebdc722afa22fe7@BLUSR01MB601.namsdf01.sdf.exchangelabs.com>",
+			"subject": "Sports statistics",
+			"bodyPreview": "Do you LOVE sports?  If so, read on...\r\n\r\n\r\n\r\nWe are going to start meeting in the lounge on Fridays to go over some stats for our favorite teams!  Go Sounders!\r\n\r\n\r\n\r\n~Joni",
+			"importance": "low",
+			"parentFolderId": "AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAuAAAAAAAiQ8W967B7TKBjgx9rVEURAQAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAA=",
+			"conversationId": "AAQkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OAAQAKRFWClIa4tNtGOeE3UKlAY=",
+			"isDeliveryReceiptRequested": null,
+			"isReadReceiptRequested": false,
+			"isRead": true,
+			"isDraft": false,
+			"webLink": "https://outlook.office365.com/owa/?ItemID=AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e%2FT7KzowPTAAAAAAEMAAAiIsqMbYjsT5e%2FT7KzowPTAAAYbsdJAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+			"inferenceClassification": "focused",
+			"body": {
+				"@odata.type": "#microsoft.graph.itemBody",
+				"contentType": "html",
+				"content": "<html dir=\"ltr\">\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\r\n<meta content=\"text/html; charset=us-ascii\">\r\n<meta name=\"GENERATOR\" content=\"MSHTML 10.00.8400.0\">\r\n<style id=\"owaParaStyle\">\r\n<!--\r\np\r\n\t{margin-top:0;\r\n\tmargin-bottom:0}\r\n-->\r\n</style>\r\n</head>\r\n<body>\r\n<div style=\"font-family:Tahoma; font-size:13px; color:#000000; margin:0\">\r\n<p>Do you LOVE sports?&nbsp; If so, read on...</p>\r\n<p>&nbsp;</p>\r\n<p>We are going to start meeting in the lounge on Fridays to go over some stats for our favorite teams!&nbsp; Go Sounders!</p>\r\n<p>&nbsp;</p>\r\n<p>~Joni</p>\r\n</div>\r\n</body>\r\n</html>\r\n"
+			},
+			"sender": {
+				"@odata.type": "#microsoft.graph.recipient",
+				"emailAddress": {
+					"@odata.type": "#microsoft.graph.emailAddress",
+					"name": "Joni Sherman",
+					"address": "JoniS@M365x214355.onmicrosoft.com"
+				}
+			},
+			"from": {
+				"@odata.type": "#microsoft.graph.recipient",
+				"emailAddress": {
+					"@odata.type": "#microsoft.graph.emailAddress",
+					"name": "Joni Sherman",
+					"address": "JoniS@M365x214355.onmicrosoft.com"
+				}
+			},
+			"toRecipients": [
+				{
+					"@odata.type": "#microsoft.graph.recipient",
+					"emailAddress": {
+						"@odata.type": "#microsoft.graph.emailAddress",
+						"name": "Megan Bowen",
+						"address": "MeganB@M365x214355.onmicrosoft.com"
+					}
+				}
+			],
+			"ccRecipients": [],
+			"bccRecipients": [],
+			"replyTo": [],
+			"flag": {
+				"@odata.type": "#microsoft.graph.followupFlag",
+				"flagStatus": "notFlagged"
+			}
+		}
+	]
+}

--- a/odata-client-msgraph/src/test/resources/response-user-expand-with-drive.json
+++ b/odata-client-msgraph/src/test/resources/response-user-expand-with-drive.json
@@ -1,0 +1,49 @@
+{
+	"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+	"businessPhones": [
+		"+1 412 555 0109"
+	],
+	"displayName": "Megan Bowen",
+	"givenName": "Megan",
+	"jobTitle": "Auditor",
+	"mail": "MeganB@M365x214355.onmicrosoft.com",
+	"mobilePhone": null,
+	"officeLocation": "12/1110",
+	"preferredLanguage": "en-US",
+	"surname": "Bowen",
+	"userPrincipalName": "MeganB@M365x214355.onmicrosoft.com",
+	"id": "48d31887-5fad-4d73-a9f5-3c356e68a038",
+	"drive": {
+		"id": "b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd",
+		"createdBy": {
+			"user": {
+				"displayName": "System Account"
+			}
+		},
+		"createdDateTime": "2017-07-27T02:41:36Z",
+		"description": "",
+		"lastModifiedBy": {
+			"user": {
+				"displayName": "Megan Bowen",
+				"id": "48d31887-5fad-4d73-a9f5-3c356e68a038"
+			}
+		},
+		"lastModifiedDateTime": "2018-03-27T07:34:38Z",
+		"name": "OneDrive",
+		"webUrl": "https://m365x214355-my.sharepoint.com/personal/meganb_m365x214355_onmicrosoft_com/Documents",
+		"driveType": "business",
+		"owner": {
+			"user": {
+				"displayName": "Megan Bowen",
+				"id": "48d31887-5fad-4d73-a9f5-3c356e68a038"
+			}
+		},
+		"quota": {
+			"deleted": 0,
+			"remaining": 1099280676413,
+			"state": "normal",
+			"total": 1099511627776,
+			"used": 106330475
+		}
+	}
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
@@ -21,7 +21,7 @@ public abstract class EntityRequest<T extends ODataEntityType> {
     T get(EntityRequestOptions<T> options) {
         if (value.isPresent()) {
             String json = Serializer.INSTANCE.serialize(value.get());
-            return Serializer.INSTANCE.deserialize(json, cls);
+            return Serializer.INSTANCE.deserialize(json, cls, contextPath, false);
         } else {
             return RequestHelper.get(contextPath, cls, options, schemaInfo);
         }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
@@ -1,5 +1,7 @@
 package com.github.davidmoten.odata.client;
 
+import java.util.Optional;
+
 import com.github.davidmoten.odata.client.internal.RequestHelper;
 
 public abstract class EntityRequest<T extends ODataEntityType> {
@@ -7,15 +9,22 @@ public abstract class EntityRequest<T extends ODataEntityType> {
     private final Class<T> cls;
     protected final ContextPath contextPath;
     private final SchemaInfo schemaInfo;
+    private Optional<Object> value;
 
-    public EntityRequest(Class<T> cls, ContextPath contextPath, SchemaInfo schemaInfo) {
+    public EntityRequest(Class<T> cls, ContextPath contextPath, SchemaInfo schemaInfo, Optional<Object> value) {
         this.cls = cls;
         this.contextPath = contextPath;
         this.schemaInfo = schemaInfo;
+        this.value = value;
     }
 
     T get(EntityRequestOptions<T> options) {
-        return RequestHelper.get(contextPath, cls, options, schemaInfo);
+        if (value.isPresent()) {
+            String json = Serializer.INSTANCE.serialize(value.get());
+            return Serializer.INSTANCE.deserialize(json, cls);
+        } else {
+            return RequestHelper.get(contextPath, cls, options, schemaInfo);
+        }
     }
 
     void delete(EntityRequestOptions<T> options) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ODataValue.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ODataValue.java
@@ -3,7 +3,6 @@ package com.github.davidmoten.odata.client;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.davidmoten.odata.client.internal.UnmappedFields;
 
 public class ODataValue<T> {
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -28,7 +28,6 @@ import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
 import com.github.davidmoten.odata.client.internal.ChangedFields;
 import com.github.davidmoten.odata.client.internal.InjectableValuesFromFactories;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
-import com.github.davidmoten.odata.client.internal.UnmappedFields;
 
 public final class Serializer {
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/UnmappedFields.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/UnmappedFields.java
@@ -1,0 +1,83 @@
+package com.github.davidmoten.odata.client;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class UnmappedFields implements Map<String, Object> {
+
+    public static final UnmappedFields EMPTY = new UnmappedFields(Collections.emptyMap());
+
+    private final Map<String, Object> map;
+    
+    public UnmappedFields() {
+        this(new HashMap<>());
+    }
+    
+    private UnmappedFields(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        return map.put(key,  value);
+    }
+
+    @Override
+    public Object remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends Object> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return map.entrySet();
+    }
+
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/UnmappedFields.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/UnmappedFields.java
@@ -79,5 +79,10 @@ public final class UnmappedFields implements Map<String, Object> {
     public Set<Entry<String, Object>> entrySet() {
         return map.entrySet();
     }
+    
+    @Override
+    public String toString() {
+        return map.toString();
+    }
 
 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -31,6 +31,7 @@ import com.github.davidmoten.odata.client.SchemaInfo;
 import com.github.davidmoten.odata.client.Serializer;
 import com.github.davidmoten.odata.client.StreamProvider;
 import com.github.davidmoten.odata.client.StreamUploaderSingleCall;
+import com.github.davidmoten.odata.client.UnmappedFields;
 
 public final class RequestHelper {
 
@@ -484,6 +485,14 @@ public final class RequestHelper {
                 "bytes " + startByte + "-" + (finishByte - 1) + "/" + size));
         HttpResponse response = service.put(url, h, in,  (int) (finishByte - startByte), options);
         checkResponseCode(url, response, 200, 204);
+    }
+    
+    public static Optional<Object> getValue(UnmappedFields unmappedFields, String name) {
+        if (unmappedFields == null) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(unmappedFields.get(name));
+        }
     }
 
 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/UnmappedFields.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/UnmappedFields.java
@@ -1,9 +1,0 @@
-package com.github.davidmoten.odata.client.internal;
-
-import java.util.HashMap;
-
-public final class UnmappedFields extends HashMap<String, Object> {
-
-    private static final long serialVersionUID = 823105277916737973L;
-
-}

--- a/src/docs/FileAttachment.java
+++ b/src/docs/FileAttachment.java
@@ -213,7 +213,7 @@ public class FileAttachment extends Attachment implements ODataEntityType {
     @Override
     @JsonIgnore
     public UnmappedFields getUnmappedFields() {
-        return unmappedFields == null ? new UnmappedFields() : unmappedFields;
+        return unmappedFields == null ? UnmappedFields.EMPTY : unmappedFields;
     }
 
     /**

--- a/src/docs/FileAttachment.java
+++ b/src/docs/FileAttachment.java
@@ -11,11 +11,11 @@ import com.github.davidmoten.odata.client.NameValue;
 import com.github.davidmoten.odata.client.ODataEntityType;
 import com.github.davidmoten.odata.client.RequestOptions;
 import com.github.davidmoten.odata.client.StreamProvider;
+import com.github.davidmoten.odata.client.UnmappedFields;
 import com.github.davidmoten.odata.client.Util;
 import com.github.davidmoten.odata.client.annotation.Property;
 import com.github.davidmoten.odata.client.internal.ChangedFields;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
-import com.github.davidmoten.odata.client.internal.UnmappedFields;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;


### PR DESCRIPTION
The example below explains how when expand is used the associated collection request is satisfied by looking at the unmapped fields rather than performing another network call. Similarly for an entity request.

```java
Message m = client
  .users("fred")
  .messages("123")
  .expand("attachments")
  .get();
// because expand used this next call will not make a network request 
// but rather get its result from the unmapped fields of m
List<Attachment> list = m.getAttachments().toList();
```
Raised in #47 