### PR TITLE
enable setting of path style in MicrosoftClientBuilder 

### DIFF
--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/MsGraph.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/MsGraph.java
@@ -6,6 +6,7 @@ import com.github.davidmoten.microsoft.authentication.GraphConstants;
 import com.github.davidmoten.microsoft.client.builder.MicrosoftClientBuilder;
 import com.github.davidmoten.microsoft.client.builder.MicrosoftClientBuilder.Builder5;
 import com.github.davidmoten.msgraph.builder.GraphExplorerHttpService;
+import com.github.davidmoten.odata.client.PathStyle;
 
 import odata.msgraph.client.container.GraphService;
 
@@ -22,7 +23,9 @@ public final class MsGraph {
                 .baseUrl(MSGRAPH_1_0_BASE_URL) //
                 .creator(GraphService::new) //
                 .addSchema(odata.msgraph.client.schema.SchemaInfo.INSTANCE) //
-                .addSchema(odata.msgraph.client.callrecords.schema.SchemaInfo.INSTANCE).build() //
+                .addSchema(odata.msgraph.client.callrecords.schema.SchemaInfo.INSTANCE) //
+                .pathStyle(PathStyle.IDENTIFIERS_AS_SEGMENTS) //
+                .build() //
                 .tenantName(tenantName) //
                 .resource(GraphConstants.RESOURCE_MS_GRAPH) //
                 .scope(GraphConstants.SCOPE_MS_GRAPH_DEFAULT);


### PR DESCRIPTION
As discussed in #103. Here's an example of use taken from the MsGraph class:

```java
public static MicrosoftClientBuilder.Builder3<GraphService> tenantName(String tenantName) {
        return MicrosoftClientBuilder //
                .baseUrl(MSGRAPH_1_0_BASE_URL) //
                .creator(GraphService::new) //
                .addSchema(odata.msgraph.client.schema.SchemaInfo.INSTANCE) //
                .addSchema(odata.msgraph.client.callrecords.schema.SchemaInfo.INSTANCE) //
                .pathStyle(PathStyle.IDENTIFIERS_AS_SEGMENTS) //
                .build() //
                .tenantName(tenantName) //
                .resource(GraphConstants.RESOURCE_MS_GRAPH) //
                .scope(GraphConstants.SCOPE_MS_GRAPH_DEFAULT);
    }
```