### PR TITLE
Update XJC parameters to jaxb2-maven-plugin compatibility

### DIFF
--- a/odata-client-generator/pom.xml
+++ b/odata-client-generator/pom.xml
@@ -65,7 +65,9 @@
                         </goals>
                         <configuration>
                             <packageName>org.oasisopen.odata.csdl.v4</packageName>
-                            <schemaDirectory>src/xsd</schemaDirectory>
+                            <sources>
+                                <source>src/main/xsd/</source>
+                            </sources>
                             <clearOutputDir>false</clearOutputDir>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The `<schemaDirectory>` element is no longer used with the jaxb2-maven-plugin (it was a 1.x option, as I discovered in the answer for here: https://stackoverflow.com/questions/54933138/how-do-i-define-schema-directory-in-jaxb2-maven-plugin-version-2-4) Updated the pom to use the correct parameter.