### PR TITLE
Fix NPE when service call returns no content (HTTP 204)

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.config.RequestConfig.Builder;
@@ -128,7 +129,12 @@ public class ApacheHttpClientHttpService implements HttpService {
                 log.debug("executed request, code={}", statusCode);
                 final byte[] bytes;
                 if (doInput || isError(statusCode)) {
-                    bytes = Util.read(response.getEntity().getContent());
+                    HttpEntity entity = response.getEntity();
+                    if (entity == null) {
+                        bytes = null;
+                    } else {
+                        bytes = Util.read(entity.getContent());
+                    }
                 } else {
                     bytes = null;
                 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -132,8 +132,8 @@ public class ApacheHttpClientHttpService implements HttpService {
                 } else {
                     bytes = null;
                 }
-                if (log.isDebugEnabled() ) {
-                    log.debug("response text=\n{}", new String(bytes, StandardCharsets.UTF_8));
+                if (log.isDebugEnabled()) {
+                    log.debug("response text=\n{}", bytes == null ? "null" :new String(bytes, StandardCharsets.UTF_8));
                 }
                 return new HttpResponse(statusCode, bytes);
             }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -133,7 +133,7 @@ public class ApacheHttpClientHttpService implements HttpService {
                     bytes = null;
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug("response text=\n{}", bytes == null ? "null" :new String(bytes, StandardCharsets.UTF_8));
+                    log.debug("response text=\n{}", bytes == null ? "null" : new String(bytes, StandardCharsets.UTF_8));
                 }
                 return new HttpResponse(statusCode, bytes);
             }


### PR DESCRIPTION
As discussed in #123, this PR fixes an NPE in `ApacheHttpClientService` and also ensures that another NPE does not occur if debug logging is enabled.