### PR TITLE
odata-client-generator - log all entities that have no keys before failing

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -150,6 +150,12 @@ public final class Generator {
 
 			Map<String, List<Function>> collectionTypeFunctions = createTypeFunctions(schema, names, true);
 			System.out.println("    collection functions count = " + collectionTypeFunctions.size());
+			
+			log("  checking entities have keys");
+            Util.types(schema, TEntityType.class) //
+                    .map(x -> new EntityType(x, names)) //
+                    .filter(x -> !x.hasKey()) //
+                    .forEach(x -> log("    " + x.getFullType() + " has no keys"));
 
 			log("  writing schema info");
 			writeSchemaInfo(schema);

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/EntityType.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/EntityType.java
@@ -119,6 +119,14 @@ public final class EntityType extends Structure<TEntityType> {
                 .flatMap(x -> ((EntityType) x).getKeysLocal().stream()) //
                 .collect(Collectors.toList());
     }
+    
+    public boolean hasKey() {
+        return getHeirarchy() //
+                .stream() //
+                .flatMap(x -> ((EntityType) x).getKeysLocal().stream()) //
+                .findAny() //
+                .isPresent();
+    }
 
     public KeyElement getFirstKey() {
         if (getKeys().isEmpty()) {


### PR DESCRIPTION
When one entity without keys (invalid) is found the build fails fast. This PR ensures that all entities without keys are logged to the console before failing.