### PR TITLE
Support attachment list in Email send builder

### DIFF
--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
@@ -148,6 +148,16 @@ public final class Email {
             b.headers.add(new Header(name, value));
             return this;
         }
+        
+        public Builder4 attachments(List<Attachment> attachments) {
+            b.attachments.addAll(attachments);
+            return this;
+        }
+        
+        public Builder4 attachments(Attachment... attachments) {
+            b.attachments.addAll(Arrays.asList(attachments));
+            return this;
+        }
 
         public Builder6 attachment(String contentUtf8) {
             return new BuilderAttachment(this).contentTextUtf8(contentUtf8);
@@ -244,7 +254,7 @@ public final class Email {
                             .build();
 
                     StreamUploaderChunked uploader = client //
-                            .users(a.sender.b.mailbox) //
+                            .users(b.mailbox) //
                             .messages(m.getId().get()) //
                             .attachments() //
                             .createUploadSession(ai) //
@@ -290,10 +300,9 @@ public final class Email {
         final long length;
         final int chunkSize;
         final Retries retries;
-        final Builder4 sender;
         
         Attachment(long readTimeoutMs, String name, String contentMimeType, File file,
-                InputStream inputStream, long length, int chunkSize, Retries retries, Builder4 sender) {
+                InputStream inputStream, long length, int chunkSize, Retries retries) {
             this.readTimeoutMs = readTimeoutMs;
             this.name = name;
             this.contentMimeType = contentMimeType;
@@ -302,7 +311,109 @@ public final class Email {
             this.length = length;
             this.chunkSize = chunkSize;
             this.retries = retries;
-            this.sender = sender;
+        }
+        
+        public static AttachmentBuilderHasLength file(File file) {
+            return new AttachmentBuilder().file(file);
+        }
+
+        public static AttachmentBuilderInputStream inputStream(InputStream in) {
+            return new AttachmentBuilder().inputStream(in);
+        }
+
+        public static AttachmentBuilderHasLength bytes(byte[] bytes) {
+            return new AttachmentBuilder().bytes(bytes);            
+        }
+
+        public static AttachmentBuilderHasLength contentTextUtf8(String text) {
+            return new AttachmentBuilder().contentTextUtf8(text);
+        }
+    
+    }
+    
+    public static final class AttachmentBuilder {
+        private long readTimeoutMs = -1; // use default
+        private String name = "attachment";
+        private String contentMimeType = "application/octet-stream";
+        private File file;
+        private InputStream inputStream;
+        private long length;
+        private int chunkSize = 512 * 1024;
+        private Retries retries = Retries.NONE;
+        
+        AttachmentBuilder() {
+            // prevent public instantiation
+        }
+        
+        public AttachmentBuilderHasLength file(File file) {
+            this.file = file;
+            this.name = file.getName();
+            return new AttachmentBuilderHasLength(this);
+        }
+
+        public AttachmentBuilderInputStream inputStream(InputStream in) {
+            this.inputStream = in;
+            return new AttachmentBuilderInputStream(this);
+        }
+
+        public AttachmentBuilderHasLength bytes(byte[] bytes) {
+            return inputStream(new ByteArrayInputStream(bytes)).length(bytes.length);
+        }
+
+        public AttachmentBuilderHasLength contentTextUtf8(String text) {
+            return bytes(text.getBytes(StandardCharsets.UTF_8)).contentMimeType("text/plain");
+        }
+    }
+    
+    public static final class AttachmentBuilderInputStream {
+
+        private final AttachmentBuilder b;
+
+        AttachmentBuilderInputStream(AttachmentBuilder b) {
+            this.b = b;
+        }
+
+        public AttachmentBuilderHasLength length(int length) {
+            b.length = length;
+            return new AttachmentBuilderHasLength(b);
+        }
+    }
+    
+    public static final class AttachmentBuilderHasLength {
+
+        private final AttachmentBuilder b;
+
+        AttachmentBuilderHasLength(AttachmentBuilder b) {
+            this.b = b;
+        }
+        
+        public AttachmentBuilderHasLength contentMimeType(String mimeType) {
+            b.contentMimeType = mimeType;
+            return this;
+        }
+
+        public AttachmentBuilderHasLength readTimeout(long duration, TimeUnit unit) {
+            b.readTimeoutMs = unit.toMillis(duration);
+            return this;
+        }
+
+        public AttachmentBuilderHasLength chunkSize(int chunkSize) {
+            b.chunkSize = chunkSize;
+            return this;
+        }
+
+        public AttachmentBuilderHasLength retries(Retries retries) {
+            b.retries = retries;
+            return this;
+        }
+        
+        public AttachmentBuilderHasLength name(String name) {
+            b.name = name;
+            return this;
+        }
+        
+        public Attachment build() {
+            return new Attachment(b.readTimeoutMs, b.name, b.contentMimeType, b.file, b.inputStream, b.length, b.chunkSize, b.retries);
         }
     }
 
@@ -343,7 +454,7 @@ public final class Email {
         
         // this should not be public
         Attachment createAttachment() {
-            return new Attachment(readTimeoutMs, name, contentMimeType, file, inputStream, length, chunkSize, retries, sender);
+            return new Attachment(readTimeoutMs, name, contentMimeType, file, inputStream, length, chunkSize, retries);
         }
 
     }

--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
@@ -331,15 +331,21 @@ public final class Email {
     
     }
     
+    private static final int DEFAULT_READ_TIMEOUT_MS = -1; // use default
+    private static final Retries DEFAULT_RETRIES = Retries.NONE;
+    private static final int DEFAULT_CHUNK_SIZE = 512 * 1024;
+    private static final String DEFAULT_CONTENT_MIME_TYPE = "application/octet-stream";
+    private static final String DEFAULT_ATTACHMENT_NAME = "attachment";
+    
     public static final class AttachmentBuilder {
-        private long readTimeoutMs = -1; // use default
-        private String name = "attachment";
-        private String contentMimeType = "application/octet-stream";
+        private long readTimeoutMs = DEFAULT_READ_TIMEOUT_MS; 
+        private String name = DEFAULT_ATTACHMENT_NAME;
+        private String contentMimeType = DEFAULT_CONTENT_MIME_TYPE;
         private File file;
         private InputStream inputStream;
         private long length;
-        private int chunkSize = 512 * 1024;
-        private Retries retries = Retries.NONE;
+        private int chunkSize = DEFAULT_CHUNK_SIZE;
+        private Retries retries = DEFAULT_RETRIES;
         
         AttachmentBuilder() {
             // prevent public instantiation
@@ -419,15 +425,15 @@ public final class Email {
 
     public static final class BuilderAttachment {
 
-        private long readTimeoutMs = -1; // use default
-        private String name = "attachment";
+        private long readTimeoutMs = DEFAULT_READ_TIMEOUT_MS; // use default
+        private String name = DEFAULT_ATTACHMENT_NAME;
         private final Builder4 sender;
-        private String contentMimeType = "application/octet-stream";
+        private String contentMimeType = DEFAULT_CONTENT_MIME_TYPE;
         private File file;
         private InputStream inputStream;
         private long length;
-        private int chunkSize = 512 * 1024;
-        private Retries retries = Retries.NONE;
+        private int chunkSize = DEFAULT_CHUNK_SIZE;
+        private Retries retries = DEFAULT_RETRIES;
 
         BuilderAttachment(Builder4 sender) {
             this.sender = sender;

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
@@ -8,6 +8,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.davidmoten.msgraph.Email;
+import com.github.davidmoten.msgraph.Email.Attachment;
 import com.github.davidmoten.odata.client.Retries;
 
 import odata.msgraph.client.container.GraphService;
@@ -15,34 +16,71 @@ import odata.msgraph.client.enums.BodyType;
 
 public final class EmailTest {
 
-	@Test
-	@Ignore
-	public void testSendMailCompiles() {
-		GraphService client = null;
-		Email //
-				.mailbox("sender@marathon.com") //
-				.subject("Hi there") //
-				.bodyType(BodyType.TEXT) //
-				.body("Just a quick test") //
-				.to("dave@gmail.com") //
-				.bcc("sarah@gmail.com", "andrew@gmail.com") //
-				.header("x-security-classification", "OFFICIAL") //
-				.attachment(new File("info.txt")) //
-				.contentMimeType("text/plain") //
-				.readTimeout(10, TimeUnit.MINUTES) //
-				.retries(Retries.builder().maxRetries(3).build()) //
-				.name("more-info.txt") //
-				.attachment("some info for you") //
-				.name("info2.txt") //
-				.chunkSize(512 * 1024) //
-				.attachment(new byte[] {})
-				.contentMimeType("text/plain")
-				.name("empty.txt")
-				.attachment(new ByteArrayInputStream(new byte[] {0, 1})) //
-				.length(2) //
-				.name("two-bytes") //
-				.contentMimeType("application/octet-stream") //
-				.send(client);
-	}
+    @Test
+    @Ignore
+    public void testSendMailCompiles() {
+        GraphService client = null;
+        Email //
+                .mailbox("sender@marathon.com") //
+                .subject("Hi there") //
+                .bodyType(BodyType.TEXT) //
+                .body("Just a quick test") //
+                .to("dave@gmail.com") //
+                .bcc("sarah@gmail.com", "andrew@gmail.com") //
+                .header("x-security-classification", "OFFICIAL") //
+                .attachment(new File("info.txt")) //
+                .contentMimeType("text/plain") //
+                .readTimeout(10, TimeUnit.MINUTES) //
+                .retries(Retries.builder().maxRetries(3).build()) //
+                .name("more-info.txt") //
+                .attachment("some info for you") //
+                .name("info2.txt") //
+                .chunkSize(512 * 1024) //
+                .attachment(new byte[] {}).contentMimeType("text/plain").name("empty.txt")
+                .attachment(new ByteArrayInputStream(new byte[] {0, 1})) //
+                .length(2) //
+                .name("two-bytes") //
+                .contentMimeType("application/octet-stream") //
+                .send(client);
+    }
+
+    @Test
+    @Ignore
+    public void testSendMailListAttachmentsCompiles() {
+        GraphService client = null;
+        Attachment a1 = Attachment //
+                .file(new File("info.txt")) //
+                .contentMimeType("text/plain") //
+                .readTimeout(10, TimeUnit.MINUTES) //
+                .retries(Retries.builder().maxRetries(3).build()) //
+                .name("more-info.txt") //
+                .build();
+        Attachment a2 = Attachment //
+                .contentTextUtf8("some info for you") //
+                .name("info2.txt") //
+                .chunkSize(512 * 1024) //
+                .build();
+        Attachment a3 = Attachment //
+                .bytes(new byte[] {}) //
+                .contentMimeType("text/plain") //
+                .name("empty.txt")//
+                .build();
+        Attachment a4 = Attachment //
+                .inputStream(new ByteArrayInputStream(new byte[] {0, 1})) //
+                .length(2) //
+                .name("two-bytes") //
+                .contentMimeType("application/octet-stream") //
+                .build();
+        Email //
+                .mailbox("sender@marathon.com") //
+                .subject("Hi there") //
+                .bodyType(BodyType.TEXT) //
+                .body("Just a quick test") //
+                .to("dave@gmail.com") //
+                .bcc("sarah@gmail.com", "andrew@gmail.com") //
+                .header("x-security-classification", "OFFICIAL") //
+                .attachments(a1, a2, a3, a4) //
+                .send(client);
+    }
 
 }

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/email/EmailTest.java
@@ -36,7 +36,9 @@ public final class EmailTest {
                 .attachment("some info for you") //
                 .name("info2.txt") //
                 .chunkSize(512 * 1024) //
-                .attachment(new byte[] {}).contentMimeType("text/plain").name("empty.txt")
+                .attachment(new byte[] {}) //
+                .contentMimeType("text/plain") //
+                .name("empty.txt")
                 .attachment(new ByteArrayInputStream(new byte[] {0, 1})) //
                 .length(2) //
                 .name("two-bytes") //


### PR DESCRIPTION
The builder already allows the specification of attachments using method and builder chaining but is not at all convenient if you have an arbitrary list of attachments you need to specify.

This PR adds `.attachments(List<Attachment>)` to the builder  (and `Attachment.*` builder methods as well.

See the new test in this PR for an example.