### PR TITLE
support relative urls in CustomRequest

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
@@ -52,6 +52,10 @@ public final class CustomRequest {
         return new CustomRequest(context, true);
     }
     
+    public CustomRequest withRelativeUrls(boolean value) {
+        return new CustomRequest(context, value);
+    }
+    
     public String getString(String url, RequestOptions options, RequestHeader... headers) {
         return context.service().getStringUtf8(toAbsoluteUrl(url), Arrays.asList(headers), options);
     }
@@ -78,16 +82,16 @@ public final class CustomRequest {
         return RequestHelper.postAny(context, info.contextPath, responseClass, info);
     }
 
-    public void postJson(String url, String contentJson, RequestOptions options,
+    public void postString(String url, String content, RequestOptions options,
             RequestHeader... headers) {
         UrlInfo info = getInfo(context, url, headers, options);
-        context.service().post(url, info.requestHeaders, contentJson, options);
+        context.service().post(url, info.requestHeaders, content, options);
     }
 
-    public String postJsonReturnsJson(String url, String contentJson, RequestOptions options,
+    public String postStringReturnsString(String url, String content, RequestOptions options,
             RequestHeader... headers) {
         UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
-        HttpResponse response = context.service().post(url, info.requestHeaders, contentJson,
+        HttpResponse response = context.service().post(url, info.requestHeaders, content,
                 options);
         RequestHelper.checkResponseCode(info.contextPath, response, 200, 299);
         return response.getText();

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
@@ -16,34 +16,65 @@ import com.github.davidmoten.odata.client.internal.RequestHelper;
 public final class CustomRequest {
 
     private final Context context;
+    private final boolean relativeUrls;
 
-    public CustomRequest(Context context) {
+    public CustomRequest(Context context, boolean relativeUrls) {
         this.context = context;
+        this.relativeUrls = relativeUrls;
     }
-
+    
+    private String toAbsoluteUrl(String url) {
+        if (relativeUrls) {
+            if (url.startsWith("https://")) {
+                return url;
+            } else {
+                String base = context.service().getBasePath().toUrl();
+                String a;
+                if (base.endsWith("/")) {
+                    a = base;
+                } else {
+                    a = base + "/";
+                }
+                String b;
+                if (url.startsWith("/")) {
+                    b = url.substring(1);
+                } else {
+                    b = url;
+                }
+                return a + b;
+            }
+        } else {
+            return url;
+        }
+    }
+    
+    public CustomRequest withRelativeUrls() {
+        return new CustomRequest(context, true);
+    }
+    
     public String getString(String url, RequestOptions options, RequestHeader... headers) {
-        return context.service().getStringUtf8(url, Arrays.asList(headers), options);
+        return context.service().getStringUtf8(toAbsoluteUrl(url), Arrays.asList(headers), options);
     }
 
     public InputStream getStream(String url, RequestOptions options, RequestHeader... headers) {
-        return context.service().getStream(url, Arrays.asList(headers), options);
+        return context.service().getStream(toAbsoluteUrl(url), Arrays.asList(headers), options);
     }
 
     public <T> T get(String url, Class<T> responseCls, HttpRequestOptions options,
             RequestHeader... headers) {
-        UrlInfo info = getInfo(context, url, headers, options);
+        UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         return RequestHelper.get(info.contextPath, responseCls, info);
     }
 
     public <T extends ODataEntityType> void post(String url, Class<T> contentClass, T content,
             HttpRequestOptions options, RequestHeader... headers) {
-        UrlInfo info = getInfo(context, url, headers, options);
+        UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         RequestHelper.post(content, info.contextPath, contentClass, info);
     }
 
     public <T> T post(String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
-        UrlInfo info = getInfo(context, url, headers, options);
+        UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         return RequestHelper.postAny(context, info.contextPath, responseClass, info);
     }
 
@@ -55,7 +86,7 @@ public final class CustomRequest {
 
     public String postJsonReturnsJson(String url, String contentJson, RequestOptions options,
             RequestHeader... headers) {
-        UrlInfo info = getInfo(context, url, headers, options);
+        UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         HttpResponse response = context.service().post(url, info.requestHeaders, contentJson,
                 options);
         RequestHelper.checkResponseCode(info.contextPath, response, 200, 299);

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HasContext.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HasContext.java
@@ -5,7 +5,7 @@ public interface HasContext {
     Context _context();
 
     default CustomRequest _custom() {
-        return new CustomRequest(_context());
+        return new CustomRequest(_context(), false);
     }
 
 }


### PR DESCRIPTION
and rename methods `postJson` to `postString` and `postJsonReturnsJson` to `postStringReturnsString` (breaking change).