### PR TITLE
TestingService - support setting response status code for all methods

### DIFF
--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -941,7 +941,7 @@ public class GraphServiceTest {
             assertEquals(HttpURLConnection.HTTP_NOT_FOUND, (int) e.getStatusCode().get());
         }
     }
-
+    
     @Test
     public void testMailRead() {
         GraphService client = clientBuilder() //

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -920,10 +920,30 @@ public class GraphServiceTest {
         Message m2 = m.move("Archive").metadataFull().get();
         assertEquals(m.getId(), m2.getId());
     }
+    
+    @Test
+    public void testPatchOfResourceNotFound() {
+        GraphService client = clientBuilder() //
+                .expectRequest("/users/1") //
+                .withResponse("/response-user.json") //
+                .withRequestHeadersStandard() //
+                .expectRequest("/users/1") //
+                .withPayload("/request-user-patch.json") //
+                .withResponseStatusCode(HttpURLConnection.HTTP_NOT_FOUND) //
+                .withMethod(HttpMethod.PATCH) //
+                .withRequestHeaders(RequestHeader.CONTENT_TYPE_JSON, RequestHeader.ODATA_VERSION,
+                        RequestHeader.ACCEPT_JSON) //
+                .build();
+        User user = client.users("1").get();
+        try {
+            user.withCity("Canberra").patch();
+        } catch (ClientException e) {
+            assertEquals(HttpURLConnection.HTTP_NOT_FOUND, (int) e.getStatusCode().get());
+        }
+    }
 
     @Test
     public void testMailRead() {
-
         GraphService client = clientBuilder() //
                 .expectRequest(
                         "/users/fred/mailFolders/inbox/messages?$filter=isRead%20eq%20false&$orderBy=createdDateTime&$expand=attachments") //

--- a/odata-client-msgraph/src/test/resources/request-user-patch.json
+++ b/odata-client-msgraph/src/test/resources/request-user-patch.json
@@ -1,0 +1,1 @@
+{"@odata.type":"microsoft.graph.user","city":"Canberra"}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpResponse.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpResponse.java
@@ -13,7 +13,11 @@ public class HttpResponse {
     }
 
     public String getText() {
-        return new String(bytes, StandardCharsets.UTF_8);
+        if (bytes == null) {
+            return null;
+        } else {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
     }
 
     public int getResponseCode() {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -189,11 +189,15 @@ public final class TestingService {
         }
 
         @SuppressWarnings("unchecked")
-        public T expectDelete(String path, RequestHeader... requestHeaders) {
+        public T expectDelete(String path, int responseStatusCode, RequestHeader... requestHeaders) {
             String key = toKey(HttpMethod.DELETE, baseUrl + path, asList(requestHeaders));
             requests.put(key, "DELETE");
-            responses.put(key, new Response(null, HttpURLConnection.HTTP_NO_CONTENT));
+            responses.put(key, new Response(null, responseStatusCode));
             return (T) this;
+        }
+        
+        public T expectDelete(String path, RequestHeader... requestHeaders) {
+            return expectDelete(path, HttpURLConnection.HTTP_NO_CONTENT,requestHeaders);
         }
 
         private static String toKey(HttpMethod method, String url,


### PR DESCRIPTION
As discussed in #99, add the ability to specify the returned status code from any unit test calls using TestingService.