### PR TITLE
Fix msgraph metadata for report functions and actions, support returning Edm.Stream from function/action 

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Action.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Action.java
@@ -126,6 +126,10 @@ public final class Action implements Method {
             this.isCollection = isCollection;
             this.innerImportedFullClassName = innerImportedFullClassName;
         }
+
+        public boolean isStream() {
+            return "Edm.Stream".equals(innerType);
+        }
     }
 
     public boolean hasReturnType() {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Function.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Function.java
@@ -117,6 +117,10 @@ public final class Function implements Method {
             this.isCollection = isCollection;
             this.innerImportedFullClassName = innerImportedFullClassName;
         }
+        
+        public boolean isStream() {
+            return "Edm.Stream".equals(innerType);
+        }
     }
 
     public ReturnType getReturnType(Imports imports) {

--- a/odata-client-generator/src/main/odata/msgraph-metadata.xml
+++ b/odata-client-generator/src/main/odata/msgraph-metadata.xml
@@ -11462,15 +11462,15 @@
       </Action>
       <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
@@ -11478,428 +11478,428 @@
         <Parameter Name="top" Type="Edm.Int32"/>
         <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
         <Parameter Name="skipToken" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="graph.report"/>
+        <ReturnType Type="Edm.Stream"/>
       </Function>
       <Function Name="getEmailActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailAppUsageAppsUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailAppUsageUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailAppUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailAppUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getEmailAppUsageVersionsUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getMailboxUsageDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getMailboxUsageMailboxCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getMailboxUsageQuotaStatusMailboxCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getMailboxUsageStorage" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActivationCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActivationsUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActiveUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityFileCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityGroupCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365GroupsActivityStorage" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOffice365ServicesUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveActivityFileCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveUsageAccountCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveUsageFileCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getOneDriveUsageStorage" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointActivityFileCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointActivityPages" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsageFileCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsagePages" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsageSiteCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSharePointSiteUsageStorage" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessDeviceUsageUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessOrganizerActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessOrganizerActivityMinuteCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessOrganizerActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessParticipantActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessParticipantActivityMinuteCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessParticipantActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessPeerToPeerActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessPeerToPeerActivityMinuteCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getSkypeForBusinessPeerToPeerActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsDeviceUsageUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsUserActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsUserActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsUserActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getTeamsUserActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="reportRoot" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerActivityUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerDeviceUsageUserCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerGroupsActivityCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Function Name="getYammerGroupsActivityGroupCounts" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
         <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="graph.report" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
       </Function>
       <Action Name="setPriority" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.deviceEnrollmentConfiguration"/>

--- a/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
+++ b/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
@@ -6,6 +6,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import com.github.davidmoten.odata.client.HttpMethod;
 import com.github.davidmoten.odata.client.HttpRequestOptions;
 import com.github.davidmoten.odata.client.HttpResponse;
 import com.github.davidmoten.odata.client.HttpService;
@@ -71,6 +72,12 @@ public final class GraphExplorerHttpService implements HttpService {
     @Override
     public Path getBasePath() {
         return s.getBasePath();
+    }
+
+    @Override
+    public InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            InputStream content, int length, HttpRequestOptions options) {
+        return s.getStream(method, convert(url), requestHeaders, content, length, options);
     }
     
 }

