### PR TITLE
Simplify HttpService and fix some wrong signatures in CustomRequest

### DIFF
--- a/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
+++ b/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
@@ -32,38 +32,16 @@ public final class GraphExplorerHttpService implements HttpService {
     }
     
     @Override
+    public HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            InputStream content, int length, HttpRequestOptions options) {
+        return s.submit(method, convert(url), requestHeaders, content, length, options);
+    }
+    
+    @Override
     public void close() throws Exception {
         s.close();
     }
-
-    @Override
-    public HttpResponse get(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
-        return s.get(convert(url), requestHeaders, options);
-    }
-
-    @Override
-    public HttpResponse patch(String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
-        return s.patch(convert(url), requestHeaders, content, length, options);
-    }
-
-    @Override
-    public HttpResponse put(String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
-        return s.put(convert(url), requestHeaders, content, length, options);
-    }
-
-    @Override
-    public HttpResponse post(String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
-        return s.post(convert(url), requestHeaders, content, length, options);
-    }
-
-    @Override
-    public HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
-        return s.delete(convert(url), requestHeaders, options);
-    }
-
+    
     @Override
     public InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
         return s.getStream(convert(url), requestHeaders, options);
@@ -79,5 +57,5 @@ public final class GraphExplorerHttpService implements HttpService {
             HttpRequestOptions options) {
         return s.getStream(method, convert(url), requestHeaders, options);
     }
-    
+
 }

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -1194,7 +1194,7 @@ public class GraphServiceTest {
     }
     
     @Test
