### PR TITLE
migrate GraphExplorer code to use new hostname graph.office.net

### DIFF
--- a/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/microsoft/authentication/BearerAuthenticator.java
+++ b/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/microsoft/authentication/BearerAuthenticator.java
@@ -10,7 +10,7 @@ import com.github.davidmoten.odata.client.RequestHeader;
 
 public final class BearerAuthenticator implements Authenticator {
 
-    private static final String GRAPH_EXPLORER_BASE_URL= "https://proxy.apisandbox.msdn.microsoft.com";
+    private static final String GRAPH_EXPLORER_BASE_URL= "https://graph.office.net";
 	private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
     private static final String OAUTH_BEARER_PREFIX = "Bearer ";
 

--- a/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
+++ b/odata-client-microsoft-client-builder/src/main/java/com/github/davidmoten/msgraph/builder/GraphExplorerHttpService.java
@@ -28,7 +28,7 @@ public final class GraphExplorerHttpService implements HttpService {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
-        return "https://proxy.apisandbox.msdn.microsoft.com/svc?url=" + x;
+        return "https://graph.office.net/en-us/graph/api/proxy?url=" + x;
     }
     
     @Override

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphExplorerMain.java
@@ -22,7 +22,7 @@ public class GraphExplorerMain {
 
         GraphService client = MsGraph.explorer().build();
         {
-            client.me().messages().get().stream().findFirst().ifPresent(a -> System.out.println(a.getSubject()));
+            client.me().messages().get().stream().findFirst().ifPresent(a -> System.out.println(a.getSubject().orElse("?")));
             System.exit(0);
         }
         {


### PR DESCRIPTION
Just noticed that this code was failing with a 403, turned out that Microsoft had moved the Graph Explorer sandbox to another host graph.office.net.