--- a/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
+++ b/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
@@ -76,8 +76,8 @@ public final class GraphExplorerHttpService implements HttpService {
 
     @Override
     public InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
-        return s.getStream(method, convert(url), requestHeaders, content, length, options);
+            HttpRequestOptions options) {
+        return s.getStream(method, convert(url), requestHeaders, options);
     }
     
 }

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
@@ -22,7 +22,7 @@ public class GraphExplorerMain {
 
         GraphService client = MsGraph.explorer().build();
         {
-            client._custom().getString("https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period%3D'D7')/content", RequestOptions.EMPTY);
+            client.me().messages().get().stream().findFirst().ifPresent(a -> System.out.println(a.getSubject()));
             System.exit(0);
         }
         {

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
@@ -22,6 +22,10 @@ public class GraphExplorerMain {
 
         GraphService client = MsGraph.explorer().build();
         {
+            client._custom().getString("https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period%3D'D7')/content", RequestOptions.EMPTY);
+            System.exit(0);
+        }
+        {
             String count = client._custom().withRelativeUrls() //
                     .getString("me/mailFolders/inbox/messages?$select=id&count=true", RequestOptions.EMPTY, RequestHeader.ODATA_VERSION);
             System.out.println(count);

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -52,6 +52,7 @@ import odata.msgraph.client.complex.InvitationParticipantInfo;
 import odata.msgraph.client.complex.ItemBody;
 import odata.msgraph.client.complex.PasswordCredential;
 import odata.msgraph.client.complex.Recipient;
+import odata.msgraph.client.complex.Report;
 import odata.msgraph.client.complex.ServiceHostedMediaConfig;
 import odata.msgraph.client.complex.UploadSession;
 import odata.msgraph.client.container.GraphService;
@@ -951,6 +952,17 @@ public class GraphServiceTest {
         System.out.println(m.getSubject());
         // mark as read
         m.withIsRead(true).patch();
+    }
+    
+    @Test
+    public void testFunctionWithInlineParameters() {
+        GraphService client = clientBuilder() //
+                .expectRequest("/reports/getMailboxUsageDetail(period%3D'D7')") //
+                .withResponse("/response-get-mailbox-usage-detail.txt") //
+                .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION) //
+                .withResponseStatusCode(200) //
+                .build();
+        Report report = client.reports().getMailboxUsageDetail("D7").get();
     }
 
     @Test

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -52,7 +52,6 @@ import odata.msgraph.client.complex.InvitationParticipantInfo;
 import odata.msgraph.client.complex.ItemBody;
 import odata.msgraph.client.complex.PasswordCredential;
 import odata.msgraph.client.complex.Recipient;
-import odata.msgraph.client.complex.Report;
 import odata.msgraph.client.complex.ServiceHostedMediaConfig;
 import odata.msgraph.client.complex.UploadSession;
 import odata.msgraph.client.container.GraphService;
@@ -962,7 +961,7 @@ public class GraphServiceTest {
                 .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION) //
                 .withResponseStatusCode(200) //
                 .build();
-        Report report = client.reports().getMailboxUsageDetail("D7").get();
+        client.reports().getMailboxUsageDetail("D7");
     }
 
     @Test
@@ -998,6 +997,13 @@ public class GraphServiceTest {
     @Test
     public void testGetODataNameFromComplexType() {
         assertEquals("microsoft.graph.device", odataTypeNameFromAny(Device.class));
+    }
+    
+    @Test
+    @Ignore
+    public void testReportsReturnTypeMappedToStreamCompiles() {
+        GraphService client = clientBuilder().build();
+        client.reports().getMailboxUsageDetail("D7").getBytes();
     }
 
     @Test

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -9,7 +9,6 @@ import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import com.github.davidmoten.odata.client.ClientException;
 import com.github.davidmoten.odata.client.RequestHeader;
 import com.github.davidmoten.odata.client.RequestOptions;
 
@@ -17,7 +16,6 @@ import odata.msgraph.client.complex.AttachmentItem;
 import odata.msgraph.client.complex.EmailAddress;
 import odata.msgraph.client.complex.ItemBody;
 import odata.msgraph.client.complex.Recipient;
-import odata.msgraph.client.complex.Report;
 import odata.msgraph.client.complex.UploadSession;
 import odata.msgraph.client.container.GraphService;
 import odata.msgraph.client.entity.FileAttachment;
@@ -38,7 +36,7 @@ public class MsGraphMain {
                 .build();
         {
             client._custom().getString("https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period%3D'D7')", RequestOptions.EMPTY, RequestHeader.ACCEPT_JSON);
-            Report report = client.reports().getMailboxUsageDetail("D7").get();
+            client.reports().getMailboxUsageDetail("D7").getStringUtf8();
             System.exit(0);
         }
         {

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -9,9 +9,6 @@ import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import com.github.davidmoten.odata.client.RequestHeader;
-import com.github.davidmoten.odata.client.RequestOptions;
-
 import odata.msgraph.client.complex.AttachmentItem;
 import odata.msgraph.client.complex.EmailAddress;
 import odata.msgraph.client.complex.ItemBody;
@@ -34,11 +31,7 @@ public class MsGraphMain {
                 .clientSecret(System.getProperty("clientSecret")) //
                 .refreshBeforeExpiry(5, TimeUnit.MINUTES) //
                 .build();
-        {
-            client._custom().getString("https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period%3D'D7')", RequestOptions.EMPTY, RequestHeader.ACCEPT_JSON);
-            client.reports().getMailboxUsageDetail("D7").getStringUtf8();
-            System.exit(0);
-        }
+        
         {
             String mailbox = System.getProperty("mailbox");
             while (true) {

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -10,11 +10,14 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import com.github.davidmoten.odata.client.ClientException;
+import com.github.davidmoten.odata.client.RequestHeader;
+import com.github.davidmoten.odata.client.RequestOptions;
 
 import odata.msgraph.client.complex.AttachmentItem;
 import odata.msgraph.client.complex.EmailAddress;
 import odata.msgraph.client.complex.ItemBody;
 import odata.msgraph.client.complex.Recipient;
+import odata.msgraph.client.complex.Report;
 import odata.msgraph.client.complex.UploadSession;
 import odata.msgraph.client.container.GraphService;
 import odata.msgraph.client.entity.FileAttachment;
@@ -33,14 +36,11 @@ public class MsGraphMain {
                 .clientSecret(System.getProperty("clientSecret")) //
                 .refreshBeforeExpiry(5, TimeUnit.MINUTES) //
                 .build();
-        try {
-            client.me().get();
-        } catch (ClientException e) {
-            System.out.println(e.getStatusCode().orElse(-1));
-            e.printStackTrace();
+        {
+            client._custom().getString("https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period%3D'D7')", RequestOptions.EMPTY, RequestHeader.ACCEPT_JSON);
+            Report report = client.reports().getMailboxUsageDetail("D7").get();
             System.exit(0);
         }
-        
         {
             String mailbox = System.getProperty("mailbox");
             while (true) {

--- a/odata-client-msgraph/update-metadata.sh
+++ b/odata-client-msgraph/update-metadata.sh
@@ -13,6 +13,7 @@ sed -i 's/<EntityType Name="chatMembersNotificationAudience"\/>/<!-- commented o
 sed -i 's/<EntityType Name="auditLogRoot">/<EntityType Name="auditLogRoot" BaseType="graph.entity">/g' ../odata-client-generator/src/main/odata/msgraph-metadata.xml
 sed -i 's/<EntityType Name="identityContainer">/<EntityType Name="identityContainer" BaseType="graph.entity">/g' ../odata-client-generator/src/main/odata/msgraph-metadata.xml
 sed -i 's/<EntityType Name="directory">/<EntityType Name="directory" BaseType="graph.entity">/g' ../odata-client-generator/src/main/odata/msgraph-metadata.xml
+sed -i 's/<ReturnType Type="graph.report"/<ReturnType Type="Edm.Stream"/g' ../odata-client-generator/src/main/odata/msgraph-metadata.xml
 
 ## not required, Microsoft removed this item from metadata
 #sed -i 's/<Singleton Name="settings" Type="microsoft.graph.entitlementManagementSettings"\/>/<Singleton Name="entitlementManagementSettings" Type="microsoft.graph.entitlementManagementSettings"\/>/g' ../odata-client-msgraph-beta/src/main/odata/msgraph-beta-metadata.xml

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ActionRequestReturningStream.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ActionRequestReturningStream.java
@@ -1,0 +1,24 @@
+package com.github.davidmoten.odata.client;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import com.github.davidmoten.odata.client.internal.RequestHelper;
+import com.github.davidmoten.odata.client.internal.TypedObject;
+
+public final class ActionRequestReturningStream extends
+        ActionFunctionRequestBase<ActionRequestReturningStream> implements StreamProviderBase {
+
+    public ActionRequestReturningStream(ContextPath contextPath, Map<String, TypedObject> parameters) {
+        super(parameters, contextPath);
+    }
+
+    @Override
+    public InputStream get() {
+        Serializer serializer = contextPath.context().serializer();
+        return RequestHelper.getStream(
+                contextPath.appendToSegment(InlineParameterSyntax.encode(serializer, parameters)),
+                options(), null);
+    }
+
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ContextPath.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ContextPath.java
@@ -17,6 +17,10 @@ public final class ContextPath {
         return new ContextPath(context, path.addSegment(segment));
     }
     
+    public ContextPath appendToSegment(String s) {
+        return new ContextPath(context, path.appendToSegment(s));
+    }
+    
     public ContextPath addActionOrFunctionSegment(String fullyQualifiedName) {
         boolean useSimpleNameOnly = "true".equalsIgnoreCase(String.valueOf(context.getProperty(Properties.ACTION_OR_FUNCTION_SEGMENT_SIMPLE_NAME)));
         if (useSimpleNameOnly) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningNonCollection.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningNonCollection.java
@@ -20,7 +20,7 @@ public final class FunctionRequestReturningNonCollection<T>
     public ODataValue<T> get() {
         Serializer serializer = contextPath.context().serializer();
         return RequestHelper.getWithParametricType( //
-                contextPath.addSegment(InlineParameterSyntax.encode(serializer, parameters)), //
+                contextPath.appendToSegment(InlineParameterSyntax.encode(serializer, parameters)), //
                 ODataValue.class, //
                 returnClass, //
                 options());

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningNonCollectionUnwrapped.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningNonCollectionUnwrapped.java
@@ -19,7 +19,7 @@ public final class FunctionRequestReturningNonCollectionUnwrapped<T>
     public T get() {
         Serializer serializer = contextPath.context().serializer();
         return RequestHelper.get( //
-                contextPath.addSegment(InlineParameterSyntax.encode(serializer, parameters)), //
+                contextPath.appendToSegment(InlineParameterSyntax.encode(serializer, parameters)), //
                 returnClass, //
                 options());
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningStream.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/FunctionRequestReturningStream.java
@@ -1,0 +1,24 @@
+package com.github.davidmoten.odata.client;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import com.github.davidmoten.odata.client.internal.RequestHelper;
+import com.github.davidmoten.odata.client.internal.TypedObject;
+
+public final class FunctionRequestReturningStream extends
+        ActionFunctionRequestBase<FunctionRequestReturningStream> implements StreamProviderBase {
+
+    public FunctionRequestReturningStream(ContextPath contextPath, Map<String, TypedObject> parameters) {
+        super(parameters, contextPath);
+    }
+
+    @Override
+    public InputStream get() {
+        Serializer serializer = contextPath.context().serializer();
+        return RequestHelper.getStream(
+                contextPath.appendToSegment(InlineParameterSyntax.encode(serializer, parameters)),
+                options(), null);
+    }
+
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
@@ -30,6 +30,8 @@ public interface HttpService extends AutoCloseable {
     HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
 
     InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
+    
+    InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
 
     default Optional<Proxy> getProxy() {
         return Optional.empty();

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
@@ -29,10 +29,12 @@ public interface HttpService extends AutoCloseable {
     
     HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
 
-    InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
+    InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
     
-    InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
-
+    default InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+        return getStream(HttpMethod.GET, url, requestHeaders, options);
+    }
+    
     default Optional<Proxy> getProxy() {
         return Optional.empty();
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/InlineParameterSyntax.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/InlineParameterSyntax.java
@@ -48,6 +48,8 @@ final class InlineParameterSyntax {
             final String value;
             if (entry.getValue().object() == null) {
                 value = "null'" + entry.getValue().typeWithNamespace() + "'";
+            } else if ("Edm.String".equals(entry.getValue().typeWithNamespace())){
+                value = "'" + entry.getValue().object() + "'";
             } else {
                 value = serializer.serialize(entry.getValue().object());
             }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Path.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Path.java
@@ -36,14 +36,18 @@ public class Path {
     private String append(String url, String s) {
         return url + encode(s);
     }
-
+    
     public Path addSegment(String segment) {
         String u = url;
         u = addSegmentDelimiter(u);
         u = append(u, segment);
         return new Path(u, queries, style);
     }
-
+    
+    public Path appendToSegment(String s) {
+        return new Path(url + encode(s), queries, style);
+    }
+    
     private static String addSegmentDelimiter(String url) {
         if (url.charAt(url.length() - 1) != '/') {
             return url + '/';
@@ -136,4 +140,5 @@ public class Path {
             throw new RuntimeException(e);
         }
     }
+
 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProvider.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProvider.java
@@ -1,14 +1,11 @@
 package com.github.davidmoten.odata.client;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
 
-public final class StreamProvider {
+public final class StreamProvider implements StreamProviderBase {
 
     private final ContextPath contextPath;
     private final RequestOptions options;
@@ -25,29 +22,8 @@ public final class StreamProvider {
         this.base64 = base64;
     }
 
-    /**
-     * Returns a {@link InputStream} for the requested content every time this
-     * method is called. Note that the returned `InputStream` <b>must</b> be closed
-     * after read otherwise the http client may hang on a later request. Use the
-     * {@link #contentType()} method to get the mime type of the content delivered
-     * via the InputStream.
-     *
-     * @return InputStream for the requested content that must be closed after use
-     */
     public InputStream get() {
         return RequestHelper.getStream(contextPath, options, base64);
-    }
-
-    public byte[] getBytes() {
-        try (InputStream in = get()) {
-            return Util.toByteArray(in);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    public String getStringUtf8() {
-        return new String(getBytes(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProviderBase.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProviderBase.java
@@ -1,0 +1,33 @@
+package com.github.davidmoten.odata.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+public interface StreamProviderBase {
+
+    /**
+     * Returns a {@link InputStream} for the requested content every time this
+     * method is called. Note that the returned `InputStream` <b>must</b> be closed
+     * after read otherwise the http client may hang on a later request. Use the
+     * {@link #contentType()} method to get the mime type of the content delivered
+     * via the InputStream.
+     *
+     * @return InputStream for the requested content that must be closed after use
+     */
+    InputStream get();
+
+    default byte[] getBytes() {
+        try (InputStream in = get()) {
+            return Util.toByteArray(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    default String getStringUtf8() {
+        return new String(getBytes(), StandardCharsets.UTF_8);
+    }
+
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -354,6 +354,13 @@ public final class TestingService {
                     return new ByteArrayInputStream(h.getText().getBytes(StandardCharsets.UTF_8));
                 }
 
+                @Override
+                public InputStream getStream(HttpMethod method, String url,
+                        List<RequestHeader> requestHeaders, InputStream content, int length,
+                        HttpRequestOptions options) {
+                    throw new UnsupportedOperationException();
+                }
+
             };
         }
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -139,7 +139,7 @@ public final class TestingService {
                 this.statusCode = statusCode;
                 return this;
             }
-            
+
             public Builder<T, R> withRequestHeadersStandard() {
                 return withRequestHeaders(RequestHeader.ACCEPT_JSON_METADATA_MINIMAL,
                         RequestHeader.ODATA_VERSION);
@@ -172,8 +172,7 @@ public final class TestingService {
                 String responseResourceName, HttpMethod method, int statusCode,
                 RequestHeader... requestHeaders) {
             String url = toUrl(path);
-            requests.put(toKey(method, url, asList(requestHeaders)),
-                    requestResourceName);
+            requests.put(toKey(method, url, asList(requestHeaders)), requestResourceName);
             responses.put(toKey(method, url, asList(requestHeaders)),
                     new Response(responseResourceName, statusCode));
             return (T) this;
@@ -356,8 +355,7 @@ public final class TestingService {
 
                 @Override
                 public InputStream getStream(HttpMethod method, String url,
-                        List<RequestHeader> requestHeaders, InputStream content, int length,
-                        HttpRequestOptions options) {
+                        List<RequestHeader> requestHeaders, HttpRequestOptions options) {
                     throw new UnsupportedOperationException();
                 }
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.odata.client.ClientException;
+import com.github.davidmoten.odata.client.HttpMethod;
 import com.github.davidmoten.odata.client.HttpRequestOptions;
 import com.github.davidmoten.odata.client.HttpResponse;
 import com.github.davidmoten.odata.client.HttpService;
@@ -49,32 +50,39 @@ public class ApacheHttpClientHttpService implements HttpService {
     }
 
     public ApacheHttpClientHttpService(Path basePath) {
-        this(basePath, () -> HttpClientBuilder.create().useSystemProperties().build(), (url,m) -> m);
+        this(basePath, () -> HttpClientBuilder.create().useSystemProperties().build(),
+                (url, m) -> m);
     }
 
     @Override
-    public HttpResponse get(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    public HttpResponse get(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return getResponse(requestHeaders, new HttpGet(url), true, null, -1, options);
     }
 
     @Override
-    public HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    public HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return getResponse(requestHeaders, new HttpPatch(url), false, content, length, options);
     }
 
     @Override
-    public HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    public HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return getResponse(requestHeaders, new HttpPut(url), false, content, length, options);
     }
 
     @Override
-    public HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    public HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return getResponse(requestHeaders, new HttpPost(url), true, content, length, options);
     }
 
     @Override
-    public HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpDelete(url), false, null, HttpService.LENGTH_UNKNOWN, options);
+    public HttpResponse delete(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
+        return getResponse(requestHeaders, new HttpDelete(url), false, null,
+                HttpService.LENGTH_UNKNOWN, options);
     }
 
     @Override
@@ -92,7 +100,7 @@ public class ApacheHttpClientHttpService implements HttpService {
 
     private HttpResponse getResponse(List<RequestHeader> requestHeaders, HttpRequestBase request,
             boolean doInput, InputStream content, int length, HttpRequestOptions options) {
-    	Preconditions.checkNotNull(options);
+        Preconditions.checkNotNull(options);
         log.debug("{} from url {}", request.getMethod(), request.getURI());
         log.debug("requestHeaders={}", requestHeaders);
         for (RequestHeader header : requestHeadersModifier.apply(toUrl(request), requestHeaders)) {
@@ -100,19 +108,22 @@ public class ApacheHttpClientHttpService implements HttpService {
         }
         try {
             if (content != null && request instanceof HttpEntityEnclosingRequest) {
-                ((HttpEntityEnclosingRequest) request).setEntity(new InputStreamEntity(content, length));
+                ((HttpEntityEnclosingRequest) request)
+                        .setEntity(new InputStreamEntity(content, length));
                 log.debug("content={}", content);
             }
-            RequestConfig config = com.github.davidmoten.odata.client.Util.nvl(request.getConfig(), RequestConfig.DEFAULT);
+            RequestConfig config = com.github.davidmoten.odata.client.Util.nvl(request.getConfig(),
+                    RequestConfig.DEFAULT);
             Builder builder = RequestConfig //
-            		.copy(config);
-            options.requestConnectTimeoutMs().ifPresent(x -> builder.setConnectTimeout(x.intValue()));
+                    .copy(config);
+            options.requestConnectTimeoutMs()
+                    .ifPresent(x -> builder.setConnectTimeout(x.intValue()));
             options.requestReadTimeoutMs().ifPresent(x -> builder.setSocketTimeout(x.intValue()));
             config = builder.build();
             request.setConfig(config);
             log.debug("executing request");
             try (CloseableHttpResponse response = client.execute(request)) {
-            	int statusCode = response.getStatusLine().getStatusCode();
+                int statusCode = response.getStatusLine().getStatusCode();
                 log.debug("executed request, code={}", statusCode);
                 final String text;
                 if (doInput || isError(statusCode)) {
@@ -129,11 +140,92 @@ public class ApacheHttpClientHttpService implements HttpService {
         }
     }
 
-    private static boolean isError(int statusCode) {
-    	return statusCode >= 400;
+    @Override
+    public InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            InputStream content, int length, HttpRequestOptions options) {
+        HttpRequestBase b = toRequestBase(method, url);
+        return getStream(requestHeaders, b, content, length, options);
     }
 
-	@Override
+    private static HttpRequestBase toRequestBase(HttpMethod method, String url) {
+        if (method == HttpMethod.GET) {
+            return new HttpGet(url);
+        } else if (method == HttpMethod.DELETE) {
+            return new HttpDelete(url);
+        } else if (method == HttpMethod.PATCH) {
+            return new HttpPatch(url);
+        } else if (method == HttpMethod.PUT) {
+            return new HttpPut(url);
+        } else if (method == HttpMethod.POST) {
+            return new HttpPut(url);
+        } else {
+            throw new UnsupportedOperationException(method.toString() + " not recognized");
+        }
+    }
+
+    public InputStream getStream(List<RequestHeader> requestHeaders, HttpRequestBase request,
+            InputStream content, int length, HttpRequestOptions options) {
+        Preconditions.checkNotNull(options);
+        log.debug("{} from url {}", request.getMethod(), request.getURI());
+        log.debug("requestHeaders={}", requestHeaders);
+        boolean contentLengthSet = false;
+        for (RequestHeader header : requestHeadersModifier.apply(toUrl(request), requestHeaders)) {
+            request.addHeader(header.name(), header.value());
+            if ("Content-Length".equals(header.name())) {
+                contentLengthSet = true;
+            }
+        }
+        if (content != null && !contentLengthSet) {
+            request.addHeader("Content-Length", Integer.toString(length));
+        }
+        try {
+            if (content != null && request instanceof HttpEntityEnclosingRequest) {
+                ((HttpEntityEnclosingRequest) request)
+                        .setEntity(new InputStreamEntity(content, length));
+                log.debug("content={}", content);
+            }
+            RequestConfig config = com.github.davidmoten.odata.client.Util.nvl(request.getConfig(),
+                    RequestConfig.DEFAULT);
+            Builder builder = RequestConfig //
+                    .copy(config);
+            options.requestConnectTimeoutMs()
+                    .ifPresent(x -> builder.setConnectTimeout(x.intValue()));
+            options.requestReadTimeoutMs().ifPresent(x -> builder.setSocketTimeout(x.intValue()));
+            config = builder.build();
+            request.setConfig(config);
+            log.debug("executing request");
+            try (CloseableHttpResponse response = client.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                log.debug("executed request, code={}", statusCode);
+                InputStream is = response.getEntity().getContent();
+                InputStream in = new InputStreamWithCloseable(is, response);
+                if (!isOk(statusCode)) {
+                    try {
+                        String msg = Util.readString(in, StandardCharsets.UTF_8);
+                        throw new ClientException(statusCode,
+                                "getStream returned HTTP " + statusCode + "\n" //
+                                        + "url=" + request.getURI() + "\n" //
+                                        + "headers=" + requestHeaders + "\n" //
+                                        + "response:\n" //
+                                        + msg);
+                    } finally {
+                        in.close();
+                    }
+                } else {
+                    return in;
+                }
+
+            }
+        } catch (IOException e) {
+            throw new ClientException(e);
+        }
+    }
+
+    private static boolean isError(int statusCode) {
+        return statusCode >= 400;
+    }
+
+    @Override
     public void close() throws Exception {
         log.info("closing client");
         client.close();
@@ -141,36 +233,9 @@ public class ApacheHttpClientHttpService implements HttpService {
     }
 
     @Override
-    public InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
-        // note follow redirects by default
-        HttpGet request = new HttpGet(url);
-        log.debug("{} from url {}", request.getMethod(), request.getURI());
-        for (RequestHeader header : requestHeadersModifier.apply(toUrl(request), requestHeaders)) {
-            request.addHeader(header.name(), header.value());
-        }
-        try {
-            log.debug("executing request");
-            final CloseableHttpResponse response = client.execute(request);
-            int statusCode = response.getStatusLine().getStatusCode();
-            log.debug("executed request, code={}", response.getStatusLine().getStatusCode());
-            InputStream is = response.getEntity().getContent();
-            InputStream in = new InputStreamWithCloseable(is, response);
-            if (!isOk(statusCode)) {
-                try {
-                    String msg = Util.readString(in, StandardCharsets.UTF_8);
-                    throw new ClientException(statusCode,"getStream returned HTTP " + statusCode + "\n" //
-                            + "url=" + url + "\n" //
-                            + "headers=" + requestHeaders + "\n" + "response:\n" //
-                            + msg);
-                } finally {
-                    in.close();
-                }
-            } else {
-                return in;
-            }
-        } catch (IOException e) {
-            throw new ClientException(e);
-        }
+    public InputStream getStream(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
+        return getStream(HttpMethod.GET, url, requestHeaders, null, 0, options);
     }
 
     private static boolean isOk(int statusCode) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -142,9 +142,9 @@ public class ApacheHttpClientHttpService implements HttpService {
 
     @Override
     public InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
+            HttpRequestOptions options) {
         HttpRequestBase b = toRequestBase(method, url);
-        return getStream(requestHeaders, b, content, length, options);
+        return getStream(requestHeaders, b, null, 0, options);
     }
 
     private static HttpRequestBase toRequestBase(HttpMethod method, String url) {
@@ -230,12 +230,6 @@ public class ApacheHttpClientHttpService implements HttpService {
         log.info("closing client");
         client.close();
         log.info("closed client");
-    }
-
-    @Override
-    public InputStream getStream(String url, List<RequestHeader> requestHeaders,
-            HttpRequestOptions options) {
-        return getStream(HttpMethod.GET, url, requestHeaders, null, 0, options);
     }
 
     private static boolean isOk(int statusCode) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/DefaultHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/DefaultHttpService.java
@@ -139,14 +139,8 @@ public final class DefaultHttpService implements HttpService {
     }
 
     @Override
-    public InputStream getStream(String url, List<RequestHeader> requestHeaders,
-            HttpRequestOptions options) {
-        return getStream(HttpMethod.GET, url, requestHeaders, null, 0, options);
-    }
-
-    @Override
     public InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
+            HttpRequestOptions options) {
         try {
             URL u = new URL(url);
             HttpURLConnection c = (HttpURLConnection) u.openConnection();
@@ -159,19 +153,11 @@ public final class DefaultHttpService implements HttpService {
                     contentLengthSet = true;
                 }
             }
-            if (content != null && !contentLengthSet) {
-                c.setRequestProperty("Content-Length", Integer.toString(length));
-            }
             c.setDoInput(true);
-            c.setDoOutput(content != null);
+            c.setDoOutput(false);
             // apply just before connection established so further configuration can take
             // place like timeouts
             consumer.accept(c);
-            if (content != null) {
-                try (OutputStream o = c.getOutputStream()) {
-                    Util.copy(content, o, 8192);
-                }
-            }
             // TODO check error code and throw message read from input stream
             return c.getInputStream();
         } catch (IOException e) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/DefaultHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/DefaultHttpService.java
@@ -146,12 +146,8 @@ public final class DefaultHttpService implements HttpService {
             HttpURLConnection c = (HttpURLConnection) u.openConnection();
             c.setInstanceFollowRedirects(true);
             c.setRequestMethod(method.toString());
-            boolean contentLengthSet = false;
             for (RequestHeader header : requestHeadersModifier.apply(requestHeaders)) {
                 c.setRequestProperty(header.name(), header.value());
-                if ("Content-Length".equals(header.name())) {
-                    contentLengthSet = true;
-                }
             }
             c.setDoInput(true);
             c.setDoOutput(false);

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -352,7 +352,7 @@ public final class RequestHelper {
                     options.getRequestHeaders(), options);
         }
     }
-
+    
     // for HasStream case (only for entities, not for complexTypes)
     public static Optional<StreamProvider> createStream(ContextPath contextPath,
             ODataEntityType entity) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/Util.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/Util.java
@@ -3,6 +3,7 @@ package com.github.davidmoten.odata.client.internal;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -13,94 +14,102 @@ import com.github.davidmoten.odata.client.ODataType;
 
 public final class Util {
 
-	public static String readString(InputStream in, Charset charset) throws IOException {
-		ByteArrayOutputStream result = new ByteArrayOutputStream();
-		byte[] buffer = new byte[1024];
-		int length;
-		while ((length = in.read(buffer)) != -1) {
-			result.write(buffer, 0, length);
-		}
-		return new String(result.toByteArray(), charset);
-	}
+    public static String readString(InputStream in, Charset charset) throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = in.read(buffer)) != -1) {
+            result.write(buffer, 0, length);
+        }
+        return new String(result.toByteArray(), charset);
+    }
 
-	public static String trimTrailingSlash(String url) {
-		if (!url.isEmpty() && url.charAt(url.length() - 1) == '/') {
-			return url.substring(0, url.length() - 2);
-		} else {
-			return url;
-		}
-	}
+    public static String trimTrailingSlash(String url) {
+        if (!url.isEmpty() && url.charAt(url.length() - 1) == '/') {
+            return url.substring(0, url.length() - 2);
+        } else {
+            return url;
+        }
+    }
 
-	@SuppressWarnings("unchecked")
-	public static <T extends ODataType> String odataTypeName(Class<T> cls) {
-		try {
-			Constructor<?> c = null;
-			Constructor<?>[] constructors = cls.getDeclaredConstructors();
-			for (Constructor<?> constructor : constructors) {
-				if (constructor.getParameterCount() == 0) {
-					constructor.setAccessible(true);
-					c = constructor;
-				}
-			}
-			T o = (T) c.newInstance();
-			return o.odataTypeName();
-		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
-				| SecurityException e) {
-			throw new ClientException(e);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    public static <T extends ODataType> String odataTypeName(Class<T> cls) {
+        try {
+            Constructor<?> c = null;
+            Constructor<?>[] constructors = cls.getDeclaredConstructors();
+            for (Constructor<?> constructor : constructors) {
+                if (constructor.getParameterCount() == 0) {
+                    constructor.setAccessible(true);
+                    c = constructor;
+                }
+            }
+            T o = (T) c.newInstance();
+            return o.odataTypeName();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException | SecurityException e) {
+            throw new ClientException(e);
+        }
+    }
 
-	@SuppressWarnings("unchecked")
-	public static <T> String odataTypeNameFromAny(Class<T> cls) {
-		if (ODataType.class.isAssignableFrom(cls)) {
-			return odataTypeName((Class<? extends ODataType>) cls);
-		} else {
-			return EdmSchemaInfo.INSTANCE.getTypeWithNamespaceFromClass(cls);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    public static <T> String odataTypeNameFromAny(Class<T> cls) {
+        if (ODataType.class.isAssignableFrom(cls)) {
+            return odataTypeName((Class<? extends ODataType>) cls);
+        } else {
+            return EdmSchemaInfo.INSTANCE.getTypeWithNamespaceFromClass(cls);
+        }
+    }
 
-	/**
-	 * Reads size bytes into buffer from InputStream if end of stream not reached.
-	 * Returns the number of bytes read (which will be {@code size} if end of stream
-	 * not reached).
-	 * 
-	 * @param in     input stream
-	 * @param buffer destination array to read into
-	 * @param size   number of bytes to read if available
-	 * @return number of bytes read
-	 */
-	// TODO unit test
-	public static int readFully(InputStream in, byte[] buffer, int size) {
-		int len = 0;
-		while (len < size) {
-			try {
-				int numRead = in.read(buffer, len, size - len);
-				if (numRead == -1) {
-					break;
-				} else {
-					len += numRead;
-				}
-			} catch (IOException e) {
-				// this is unrecoverable because we cannot reread from the InputStream
-				// TODO provide a Supplier<InputStream> parameter?
-				throw new UncheckedIOException(e);
-			}
-		}
-		return len;
-	}
+    /**
+     * Reads size bytes into buffer from InputStream if end of stream not reached.
+     * Returns the number of bytes read (which will be {@code size} if end of stream
+     * not reached).
+     * 
+     * @param in     input stream
+     * @param buffer destination array to read into
+     * @param size   number of bytes to read if available
+     * @return number of bytes read
+     */
+    // TODO unit test
+    public static int readFully(InputStream in, byte[] buffer, int size) {
+        int len = 0;
+        while (len < size) {
+            try {
+                int numRead = in.read(buffer, len, size - len);
+                if (numRead == -1) {
+                    break;
+                } else {
+                    len += numRead;
+                }
+            } catch (IOException e) {
+                // this is unrecoverable because we cannot reread from the InputStream
+                // TODO provide a Supplier<InputStream> parameter?
+                throw new UncheckedIOException(e);
+            }
+        }
+        return len;
+    }
 
-	public static byte[] read(InputStream in) {
-		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-		int n;
-		byte[] buffer = new byte[8192];
-		try {
-			while ((n = in.read(buffer)) != -1) {
-				bytes.write(buffer, 0, n);
-			}
-			return bytes.toByteArray();
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
+    public static byte[] read(InputStream in) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        int n;
+        byte[] buffer = new byte[8192];
+        try {
+            while ((n = in.read(buffer)) != -1) {
+                bytes.write(buffer, 0, n);
+            }
+            return bytes.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void copy(InputStream in, OutputStream out, int bufferSize) throws IOException {
+        byte[] b = new byte[bufferSize];
+        int n;
+        while ((n = in.read(b)) != -1) {
+            out.write(b, 0, n);
+        }
+    }
 
 }

--- a/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
+++ b/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
@@ -87,8 +87,14 @@ public class CollectionPageTest {
             @Override
             public InputStream getStream(String url, List<RequestHeader> requestHeaders,
                     HttpRequestOptions options) {
-                // TODO Auto-generated method stub
-                return null;
+               throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public InputStream getStream(HttpMethod method, String url,
+                    List<RequestHeader> requestHeaders, InputStream content, int length,
+                    HttpRequestOptions options) {
+                throw new UnsupportedOperationException();
             }
 
         };

--- a/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
+++ b/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
@@ -34,8 +34,8 @@ public class CollectionPageTest {
 
         Context context = new Context(serializer, service, Arrays.asList(schemaInfo));
         CollectionPage<Person> c = serializer.deserializeCollectionPage(json, Person.class,
-                new ContextPath(context, service.getBasePath()), 
-                Collections.emptyList(), HttpRequestOptions.EMPTY, x -> {
+                new ContextPath(context, service.getBasePath()), Collections.emptyList(),
+                HttpRequestOptions.EMPTY, x -> {
                 });
         assertEquals(2, c.currentPage().size());
         assertEquals("Russell", c.currentPage().get(0).firstName);
@@ -87,13 +87,12 @@ public class CollectionPageTest {
             @Override
             public InputStream getStream(String url, List<RequestHeader> requestHeaders,
                     HttpRequestOptions options) {
-               throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException();
             }
 
             @Override
             public InputStream getStream(HttpMethod method, String url,
-                    List<RequestHeader> requestHeaders, InputStream content, int length,
-                    HttpRequestOptions options) {
+                    List<RequestHeader> requestHeaders, HttpRequestOptions options) {
                 throw new UnsupportedOperationException();
             }
 
@@ -113,11 +112,10 @@ public class CollectionPageTest {
         ContextPath contextPath = new ContextPath(context,
                 new Path("https://blah", PathStyle.IDENTIFIERS_AS_SEGMENTS));
         CollectionPage<Person> page = serializer.deserializeCollectionPage(json, Person.class,
-                contextPath, Collections.emptyList(), HttpRequestOptions.EMPTY,
-                p -> {
+                contextPath, Collections.emptyList(), HttpRequestOptions.EMPTY, p -> {
                 });
-        assertEquals(Lists.newArrayList(1,2,3), page.unmappedFields().get("hello"));
-        
+        assertEquals(Lists.newArrayList(1, 2, 3), page.unmappedFields().get("hello"));
+
         // test serialization of unmapped fields
         String json2 = Serializer.INSTANCE.serialize(page);
         assertTrue(json2.contains("hello"));

--- a/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/InlineParameterSyntaxTest.java
+++ b/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/InlineParameterSyntaxTest.java
@@ -17,7 +17,7 @@ public class InlineParameterSyntaxTest {
     public void testString() {
         Map<String, TypedObject> parameters = new HashMap<>();
         parameters.put("name", new TypedObject("Edm.String", "fred"));
-        assertEquals("(name=\"fred\")", encode(Serializer.INSTANCE, parameters));
+        assertEquals("(name='fred')", encode(Serializer.INSTANCE, parameters));
     }
 
     @Test

--- a/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test6ServiceTest.java
+++ b/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test6ServiceTest.java
@@ -87,7 +87,7 @@ public class Test6ServiceTest {
     public void testFunctionParametersAreInlineSyntax() {
         Test6Service client = Test6Service.test() //
                 .expectRequest(
-                        "/Products/1/Test6.A.functionToTestNulls/(value%3D1%2Ccollection%3D%5B1%2C2%2C3%5D)") //
+                        "/Products/1/Test6.A.functionToTestNulls(value%3D1%2Ccollection%3D%5B1%2C2%2C3%5D)") //
                 .withResponse("/function-return-1.json") //
                 .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION)
                 .build();
@@ -99,7 +99,7 @@ public class Test6ServiceTest {
     public void testFunctionParametersAreInlineSyntaxWhenNonCollectionParameterNull() {
         Test6Service client = Test6Service.test() //
                 .expectRequest(
-                        "/Products/1/Test6.A.functionToTestNulls/(value%3Dnull'Edm.Int32'%2Ccollection%3D%5B1%2C2%2C3%5D)") //
+                        "/Products/1/Test6.A.functionToTestNulls(value%3Dnull'Edm.Int32'%2Ccollection%3D%5B1%2C2%2C3%5D)") //
                 .withResponse("/function-return-1.json") //
                 .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION)
                 .build();
@@ -112,7 +112,7 @@ public class Test6ServiceTest {
     public void testFunctionParametersAreInlineSyntaxWhenCollectionParameterNull() {
         Test6Service client = Test6Service.test() //
                 .expectRequest(
-                        "/Products/1/Test6.A.functionToTestNulls/(value%3D1%2Ccollection%3Dnull'Collection(Edm.Int32)')") //
+                        "/Products/1/Test6.A.functionToTestNulls(value%3D1%2Ccollection%3Dnull'Collection(Edm.Int32)')") //
                 .withResponse("/function-return-1.json") //
                 .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION).build();
         int value = client.products(1).functionToTestNulls(1, null).get().value();
@@ -122,7 +122,7 @@ public class Test6ServiceTest {
     @Test
     public void testUnboundFunction() {
         Test6ServiceA client = Test6ServiceA.test() //
-                .expectRequest("/Test6.A.globalFunction/(productId%3D%221%22%2Cvalue%3D23)") //
+                .expectRequest("/Test6.A.globalFunction(productId%3D'1'%2Cvalue%3D23)") //
                 .withResponse("/function-return-1.json") //
                 .withRequestHeaders(RequestHeader.ACCEPT_JSON, RequestHeader.ODATA_VERSION).build();
         assertEquals(456, (int) client.globalFunction("1", 23).get().value());


### PR DESCRIPTION
See discussion in #93 

* Parameters for actions and functions are appended directly to final segment rather than being a separate segment (Bug fix) 
* Override msgraph metadata so that functions and actions that return `graph.report` return `Edm.Stream` instead.
* Add support for returning Edm.Stream from function/action
* Update msgraph v1.0 metadata (Dec 29 2020)