### PR TITLE
Fix serialization of UnsignedByte

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/edm/UnsignedByte.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/edm/UnsignedByte.java
@@ -1,6 +1,10 @@
 package com.github.davidmoten.odata.client.edm;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public final class UnsignedByte {
+    
+    @JsonValue
     private int value;
 
     public UnsignedByte(int value) {

--- a/odata-client-test-service/src/test/java/com/github/davidmoten/odata/test/DemoServiceTest.java
+++ b/odata-client-test-service/src/test/java/com/github/davidmoten/odata/test/DemoServiceTest.java
@@ -49,6 +49,8 @@ public class DemoServiceTest {
                 RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, RequestHeader.ODATA_VERSION);
         List<PersonDetail> page = client.personDetails().get().currentPage();
         assertEquals(7, page.size());
+        assertEquals(21, page.get(0).getAge().get().getValue());
+        assertTrue(Serializer.INSTANCE.serialize(page.get(0)).contains("\"Age\":21,"));
     }
 
     @Test


### PR DESCRIPTION
As per discussion in #164, `UnsignedByte` needs a `@JsonValue` annotation on the `value` field to serialize properly.