### PR TITLE
fix Email builder (builder methods not public, bodyType missed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ To help send an email a helper utility class called `Email` exists. Here's an ex
 Email
   .mailbox(mailbox) 
   .subject("hi there " + new Date())
+  .bodyType(BodyType.TEXT)
   .body("hello there how are you")
   .to("davidmoten@gmail.com")
   .header("x-security-classification", "OFFICIAL")

--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
@@ -32,370 +32,370 @@ import odata.msgraph.client.enums.BodyType;
 
 public final class Email {
 
-	public static Builder mailbox(String mailbox) {
-		return new Builder(mailbox);
-	}
+    public static Builder mailbox(String mailbox) {
+        return new Builder(mailbox);
+    }
 
-	public static final class Builder {
+    public static final class Builder {
 
-		private final String mailbox;
-		private String subject;
-		private String body;
-		private String from;
-		private final List<String> to = new ArrayList<>();
-		private final List<String> cc = new ArrayList<>();
-		private final List<String> bcc = new ArrayList<>();
-		private final List<Header> headers = new ArrayList<>();
-		
-		private String draftFolder = "Drafts";
-		private BodyType bodyType;
-		private final List<BuilderAttachment> attachments = new ArrayList<>();
+        private final String mailbox;
+        private String subject;
+        private String body;
+        private String from;
+        private final List<String> to = new ArrayList<>();
+        private final List<String> cc = new ArrayList<>();
+        private final List<String> bcc = new ArrayList<>();
+        private final List<Header> headers = new ArrayList<>();
+        
+        private String draftFolder = "Drafts";
+        private BodyType bodyType;
+        private final List<BuilderAttachment> attachments = new ArrayList<>();
 
-		Builder(String mailbox) {
-			this.mailbox = mailbox;
-			this.from = mailbox;
-		}
+        Builder(String mailbox) {
+            this.mailbox = mailbox;
+            this.from = mailbox;
+        }
 
-		public Builder1 subject(String subject) {
-			this.subject = subject;
-			return new Builder1(this);
-		}
+        public Builder1 subject(String subject) {
+            this.subject = subject;
+            return new Builder1(this);
+        }
 
-	}
+    }
 
-	public static final class Builder1 {
-		private final Builder b;
+    public static final class Builder1 {
+        private final Builder b;
 
-		Builder1(Builder b) {
-			this.b = b;
-		}
+        Builder1(Builder b) {
+            this.b = b;
+        }
 
-		public Builder2 bodyType(BodyType bodyType) {
-			b.bodyType = bodyType;
-			return new Builder2(b);
-		}
-	}
+        public Builder2 bodyType(BodyType bodyType) {
+            b.bodyType = bodyType;
+            return new Builder2(b);
+        }
+    }
 
-	public static final class Builder2 {
+    public static final class Builder2 {
 
-		private final Builder b;
+        private final Builder b;
 
-		Builder2(Builder b) {
-			this.b = b;
-		}
+        Builder2(Builder b) {
+            this.b = b;
+        }
 
-		public Builder4 body(String body) {
-			b.body = body;
-			return new Builder4(b);
-		}
-	}
+        public Builder4 body(String body) {
+            b.body = body;
+            return new Builder4(b);
+        }
+    }
 
-	public static final class Builder4 {
+    public static final class Builder4 {
 
-		private static final int ATTACHMENT_SIZE_THRESHOLD = 3000000;
-		private final Builder b;
+        private static final int ATTACHMENT_SIZE_THRESHOLD = 3000000;
+        private final Builder b;
 
-		Builder4(Builder b) {
-			this.b = b;
-		}
+        Builder4(Builder b) {
+            this.b = b;
+        }
 
-		public Builder4 from(String emailAddress) {
-			b.from = emailAddress;
-			return new Builder4(b);
-		}
+        public Builder4 from(String emailAddress) {
+            b.from = emailAddress;
+            return new Builder4(b);
+        }
 
-		public Builder4 to(String... emailAddresses) {
-			return to(Arrays.asList(emailAddresses));
-		}
+        public Builder4 to(String... emailAddresses) {
+            return to(Arrays.asList(emailAddresses));
+        }
 
-		public Builder4 to(Iterable<String> emailAddresses) {
-			for (String a : emailAddresses) {
-				b.to.add(a);
-			}
-			return this;
-		}
+        public Builder4 to(Iterable<String> emailAddresses) {
+            for (String a : emailAddresses) {
+                b.to.add(a);
+            }
+            return this;
+        }
 
-		public Builder4 cc(String... emailAddresses) {
-			return cc(Arrays.asList(emailAddresses));
-		}
+        public Builder4 cc(String... emailAddresses) {
+            return cc(Arrays.asList(emailAddresses));
+        }
 
-		public Builder4 cc(Iterable<String> emailAddresses) {
-			for (String a : emailAddresses) {
-				b.cc.add(a);
-			}
-			return this;
-		}
+        public Builder4 cc(Iterable<String> emailAddresses) {
+            for (String a : emailAddresses) {
+                b.cc.add(a);
+            }
+            return this;
+        }
 
-		public Builder4 bcc(String... emailAddresses) {
-			return bcc(Arrays.asList(emailAddresses));
-		}
+        public Builder4 bcc(String... emailAddresses) {
+            return bcc(Arrays.asList(emailAddresses));
+        }
 
-		public Builder4 bcc(List<String> emailAddresses) {
-			for (String a : emailAddresses) {
-				b.bcc.add(a);
-			}
-			return this;
-		}
+        public Builder4 bcc(List<String> emailAddresses) {
+            for (String a : emailAddresses) {
+                b.bcc.add(a);
+            }
+            return this;
+        }
 
-		public Builder4 saveDraftToFolder(String draftFolder) {
-			b.draftFolder = draftFolder;
-			return this;
-		}
-		
-		public Builder4 header(String name, String value) {
-		    Preconditions.checkNotNull(name);
-		    Preconditions.checkNotNull(value);
-		    b.headers.add(new Header(name, value));
-		    return this;
-		}
+        public Builder4 saveDraftToFolder(String draftFolder) {
+            b.draftFolder = draftFolder;
+            return this;
+        }
+        
+        public Builder4 header(String name, String value) {
+            Preconditions.checkNotNull(name);
+            Preconditions.checkNotNull(value);
+            b.headers.add(new Header(name, value));
+            return this;
+        }
 
-		public Builder6 attachment(String contentUtf8) {
-			return new BuilderAttachment(this).contentTextUtf8(contentUtf8);
-		}
+        public Builder6 attachment(String contentUtf8) {
+            return new BuilderAttachment(this).contentTextUtf8(contentUtf8);
+        }
 
-		public Builder6 attachment(byte[] content) {
-			return new BuilderAttachment(this).bytes(content);
-		}
-		
-		public Builder5 attachment(InputStream content) {
-			return new BuilderAttachment(this).inputStream(content);
-		}
-		
-		public Builder6 attachment(File file) {
-			return new BuilderAttachment(this).file(file);
-		}
+        public Builder6 attachment(byte[] content) {
+            return new BuilderAttachment(this).bytes(content);
+        }
+        
+        public Builder5 attachment(InputStream content) {
+            return new BuilderAttachment(this).inputStream(content);
+        }
+        
+        public Builder6 attachment(File file) {
+            return new BuilderAttachment(this).file(file);
+        }
 
-		public void send(GraphService client) {
-			MailFolderRequest drafts = client //
-					.users(b.mailbox) //
-					.mailFolders(b.draftFolder);
-			odata.msgraph.client.entity.Message.Builder builder = Message //
-					.builderMessage() //
-					.subject(b.subject) //
-					.body(ItemBody.builder() //
-							.content(b.body) //
-							.contentType(b.bodyType) //
-							.build()) //
-					.from(Recipient.builder() //
-							.emailAddress(EmailAddress //
-									.builder() //
-									.address(b.from) //
-									.build()) //
-							.build());
-			if (!b.to.isEmpty()) {
-				builder = builder.toRecipients(recipients(b.to));
-			}
-			if (!b.cc.isEmpty()) {
-				builder = builder.ccRecipients(recipients(b.cc));
-			}
-			if (!b.bcc.isEmpty()) {
-				builder = builder.ccRecipients(recipients(b.bcc));
-			}
-			if (!b.headers.isEmpty()) {
-			    List<InternetMessageHeader> headers = b.headers //
-			        .stream() //
-			        .map(x -> InternetMessageHeader //
-			                .builder() //
-			                .name(x.name) //
-			                .value(x.value) //
-			                .build()) //
-			        .collect(Collectors.toList());
-			    builder = builder.internetMessageHeaders(headers);
-			}
-			Message m = drafts.messages().post(builder.build());
+        public void send(GraphService client) {
+            MailFolderRequest drafts = client //
+                    .users(b.mailbox) //
+                    .mailFolders(b.draftFolder);
+            odata.msgraph.client.entity.Message.Builder builder = Message //
+                    .builderMessage() //
+                    .subject(b.subject) //
+                    .body(ItemBody.builder() //
+                            .content(b.body) //
+                            .contentType(b.bodyType) //
+                            .build()) //
+                    .from(Recipient.builder() //
+                            .emailAddress(EmailAddress //
+                                    .builder() //
+                                    .address(b.from) //
+                                    .build()) //
+                            .build());
+            if (!b.to.isEmpty()) {
+                builder = builder.toRecipients(recipients(b.to));
+            }
+            if (!b.cc.isEmpty()) {
+                builder = builder.ccRecipients(recipients(b.cc));
+            }
+            if (!b.bcc.isEmpty()) {
+                builder = builder.ccRecipients(recipients(b.bcc));
+            }
+            if (!b.headers.isEmpty()) {
+                List<InternetMessageHeader> headers = b.headers //
+                    .stream() //
+                    .map(x -> InternetMessageHeader //
+                            .builder() //
+                            .name(x.name) //
+                            .value(x.value) //
+                            .build()) //
+                    .collect(Collectors.toList());
+                builder = builder.internetMessageHeaders(headers);
+            }
+            Message m = drafts.messages().post(builder.build());
 
-			// upload attachments
-			for (BuilderAttachment a : b.attachments) {
-				// Upload attachment to the new mail
-				// We use different methods depending on the size of the attachment
-				// because will fail if doesn't match the right size window
-				if (a.file != null) {
-					a.length = a.file.length();
-				}
-				if (a.length < ATTACHMENT_SIZE_THRESHOLD) {
-					final byte[] contentBytes;
-					if (a.file != null) {
-						try {
-							contentBytes = Files.readAllBytes(a.file.toPath());
-						} catch (IOException e) {
-							throw new UncheckedIOException(e);
-						}
-					} else {
-						contentBytes = Util.read(a.inputStream);
-					}
-					client.users(b.mailbox) //
-							.messages(m.getId().get()) //
-							.attachments() //
-							.post(FileAttachment.builderFileAttachment() //
-									.name(a.name) //
-									.contentBytes(contentBytes) //
-									.contentType(a.contentMimeType) //
-									.build());
-				} else {
-					AttachmentItem ai = AttachmentItem //
-							.builder() //
-							.attachmentType(AttachmentType.FILE) //
-							.contentType(a.contentMimeType) //
-							.name(a.name) //
-							.size(a.length) //
-							.build();
+            // upload attachments
+            for (BuilderAttachment a : b.attachments) {
+                // Upload attachment to the new mail
+                // We use different methods depending on the size of the attachment
+                // because will fail if doesn't match the right size window
+                if (a.file != null) {
+                    a.length = a.file.length();
+                }
+                if (a.length < ATTACHMENT_SIZE_THRESHOLD) {
+                    final byte[] contentBytes;
+                    if (a.file != null) {
+                        try {
+                            contentBytes = Files.readAllBytes(a.file.toPath());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    } else {
+                        contentBytes = Util.read(a.inputStream);
+                    }
+                    client.users(b.mailbox) //
+                            .messages(m.getId().get()) //
+                            .attachments() //
+                            .post(FileAttachment.builderFileAttachment() //
+                                    .name(a.name) //
+                                    .contentBytes(contentBytes) //
+                                    .contentType(a.contentMimeType) //
+                                    .build());
+                } else {
+                    AttachmentItem ai = AttachmentItem //
+                            .builder() //
+                            .attachmentType(AttachmentType.FILE) //
+                            .contentType(a.contentMimeType) //
+                            .name(a.name) //
+                            .size(a.length) //
+                            .build();
 
-					StreamUploaderChunked uploader = client //
-							.users(a.sender.b.mailbox) //
-							.messages(m.getId().get()) //
-							.attachments() //
-							.createUploadSession(ai) //
-							.get() //
-							.putChunked();
-					if (a.readTimeoutMs == -1) {
-						uploader = uploader.readTimeout(a.readTimeoutMs, TimeUnit.MILLISECONDS);
-					}
-					if (a.file != null) {
-						uploader.upload(a.file, a.chunkSize, a.retries);
-					} else {
-						uploader.upload(a.inputStream, a.length, a.chunkSize, a.retries);
-					}
-				}
-			}
-			client //
-					.users(b.mailbox) //
-					.messages(m.getId().get()) //
-					.send() //
-					.call();
-		}
-	}
+                    StreamUploaderChunked uploader = client //
+                            .users(a.sender.b.mailbox) //
+                            .messages(m.getId().get()) //
+                            .attachments() //
+                            .createUploadSession(ai) //
+                            .get() //
+                            .putChunked();
+                    if (a.readTimeoutMs == -1) {
+                        uploader = uploader.readTimeout(a.readTimeoutMs, TimeUnit.MILLISECONDS);
+                    }
+                    if (a.file != null) {
+                        uploader.upload(a.file, a.chunkSize, a.retries);
+                    } else {
+                        uploader.upload(a.inputStream, a.length, a.chunkSize, a.retries);
+                    }
+                }
+            }
+            client //
+                    .users(b.mailbox) //
+                    .messages(m.getId().get()) //
+                    .send() //
+                    .call();
+        }
+    }
 
-	private static List<Recipient> recipients(List<String> emailAddresses) {
-		return emailAddresses.stream().map(x -> recipient(x)) //
-				.collect(Collectors.toList());
-	}
+    private static List<Recipient> recipients(List<String> emailAddresses) {
+        return emailAddresses.stream().map(x -> recipient(x)) //
+                .collect(Collectors.toList());
+    }
 
-	private static Recipient recipient(String emailAddress) {
-		return Recipient.builder() //
-				.emailAddress(EmailAddress.builder() //
-						.address(emailAddress) //
-						.build()) //
-				.build();
-	}
+    private static Recipient recipient(String emailAddress) {
+        return Recipient.builder() //
+                .emailAddress(EmailAddress.builder() //
+                        .address(emailAddress) //
+                        .build()) //
+                .build();
+    }
 
-	public static final class BuilderAttachment {
+    public static final class BuilderAttachment {
 
-		private long readTimeoutMs = -1; // use default
-		private String name = "attachment";
-		private final Builder4 sender;
-		private String contentMimeType = "application/octet-stream";
-		private File file;
-		private InputStream inputStream;
-		private long length;
-		private int chunkSize = 512 * 1024;
-		private Retries retries = Retries.NONE;
+        private long readTimeoutMs = -1; // use default
+        private String name = "attachment";
+        private final Builder4 sender;
+        private String contentMimeType = "application/octet-stream";
+        private File file;
+        private InputStream inputStream;
+        private long length;
+        private int chunkSize = 512 * 1024;
+        private Retries retries = Retries.NONE;
 
-		public BuilderAttachment(Builder4 sender) {
-			this.sender = sender;
-		}
+        BuilderAttachment(Builder4 sender) {
+            this.sender = sender;
+        }
 
-		Builder6 file(File file) {
-			this.file = file;
-			this.name = file.getName();
-			return new Builder6(this);
-		}
+        public Builder6 file(File file) {
+            this.file = file;
+            this.name = file.getName();
+            return new Builder6(this);
+        }
 
-		Builder5 inputStream(InputStream in) {
-			this.inputStream = in;
-			return new Builder5(this);
-		}
+        public Builder5 inputStream(InputStream in) {
+            this.inputStream = in;
+            return new Builder5(this);
+        }
 
-		Builder6 bytes(byte[] bytes) {
-			return inputStream(new ByteArrayInputStream(bytes)).length(bytes.length);
-		}
+        public Builder6 bytes(byte[] bytes) {
+            return inputStream(new ByteArrayInputStream(bytes)).length(bytes.length);
+        }
 
-		Builder6 contentTextUtf8(String text) {
-			return bytes(text.getBytes(StandardCharsets.UTF_8)).contentMimeType("text/plain");
-		}
+        public Builder6 contentTextUtf8(String text) {
+            return bytes(text.getBytes(StandardCharsets.UTF_8)).contentMimeType("text/plain");
+        }
 
-	}
+    }
 
-	public static final class Builder5 {
+    public static final class Builder5 {
 
-		private final BuilderAttachment attachment;
+        private final BuilderAttachment attachment;
 
-		Builder5(BuilderAttachment attachment) {
-			this.attachment = attachment;
-		}
+        Builder5(BuilderAttachment attachment) {
+            this.attachment = attachment;
+        }
 
-		public Builder6 length(long length) {
-			attachment.length = length;
-			return new Builder6(attachment);
-		}
-	}
+        public Builder6 length(long length) {
+            attachment.length = length;
+            return new Builder6(attachment);
+        }
+    }
 
-	public static final class Builder6 {
+    public static final class Builder6 {
 
-		private final BuilderAttachment attachment;
+        private final BuilderAttachment attachment;
 
-		public Builder6(BuilderAttachment attachment) {
-			this.attachment = attachment;
-		}
+        public Builder6(BuilderAttachment attachment) {
+            this.attachment = attachment;
+        }
 
-		public Builder6 contentMimeType(String mimeType) {
-			attachment.contentMimeType = mimeType;
-			return this;
-		}
+        public Builder6 contentMimeType(String mimeType) {
+            attachment.contentMimeType = mimeType;
+            return this;
+        }
 
-		public Builder6 readTimeout(long duration, TimeUnit unit) {
-			attachment.readTimeoutMs = unit.toMillis(duration);
-			return this;
-		}
+        public Builder6 readTimeout(long duration, TimeUnit unit) {
+            attachment.readTimeoutMs = unit.toMillis(duration);
+            return this;
+        }
 
-		public Builder6 chunkSize(int chunkSize) {
-			attachment.chunkSize = chunkSize;
-			return this;
-		}
+        public Builder6 chunkSize(int chunkSize) {
+            attachment.chunkSize = chunkSize;
+            return this;
+        }
 
-		public Builder6 retries(Retries retries) {
-			attachment.retries = retries;
-			return this;
-		}
-		
-		public Builder6 name(String name) {
-			attachment.name = name;
-			return this;
-		}
+        public Builder6 retries(Retries retries) {
+            attachment.retries = retries;
+            return this;
+        }
+        
+        public Builder6 name(String name) {
+            attachment.name = name;
+            return this;
+        }
 
-		public Builder6 attachment(File file) {
-			attachment.sender.b.attachments.add(attachment);
-			return attachment.sender.attachment(file);
-		}
-		
-		public Builder5 attachment(InputStream content) {
-			attachment.sender.b.attachments.add(attachment);
-			return attachment.sender.attachment(content);
-		}
-		
-		public Builder6 attachment(byte[] content) {
-			attachment.sender.b.attachments.add(attachment);
-			return attachment.sender.attachment(content);
-		}
-		
-		public Builder6 attachment(String content) {
-			attachment.sender.b.attachments.add(attachment);
-			return attachment.sender.attachment(content);
-		}
+        public Builder6 attachment(File file) {
+            attachment.sender.b.attachments.add(attachment);
+            return attachment.sender.attachment(file);
+        }
+        
+        public Builder5 attachment(InputStream content) {
+            attachment.sender.b.attachments.add(attachment);
+            return attachment.sender.attachment(content);
+        }
+        
+        public Builder6 attachment(byte[] content) {
+            attachment.sender.b.attachments.add(attachment);
+            return attachment.sender.attachment(content);
+        }
+        
+        public Builder6 attachment(String content) {
+            attachment.sender.b.attachments.add(attachment);
+            return attachment.sender.attachment(content);
+        }
 
-		public void send(GraphService client) {
-			attachment.sender.b.attachments.add(attachment);
-			attachment.sender.send(client);
-		}
+        public void send(GraphService client) {
+            attachment.sender.b.attachments.add(attachment);
+            attachment.sender.send(client);
+        }
 
-	}
-	
-	private static final class Header {
-	    final String name; 
-	    final String value;
+    }
+    
+    private static final class Header {
+        final String name; 
+        final String value;
 
-	    private Header(String name, String value) {
+        private Header(String name, String value) {
             this.name = name;
             this.value = value;
         }
-	}
+    }
 }

--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
@@ -56,17 +56,17 @@ public final class Email {
 			this.from = mailbox;
 		}
 
-		Builder2 subject(String subject) {
+		public Builder1 subject(String subject) {
 			this.subject = subject;
-			return new Builder2(this);
+			return new Builder1(this);
 		}
 
 	}
 
-	public static final class Builder11 {
+	public static final class Builder1 {
 		private final Builder b;
 
-		Builder11(Builder b) {
+		Builder1(Builder b) {
 			this.b = b;
 		}
 
@@ -84,7 +84,7 @@ public final class Email {
 			this.b = b;
 		}
 
-		Builder4 body(String body) {
+		public Builder4 body(String body) {
 			b.body = body;
 			return new Builder4(b);
 		}
@@ -99,73 +99,73 @@ public final class Email {
 			this.b = b;
 		}
 
-		Builder4 from(String emailAddress) {
+		public Builder4 from(String emailAddress) {
 			b.from = emailAddress;
 			return new Builder4(b);
 		}
 
-		Builder4 to(String... emailAddresses) {
+		public Builder4 to(String... emailAddresses) {
 			return to(Arrays.asList(emailAddresses));
 		}
 
-		Builder4 to(Iterable<String> emailAddresses) {
+		public Builder4 to(Iterable<String> emailAddresses) {
 			for (String a : emailAddresses) {
 				b.to.add(a);
 			}
 			return this;
 		}
 
-		Builder4 cc(String... emailAddresses) {
+		public Builder4 cc(String... emailAddresses) {
 			return cc(Arrays.asList(emailAddresses));
 		}
 
-		Builder4 cc(Iterable<String> emailAddresses) {
+		public Builder4 cc(Iterable<String> emailAddresses) {
 			for (String a : emailAddresses) {
 				b.cc.add(a);
 			}
 			return this;
 		}
 
-		Builder4 bcc(String... emailAddresses) {
+		public Builder4 bcc(String... emailAddresses) {
 			return bcc(Arrays.asList(emailAddresses));
 		}
 
-		Builder4 bcc(List<String> emailAddresses) {
+		public Builder4 bcc(List<String> emailAddresses) {
 			for (String a : emailAddresses) {
 				b.bcc.add(a);
 			}
 			return this;
 		}
 
-		Builder4 saveDraftToFolder(String draftFolder) {
+		public Builder4 saveDraftToFolder(String draftFolder) {
 			b.draftFolder = draftFolder;
 			return this;
 		}
 		
-		Builder4 header(String name, String value) {
+		public Builder4 header(String name, String value) {
 		    Preconditions.checkNotNull(name);
 		    Preconditions.checkNotNull(value);
 		    b.headers.add(new Header(name, value));
 		    return this;
 		}
 
-		Builder6 attachment(String contentUtf8) {
+		public Builder6 attachment(String contentUtf8) {
 			return new BuilderAttachment(this).contentTextUtf8(contentUtf8);
 		}
 
-		Builder6 attachment(byte[] content) {
+		public Builder6 attachment(byte[] content) {
 			return new BuilderAttachment(this).bytes(content);
 		}
 		
-		Builder5 attachment(InputStream content) {
+		public Builder5 attachment(InputStream content) {
 			return new BuilderAttachment(this).inputStream(content);
 		}
 		
-		Builder6 attachment(File file) {
+		public Builder6 attachment(File file) {
 			return new BuilderAttachment(this).file(file);
 		}
 
-		void send(GraphService client) {
+		public void send(GraphService client) {
 			MailFolderRequest drafts = client //
 					.users(b.mailbox) //
 					.mailFolders(b.draftFolder);

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -79,6 +79,7 @@ public class MsGraphMain {
 
             Email.mailbox(mailbox) //
                     .subject("hi there " + new Date()) //
+                    .bodyType(BodyType.TEXT) //
                     .body("hello there how are you") //
                     .to("davidmoten@gmail.com") //
                     .attachment(file) //

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
@@ -1,5 +1,6 @@
 package com.github.davidmoten.msgraph.email;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +35,13 @@ public final class EmailTest {
 				.attachment("some info for you") //
 				.name("info2.txt") //
 				.chunkSize(512 * 1024) //
+				.attachment(new byte[] {})
+				.contentMimeType("text/plain")
+				.name("empty.txt")
+				.attachment(new ByteArrayInputStream(new byte[] {0, 1})) //
+				.length(2) //
+				.name("two-bytes") //
+				.contentMimeType("application/octet-stream") //
 				.send(client);
 	}
 

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
@@ -1,4 +1,4 @@
-package com.github.davidmoten.msgraph;
+package com.github.davidmoten.msgraph.email;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -6,9 +6,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.github.davidmoten.msgraph.Email;
 import com.github.davidmoten.odata.client.Retries;
 
 import odata.msgraph.client.container.GraphService;
+import odata.msgraph.client.enums.BodyType;
 
 public final class EmailTest {
 
@@ -19,6 +21,7 @@ public final class EmailTest {
 		Email //
 				.mailbox("sender@marathon.com") //
 				.subject("Hi there") //
+				.bodyType(BodyType.TEXT) //
 				.body("Just a quick test") //
 				.to("dave@gmail.com") //
 				.bcc("sarah@gmail.com", "andrew@gmail.com") //


### PR DESCRIPTION
* Some builder methods were at default access and should have been public. 
* `bodyType` is required and is now included
* moved `EmailTest` to another package to test visibility

Apologies for including tab to spaces conversion as well.