### PR TITLE
Default to full metadata when returning an entity that has a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Output:
 ```
 ## Usage Notes
 ### Streams
-To find the read url for a property that is of type `Edm.Stream` you generally need to read the entity containing the stream property with the `Accept: odata.metadata=full` request header (set `.metadataFull()` before calling `get()` on an entity).
+To find the read url for a property that is of type `Edm.Stream` you generally need to read the entity containing the stream property with the `Accept: odata.metadata=full` request header (set `.metadataFull()` before calling `get()` on an entity). As of 0.1.54 this request header is the default for Media Entities or entities with stream properties (but not for collections of these entities).
 
 ## Implementation Notes
 ### Generator

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1091,9 +1091,10 @@ public final class Generator {
 			p.format("%spublic %s(%s contextPath, %s<%s> value) {\n", indent, //
 			        simpleClassName, imports.add(ContextPath.class), //
 			        imports.add(Optional.class), imports.add(Object.class));
-			p.format("%ssuper(%s.class, contextPath, value);\n", //
+			p.format("%ssuper(%s.class, contextPath, value, %s);\n", //
 					indent.right(), //
-					imports.add(t.getFullClassNameEntity()));
+					imports.add(t.getFullClassNameEntity()), //
+					t.isMediaEntityOrHasStreamProperty());
 			p.format("%s}\n", indent.left());
 
 			indent.left();

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Structure.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Structure.java
@@ -82,6 +82,13 @@ public abstract class Structure<T> {
                         .flatMap(x -> toFields(x, imports)))
                 .collect(Collectors.toList());
     }
+    
+    public final boolean isMediaEntityOrHasStreamProperty() {
+        return getHeirarchy() //
+                .stream() //
+                .flatMap(x -> x.getProperties().stream()) //
+                .anyMatch(x -> "Edm.Stream".equals(names.getType(x)));
+    }
 
     public static final class FieldName {
         public final String name;

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/EntityRequest.java
@@ -8,12 +8,14 @@ public abstract class EntityRequest<T extends ODataEntityType> {
 
     private final Class<T> cls;
     protected final ContextPath contextPath;
-    private Optional<Object> value;
+    private final Optional<Object> value;
+    private final boolean isMediaEntityOrHasStreamProperty;
 
-    public EntityRequest(Class<T> cls, ContextPath contextPath, Optional<Object> value) {
+    public EntityRequest(Class<T> cls, ContextPath contextPath, Optional<Object> value, boolean isMediaEntityOrHasStreamProperty) {
         this.cls = cls;
         this.contextPath = contextPath;
         this.value = value;
+        this.isMediaEntityOrHasStreamProperty = isMediaEntityOrHasStreamProperty;
     }
 
     T get(EntityRequestOptions<T> options) {
@@ -38,47 +40,51 @@ public abstract class EntityRequest<T extends ODataEntityType> {
     }
 
     public T get() {
-        return new EntityRequestOptionsBuilder<T>(this).get();
+        return builder().get();
     }
 
     public void delete() {
-        new EntityRequestOptionsBuilder<T>(this).delete();
+        builder().delete();
     }
 
     public T patch(T entity) {
-        return new EntityRequestOptionsBuilder<T>(this).patch(entity);
+        return builder().patch(entity);
     }
 
     public T put(T entity) {
-        return new EntityRequestOptionsBuilder<T>(this).put(entity);
+        return builder().put(entity);
     }
 
     public EntityRequestOptionsBuilder<T> requestHeader(String key, String value) {
-        return new EntityRequestOptionsBuilder<T>(this).requestHeader(key, value);
+        return builder().requestHeader(key, value);
     }
 
     public EntityRequestOptionsBuilder<T> query(String name, String value) {
-        return new EntityRequestOptionsBuilder<T>(this).query(name, value);
+        return builder().query(name, value);
     }
     
     public EntityRequestOptionsBuilder<T> select(String clause) {
-        return new EntityRequestOptionsBuilder<T>(this).select(clause);
+        return builder().select(clause);
     }
 
     public EntityRequestOptionsBuilder<T> expand(String clause) {
-        return new EntityRequestOptionsBuilder<T>(this).expand(clause);
+        return builder().expand(clause);
     }
 
     public EntityRequestOptionsBuilder<T> metadataFull() {
-        return new EntityRequestOptionsBuilder<T>(this).metadataFull();
+        return builder().metadataFull();
     }
 
     public EntityRequestOptionsBuilder<T> metadataMinimal() {
-        return new EntityRequestOptionsBuilder<T>(this).metadataMinimal();
+        return builder().metadataMinimal();
     }
 
     public EntityRequestOptionsBuilder<T> metadataNone() {
-        return new EntityRequestOptionsBuilder<T>(this).metadataNone();
+        return builder().metadataNone();
+    }
+    
+    private EntityRequestOptionsBuilder<T> builder() {
+        return new EntityRequestOptionsBuilder<T>(this, isMediaEntityOrHasStreamProperty);
     }
 
 }

--- a/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test8ServiceTest.java
+++ b/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test8ServiceTest.java
@@ -27,7 +27,7 @@ public class Test8ServiceTest {
                 .withRequestHeadersStandard() //
                 .withResponse("/response-thing.json") //
                 .build();
-        assertFalse(client.things(123).get().getPhoto().isPresent());
+        assertFalse(client.things(123).metadataMinimal().get().getPhoto().isPresent());
     }
 
     @Test
@@ -41,7 +41,9 @@ public class Test8ServiceTest {
                         RequestHeader.ODATA_VERSION) //
                 .withResponse("/response-thing-full-metadata.json") //
                 .build();
-        Optional<StreamProvider> photo = client.things(123).metadataFull().get().getPhoto();
+        // note that odata-client fetches full metadata by default for Media Entities
+        // or Entities with stream properties
+        Optional<StreamProvider> photo = client.things(123).get().getPhoto();
         assertTrue(photo.isPresent());
         try {
             // not pretty to use a try-catch but oh well
@@ -62,7 +64,7 @@ public class Test8ServiceTest {
                 .withRequestHeadersStandard() //
                 .withResponse("/response-thing-inline-photo.json") //
                 .build();
-        Optional<StreamProvider> photo = client.things(123).get().getPhoto();
+        Optional<StreamProvider> photo = client.things(123).metadataMinimal().get().getPhoto();
         assertTrue(photo.isPresent());
         assertEquals("hello", photo.get().getStringUtf8());
     }


### PR DESCRIPTION
As mentioned in #128, if a Media Entity or an Entity with a stream property is returned without full metadata then the stream may not be available (`Optional.empty()`). This PR defaults to setting `.metadataFull()` for Media Entities or entities with stream properties when the object is returned via an entity request. For example the call below will work without having to call `.metadataFull()` before the first `.get()`.

```java
byte[] bytes = client 
  .drives(driveId) 
  .items(itemId)
  .get()
  .getContent()
  .get()
  .getBytes();
```
Note that explicitly setting the metadata value (say by calling `.metadataMinimal()`) will override the default setting.

This PR is unit tested.

cc @AmudhaNila