-    public void testDriveIssue173() {
+    public void testDriveIssue173Post() {
         GraphService client = clientBuilder()
                 .expectRequest("/drives/123/items/456:/filename.txt:/createuploadsession")
                 .withMethod(HttpMethod.POST) //
@@ -1214,6 +1214,32 @@ public class GraphServiceTest {
                         RequestHeader.CONTENT_TYPE_JSON);
         assertEquals("https://blah", u.getUploadUrl().get());
     }
+
+    @Test
+    @Ignore
+    public void testDriveIssue173Put() {
+        GraphService client = clientBuilder()
+                .expectRequest("/drives/123/items/456:/filename.txt:/createuploadsession")
+                .withMethod(HttpMethod.POST) //
+                .withRequestHeaders(RequestHeader.ODATA_VERSION, RequestHeader.CONTENT_TYPE_JSON,
+                        RequestHeader.ACCEPT_JSON)
+                .withResponse("/response-drive.json") //
+                .build();
+
+        UploadSession u = client //
+                ._custom() //
+                .post( //
+                        "https://graph.microsoft.com/v1.0//drives/{drive-id}/items/{parent-id}:/{filename}:/content", //
+                        null, //
+                        UploadSession.class, //
+                        HttpRequestOptions.EMPTY, //
+                        RequestHeader.ODATA_VERSION, //
+                        RequestHeader.CONTENT_TYPE_JSON);
+        assertEquals("https://blah", u.getUploadUrl().get());
+    }
+
+    
+//    /drives/{drive-id}/items/{parent-id}:/{filename}:/content
 
     private void checkCreateApplicationPassword(int responseCode) {
         GraphService client = clientBuilder() //

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -1228,21 +1228,21 @@ public class GraphServiceTest {
                 .build();
 
         String url = "https://graph.microsoft.com/v1.0/drives/123/items/456:/filename.txt:/content";
-        List<RequestHeader> headers = Collections
-                .singletonList(RequestHeader.CONTENT_TYPE_TEXT_PLAIN);
         String content = "hello";
         {
             // use HttpService
+            List<RequestHeader> headers = Collections
+                    .singletonList(RequestHeader.CONTENT_TYPE_TEXT_PLAIN);
             HttpResponse u = client //
                     ._service() //
                     .submit(HttpMethod.PUT, url, headers, content, HttpRequestOptions.EMPTY);
             assertTrue(u.getText().contains("0123456789abc"));
         }
         {
-            // use CustomRequest
+            // use CustomRequest (with bytes content this time)
             String json = client //
                     ._custom() //
-                    .submitStringReturnsString(HttpMethod.PUT, url, content,
+                    .submitBytesReturnsString(HttpMethod.PUT, url, content.getBytes(StandardCharsets.UTF_8),
                             HttpRequestOptions.EMPTY, RequestHeader.CONTENT_TYPE_TEXT_PLAIN);
             assertTrue(json.contains("0123456789abc"));
         }

--- a/odata-client-msgraph/src/test/resources/response-drive-item-put.json
+++ b/odata-client-msgraph/src/test/resources/response-drive-item-put.json
@@ -1,0 +1,6 @@
+{
+  "id": "0123456789abc",
+  "name": "filename.txt",
+  "size": 5,
+  "file": { }
+}

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
@@ -116,14 +116,14 @@ public final class CustomRequest {
             RequestHeader... headers) {
         String absoluteUrl = toAbsoluteUrl(url);
         UrlInfo info = getInfo(context, absoluteUrl, headers, options);
-        context.service().submitWithContent(method, absoluteUrl, info.requestHeaders, content, options);
+        context.service().submit(method, absoluteUrl, info.requestHeaders, content, options);
     }
 
     public String submitStringReturnsString(HttpMethod method, String url, String content, RequestOptions options,
             RequestHeader... headers) {
         String absoluteUrl = toAbsoluteUrl(url);
         UrlInfo info = getInfo(context, absoluteUrl, headers, options);
-        HttpResponse response = context.service().submitWithContent(method, absoluteUrl, info.requestHeaders, content,
+        HttpResponse response = context.service().submit(method, absoluteUrl, info.requestHeaders, content,
                 options);
         RequestHelper.checkResponseCodeOk(info.contextPath, response);
         return response.getText();

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
@@ -16,48 +16,58 @@ import java.util.function.Function;
 import com.github.davidmoten.odata.client.internal.DefaultHttpService;
 
 public interface HttpService extends AutoCloseable {
-    
-    static int LENGTH_UNKNOWN = -1;
-    
-    Path getBasePath();
-    
-    HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
 
-    InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
-    
-    default HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    static int LENGTH_UNKNOWN = -1;
+
+    Path getBasePath();
+
+    HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            InputStream content, int length, HttpRequestOptions options);
+
+    InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options);
+
+    default HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return submit(method, url, requestHeaders, null, LENGTH_UNKNOWN, options);
     }
 
-    default HttpResponse get(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    default HttpResponse get(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return submit(HttpMethod.GET, url, requestHeaders, options);
     }
 
-    default HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    default HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return submit(HttpMethod.PATCH, url, requestHeaders, content, length, options);
     }
 
-    default HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    default HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return submit(HttpMethod.PUT, url, requestHeaders, content, length, options);
     }
 
-    default HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+    default HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content,
+            int length, HttpRequestOptions options) {
         return submit(HttpMethod.POST, url, requestHeaders, content, length, options);
     }
-    
-    default HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+
+    default HttpResponse delete(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return submit(HttpMethod.DELETE, url, requestHeaders, options);
     }
 
-    default InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    default InputStream getStream(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return getStream(HttpMethod.GET, url, requestHeaders, options);
     }
-    
+
     default Optional<Proxy> getProxy() {
         return Optional.empty();
     }
-    
-    default HttpResponse patch(String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
+
+    default HttpResponse patch(String url, List<RequestHeader> requestHeaders, String content,
+            HttpRequestOptions options) {
         byte[] b = content.getBytes(StandardCharsets.UTF_8);
         try (InputStream in = new ByteArrayInputStream(b)) {
             return patch(url, requestHeaders, in, b.length, options);
@@ -66,7 +76,8 @@ public interface HttpService extends AutoCloseable {
         }
     }
 
-    default HttpResponse put(String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
+    default HttpResponse put(String url, List<RequestHeader> requestHeaders, String content,
+            HttpRequestOptions options) {
         byte[] b = content.getBytes(StandardCharsets.UTF_8);
         try (InputStream in = new ByteArrayInputStream(b)) {
             return put(url, requestHeaders, in, b.length, options);
@@ -74,17 +85,24 @@ public interface HttpService extends AutoCloseable {
             throw new UncheckedIOException(e);
         }
     }
-    
-    default HttpResponse submit(HttpMethod method,String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
-        byte[] b = content.getBytes(StandardCharsets.UTF_8);
-        try (InputStream in = new ByteArrayInputStream(b)) {
-            return submit(method, url, requestHeaders, in, b.length, options);
+
+    default HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            byte[] content, HttpRequestOptions options) {
+        try (InputStream in = new ByteArrayInputStream(content)) {
+            return submit(method, url, requestHeaders, in, content.length, options);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    default HttpResponse post(String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
+    default HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            String content, HttpRequestOptions options) {
+        byte[] b = content.getBytes(StandardCharsets.UTF_8);
+        return submit(method, url, requestHeaders, b, options);
+    }
+
+    default HttpResponse post(String url, List<RequestHeader> requestHeaders, String content,
+            HttpRequestOptions options) {
         return submit(HttpMethod.POST, url, requestHeaders, content, options);
     }
 
@@ -100,7 +118,8 @@ public interface HttpService extends AutoCloseable {
         return getBytes(url, Collections.emptyList(), options);
     }
 
-    default byte[] getBytes(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    default byte[] getBytes(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return Util.toByteArray(getStream(url, requestHeaders, options));
     }
 
@@ -108,13 +127,14 @@ public interface HttpService extends AutoCloseable {
         return getStringUtf8(url, Collections.emptyList(), options);
     }
 
-    default String getStringUtf8(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+    default String getStringUtf8(String url, List<RequestHeader> requestHeaders,
+            HttpRequestOptions options) {
         return new String(getBytes(url, requestHeaders, options), StandardCharsets.UTF_8);
     }
 
     static HttpService createDefaultService(Path path,
-                                            Function<List<RequestHeader>, List<RequestHeader>> requestHeadersModifier,
-                                            Consumer<HttpURLConnection> consumer) {
+            Function<List<RequestHeader>, List<RequestHeader>> requestHeadersModifier,
+            Consumer<HttpURLConnection> consumer) {
         return new DefaultHttpService(path, requestHeadersModifier, consumer);
     }
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
@@ -18,19 +18,37 @@ import com.github.davidmoten.odata.client.internal.DefaultHttpService;
 public interface HttpService extends AutoCloseable {
     
     static int LENGTH_UNKNOWN = -1;
-
-    HttpResponse get(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
-
-    HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
-
-    HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
-
-    HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
     
-    HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
+    Path getBasePath();
+    
+    HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options);
 
     InputStream getStream(HttpMethod method, String url, List<RequestHeader> requestHeaders, HttpRequestOptions options);
     
+    default HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+        return submit(method, url, requestHeaders, null, LENGTH_UNKNOWN, options);
+    }
+
+    default HttpResponse get(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+        return submit(HttpMethod.GET, url, requestHeaders, options);
+    }
+
+    default HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+        return submit(HttpMethod.PATCH, url, requestHeaders, content, length, options);
+    }
+
+    default HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+        return submit(HttpMethod.PUT, url, requestHeaders, content, length, options);
+    }
+
+    default HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
+        return submit(HttpMethod.POST, url, requestHeaders, content, length, options);
+    }
+    
+    default HttpResponse delete(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
+        return submit(HttpMethod.DELETE, url, requestHeaders, options);
+    }
+
     default InputStream getStream(String url, List<RequestHeader> requestHeaders, HttpRequestOptions options) {
         return getStream(HttpMethod.GET, url, requestHeaders, options);
     }
@@ -38,24 +56,7 @@ public interface HttpService extends AutoCloseable {
     default Optional<Proxy> getProxy() {
         return Optional.empty();
     }
-
-    Path getBasePath();
     
-    
-    default HttpResponse send(HttpMethod method, String url, List<RequestHeader> requestHeaders,
-            InputStream content, int length, HttpRequestOptions options) {
-        if (method == HttpMethod.PATCH) {
-            return patch(url, requestHeaders, content, length, options);
-        } else if (method == HttpMethod.POST) {
-            return post(url, requestHeaders, content, length, options);
-        } else if (method == HttpMethod.PUT) {
-            return put(url, requestHeaders, content, length, options);
-        } else {
-            throw new ClientException(
-                    "method not supported for update: " + method + ", url=" + url);
-        }
-    }
-
     default HttpResponse patch(String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
         byte[] b = content.getBytes(StandardCharsets.UTF_8);
         try (InputStream in = new ByteArrayInputStream(b)) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/HttpService.java
@@ -74,38 +74,18 @@ public interface HttpService extends AutoCloseable {
             throw new UncheckedIOException(e);
         }
     }
+    
+    default HttpResponse submit(HttpMethod method,String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
+        byte[] b = content.getBytes(StandardCharsets.UTF_8);
+        try (InputStream in = new ByteArrayInputStream(b)) {
+            return submit(method, url, requestHeaders, in, b.length, options);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
     default HttpResponse post(String url, List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
-        byte[] b = content.getBytes(StandardCharsets.UTF_8);
-        try (InputStream in = new ByteArrayInputStream(b)) {
-            return post(url, requestHeaders, in, b.length, options);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    default HttpResponse submitWithContent(HttpMethod method, String url,
-            List<RequestHeader> requestHeaders, InputStream content, int length, HttpRequestOptions options) {
-        if (method == HttpMethod.PATCH) {
-            return patch(url, requestHeaders, content, length, options);
-        } else if (method == HttpMethod.PUT) {
-            return put(url, requestHeaders, content, length, options);
-        } else if (method == HttpMethod.POST) {
-            return post(url, requestHeaders, content, length, options);
-        } else {
-            throw new IllegalArgumentException(
-                    method + " not permitted for a submission with content");
-        }
-    }
-
-    default HttpResponse submitWithContent(HttpMethod method, String url,
-            List<RequestHeader> requestHeaders, String content, HttpRequestOptions options) {
-        byte[] b = content.getBytes(StandardCharsets.UTF_8);
-        try (InputStream in = new ByteArrayInputStream(b)) {
-            return submitWithContent(method, url, requestHeaders, in, b.length, options);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return submit(HttpMethod.POST, url, requestHeaders, content, options);
     }
 
     default HttpResponse get(String url, HttpRequestOptions options) {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/RequestHeader.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/RequestHeader.java
@@ -49,6 +49,8 @@ public final class RequestHeader {
 
     public static final RequestHeader TRANSFER_ENCODING_CHUNKED = RequestHeader.create("Transfer-Encoding", "chunked");
 
+    public static final RequestHeader CONTENT_TYPE_TEXT_PLAIN = RequestHeader.create("Content-Type", "text/plain");
+
     public boolean isAcceptJsonWithMetadata() {
         return name.equals("Accept") && value.contains("application/json;odata.metadata=");
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.github.davidmoten.guavamini.Preconditions;
 
 public final class TestingService {
@@ -251,7 +252,7 @@ public final class TestingService {
                     } else {
                         text = Util.utf8(content);
                     }
-                    log("content="+text);
+                    log("content=" + text);
                     logExpected();
                     log("Calling:");
                     String key = BuilderBase.toKey(method, url, requestHeaders);
@@ -265,8 +266,7 @@ public final class TestingService {
                         System.out.println("requestResourceName=" + requestResourceName);
                         byte[] requestExpected = readResource(url, requestResourceName);
                         String expectedText = new String(requestExpected, StandardCharsets.UTF_8);
-                        if (expectedText.equals(text)
-                                || Serializer.INSTANCE.matches(expectedText, text)) {
+                        if (expectedText.equals(text) || jsonEquals(text, expectedText)) {
                             Response resp = responses
                                     .get(BuilderBase.toKey(method, url, requestHeaders));
                             String responseResourceName = resp.resource;
@@ -321,6 +321,14 @@ public final class TestingService {
         }
 
         public abstract R build();
+    }
+
+    private static boolean jsonEquals(final String text, String expectedText) throws IOException {
+        try {
+            return Serializer.INSTANCE.matches(expectedText, text);
+        } catch (JsonParseException e) {
+            return false;
+        }
     }
 
     public static abstract class ContainerBuilder<T> extends BuilderBase<ContainerBuilder<T>, T> {

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/TestingService.java
@@ -19,14 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public final class TestingService {
+import com.github.davidmoten.guavamini.Preconditions;
 
-    private static final InputStream EMPTY = new InputStream() {
-        @Override
-        public int read() throws IOException {
-            return -1;
-        }
-    };
+public final class TestingService {
 
     public static Builder baseUrl(String url) {
         if (url.endsWith("/")) {
@@ -145,7 +140,7 @@ public final class TestingService {
                         responseResourcePath, method, applyDefaultIfMissing(statusCode, method),
                         requestHeaders.toArray(new RequestHeader[] {}));
             }
-            
+
             public R build() {
                 return add().build();
             }
@@ -205,7 +200,19 @@ public final class TestingService {
             return new HttpService() {
 
                 @Override
-                public HttpResponse get(String url, List<RequestHeader> requestHeaders,
+                public HttpResponse submit(HttpMethod method, String url,
+                        List<RequestHeader> requestHeaders, InputStream content, int length,
+                        HttpRequestOptions options) {
+                    if (method == HttpMethod.GET) {
+                        Preconditions.checkArgument(content == null);
+                        return _get(url, requestHeaders, options);
+                    } else {
+                        return postPatchPutOrDelete(url, requestHeaders, content, length, options,
+                                method);
+                    }
+                }
+
+                private HttpResponse _get(String url, List<RequestHeader> requestHeaders,
                         HttpRequestOptions options) {
                     logExpected();
                     String key = BuilderBase.toKey(HttpMethod.GET, url, requestHeaders);
@@ -234,40 +241,17 @@ public final class TestingService {
                     responses.entrySet().forEach(r -> log(r.getKey() + "\n=>" + r.getValue()));
                 }
 
-                @Override
-                public HttpResponse patch(String url, List<RequestHeader> requestHeaders,
-                        InputStream content, int length, HttpRequestOptions options) {
-                    return postPatchPutOrDelete(url, requestHeaders, content, length, options,
-                            HttpMethod.PATCH);
-                }
-
-                @Override
-                public HttpResponse put(String url, List<RequestHeader> requestHeaders,
-                        InputStream content, int length, HttpRequestOptions options) {
-                    return postPatchPutOrDelete(url, requestHeaders, content, length, options,
-                            HttpMethod.PUT);
-                }
-
-                @Override
-                public HttpResponse post(String url, List<RequestHeader> requestHeaders,
-                        InputStream content, int length, HttpRequestOptions options) {
-                    return postPatchPutOrDelete(url, requestHeaders, content, length, options,
-                            HttpMethod.POST);
-                }
-
-                @Override
-                public HttpResponse delete(String url, List<RequestHeader> requestHeaders,
-                        HttpRequestOptions options) {
-                    return postPatchPutOrDelete(url, requestHeaders, EMPTY, 0, options,
-                            HttpMethod.DELETE);
-                }
-
                 private HttpResponse postPatchPutOrDelete(String url,
                         List<RequestHeader> requestHeaders, InputStream content, int length,
                         HttpRequestOptions options, HttpMethod method) {
                     log(method + " called at " + url);
-                    String text = Util.utf8(content);
-                    log(text);
+                    final String text;
+                    if (content == null) {
+                        text = "";
+                    } else {
+                        text = Util.utf8(content);
+                    }
+                    log("content="+text);
                     logExpected();
                     log("Calling:");
                     String key = BuilderBase.toKey(method, url, requestHeaders);

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/ApacheHttpClientHttpService.java
@@ -17,7 +17,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.InputStreamEntity;
@@ -54,38 +53,13 @@ public class ApacheHttpClientHttpService implements HttpService {
         this(basePath, () -> HttpClientBuilder.create().useSystemProperties().build(),
                 (url, m) -> m);
     }
-
+    
     @Override
-    public HttpResponse get(String url, List<RequestHeader> requestHeaders,
-            HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpGet(url), null, -1, options);
+    public HttpResponse submit(HttpMethod method, String url, List<RequestHeader> requestHeaders,
+            InputStream content, int length, HttpRequestOptions options) {
+        return getResponse(requestHeaders, toRequestBase(method, url), content, length, options);
     }
-
-    @Override
-    public HttpResponse patch(String url, List<RequestHeader> requestHeaders, InputStream content,
-            int length, HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpPatch(url), content, length, options);
-    }
-
-    @Override
-    public HttpResponse put(String url, List<RequestHeader> requestHeaders, InputStream content,
-            int length, HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpPut(url), content, length, options);
-    }
-
-    @Override
-    public HttpResponse post(String url, List<RequestHeader> requestHeaders, InputStream content,
-            int length, HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpPost(url), content, length, options);
-    }
-
-    @Override
-    public HttpResponse delete(String url, List<RequestHeader> requestHeaders,
-            HttpRequestOptions options) {
-        return getResponse(requestHeaders, new HttpDelete(url), null, HttpService.LENGTH_UNKNOWN,
-                options);
-    }
-
+   
     @Override
     public Path getBasePath() {
         return basePath;

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -147,8 +147,13 @@ public final class RequestHelper {
 
         checkResponseCodeOk(cp, response);
     }
-
+    
     public static <T> T postAny(Object object, ContextPath contextPath, Class<T> responseClass,
+            RequestOptions options) {
+        return submitAny(HttpMethod.POST, object, contextPath, responseClass, options);
+    }
+    
+    public static <T> T submitAny(HttpMethod method, Object object, ContextPath contextPath, Class<T> responseClass,
             RequestOptions options) {
         // build the url
         ContextPath cp = contextPath.addQueries(options.getQueries());
@@ -264,7 +269,7 @@ public final class RequestHelper {
         }
         // get the response
         HttpService service = cp.context().service();
-        final HttpResponse response = service.submitWithContent(method, url, h, json, options);
+        final HttpResponse response = service.submit(method, url, h, json, options);
         checkResponseCodeOk(cp, response);
         // TODO is service returning the entity that we should use rather than the
         // original?
@@ -281,7 +286,7 @@ public final class RequestHelper {
         List<RequestHeader> h = cleanAndSupplementRequestHeaders(options, "minimal", true);
         ContextPath cp = contextPath.addQueries(options.getQueries());
         HttpService service = cp.context().service();
-        final HttpResponse response = service.submitWithContent(method, cp.toUrl(), h, in, length,
+        final HttpResponse response = service.submit(method, cp.toUrl(), h, in, length,
                 options);
         checkResponseCodeOk(cp, response);
     }

--- a/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
+++ b/odata-client-runtime/src/test/java/com/github/davidmoten/odata/client/CollectionPageTest.java
@@ -40,45 +40,30 @@ public class CollectionPageTest {
         assertEquals(2, c.currentPage().size());
         assertEquals("Russell", c.currentPage().get(0).firstName);
     }
-    
+
     private static final byte[] EMPTY_ARRAY = new byte[0];
-    
+
     private static HttpService createHttpService(String json) {
         return new HttpService() {
 
             @Override
-            public HttpResponse get(String url, List<RequestHeader> requestHeaders,
+            public HttpResponse submit(HttpMethod method, String url,
+                    List<RequestHeader> requestHeaders, InputStream content, int length,
                     HttpRequestOptions options) {
-                return new HttpResponse(200, json.getBytes(StandardCharsets.UTF_8));
+                if (method == HttpMethod.GET) {
+                    return new HttpResponse(HttpURLConnection.HTTP_OK,
+                            json.getBytes(StandardCharsets.UTF_8));
+                } else if (method == HttpMethod.POST) {
+                    return new HttpResponse(HttpURLConnection.HTTP_CREATED, EMPTY_ARRAY);
+                } else {
+                    return new HttpResponse(HttpURLConnection.HTTP_NO_CONTENT, EMPTY_ARRAY);
+                }
             }
 
+            
             @Override
             public Path getBasePath() {
                 return new Path("https://base", PathStyle.IDENTIFIERS_AS_SEGMENTS);
-            }
-
-            @Override
-            public HttpResponse patch(String url, List<RequestHeader> requestHeaders,
-                    InputStream content, int length, HttpRequestOptions options) {
-                return new HttpResponse(HttpURLConnection.HTTP_NO_CONTENT, EMPTY_ARRAY);
-            }
-
-            @Override
-            public HttpResponse put(String url, List<RequestHeader> requestHeaders,
-                    InputStream content, int length, HttpRequestOptions options) {
-                return new HttpResponse(HttpURLConnection.HTTP_NO_CONTENT, EMPTY_ARRAY);
-            }
-
-            @Override
-            public HttpResponse post(String url, List<RequestHeader> h, InputStream content,
-                    int length, HttpRequestOptions options) {
-                return new HttpResponse(HttpURLConnection.HTTP_CREATED, EMPTY_ARRAY);
-            }
-
-            @Override
-            public HttpResponse delete(String url, List<RequestHeader> requestHeaders,
-                    HttpRequestOptions options) {
-                return new HttpResponse(HttpURLConnection.HTTP_NO_CONTENT, EMPTY_ARRAY);
             }
 
             @Override
@@ -97,7 +82,6 @@ public class CollectionPageTest {
                     List<RequestHeader> requestHeaders, HttpRequestOptions options) {
                 throw new UnsupportedOperationException();
             }
-
         };
     }
 


### PR DESCRIPTION
As it becomes obvious that the HTTP verb itself doesn't limit whether a request has content or returns response body I've rejigged the HttpService interface (and updated all implementations of HttpService).

Inspiration for the work was adding a custom request put example for #173.