### PR TITLE
Specify request headers and timeouts to StreamProvider

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/RequestOptions.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/RequestOptions.java
@@ -12,7 +12,7 @@ public interface RequestOptions  extends HttpRequestOptions {
     Map<String, String> getQueries();
     
     Optional<String> getUrlOverride();
-
+    
     RequestOptions EMPTY = new RequestOptions() {
 
         @Override

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProvider.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/StreamProvider.java
@@ -1,9 +1,11 @@
 package com.github.davidmoten.odata.client;
 
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.odata.client.internal.RequestHelper;
+import com.github.davidmoten.odata.client.internal.RequestOptionsImpl;
 
 public final class StreamProvider implements StreamProviderBase {
 
@@ -21,7 +23,24 @@ public final class StreamProvider implements StreamProviderBase {
         this.contentType = contentType;
         this.base64 = base64;
     }
-
+    
+    public StreamProvider requestHeader(String name, String value) {
+        RequestOptionsImpl o = new RequestOptionsImpl(options).withRequestHeader(name, value);
+        return new StreamProvider(contextPath, o, contentType, base64);
+    }
+    
+    public StreamProvider connectTimeout(long duration, TimeUnit unit) {
+        Preconditions.checkNotNull(unit);
+        RequestOptionsImpl o = new RequestOptionsImpl(options).withConnectTimeoutMs(duration, unit);
+        return new StreamProvider(contextPath, o, contentType, base64);
+    }
+    
+    public StreamProvider readTimeout(long duration, TimeUnit unit) {
+        Preconditions.checkNotNull(unit);
+        RequestOptionsImpl o = new RequestOptionsImpl(options).withReadTimeoutMs(duration, unit);
+        return new StreamProvider(contextPath, o, contentType, base64);
+    }
+    
     public InputStream get() {
         return RequestHelper.getStream(contextPath, options, base64);
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestOptionsImpl.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestOptionsImpl.java
@@ -1,0 +1,78 @@
+package com.github.davidmoten.odata.client.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.github.davidmoten.odata.client.RequestHeader;
+import com.github.davidmoten.odata.client.RequestOptions;
+
+public class RequestOptionsImpl implements RequestOptions {
+
+    private final Optional<Long> requestConnectTimeoutMs;
+    private final Optional<Long> requestReadTimeoutMs;
+    private final List<RequestHeader> requestHeaders;
+    private final Map<String, String> queries;
+    private final Optional<String> urlOverride;
+
+    public RequestOptionsImpl(Optional<Long> requestConnectTimeoutMs,
+            Optional<Long> requestReadTimeoutMs, List<RequestHeader> requestHeaders,
+            Map<String, String> queries, Optional<String> urlOverride) {
+        this.requestConnectTimeoutMs = requestConnectTimeoutMs;
+        this.requestReadTimeoutMs = requestReadTimeoutMs;
+        this.requestHeaders = requestHeaders;
+        this.queries = queries;
+        this.urlOverride = urlOverride;
+
+    }
+
+    public RequestOptionsImpl(RequestOptions r) {
+        this(r.requestConnectTimeoutMs(), r.requestReadTimeoutMs(), r.getRequestHeaders(),
+                r.getQueries(), r.getUrlOverride());
+    }
+
+    public RequestOptionsImpl withConnectTimeoutMs(long duration, TimeUnit unit) {
+        return new RequestOptionsImpl(Optional.of(unit.toMillis(duration)), requestReadTimeoutMs, requestHeaders,
+                queries, urlOverride);
+    }
+
+    public RequestOptionsImpl withReadTimeoutMs(long duration, TimeUnit unit) {
+        return new RequestOptionsImpl(requestConnectTimeoutMs, Optional.of(unit.toMillis(duration)), requestHeaders,
+                queries, urlOverride);
+    }
+
+    public RequestOptionsImpl withRequestHeader(String name, String value) {
+        List<RequestHeader> h = new ArrayList<>(requestHeaders);
+        h.add(RequestHeader.create(name, value));
+        return new RequestOptionsImpl(requestConnectTimeoutMs, requestReadTimeoutMs, h, queries,
+                urlOverride);
+    }
+
+    @Override
+    public Optional<Long> requestConnectTimeoutMs() {
+        return requestConnectTimeoutMs;
+    }
+
+    @Override
+    public Optional<Long> requestReadTimeoutMs() {
+        return requestReadTimeoutMs;
+    }
+
+    @Override
+    public List<RequestHeader> getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    @Override
+    public Map<String, String> getQueries() {
+        return queries;
+    }
+
+    @Override
+    public Optional<String> getUrlOverride() {
+        return urlOverride;
+    }
+
+}


### PR DESCRIPTION
As discussed in #152 the ability to specify request headers for a stream download is needed. While I was there I added custom timeouts.
