### PR TITLE
Support json enum default value for deserializing unknown values (evolvable enums)

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -493,20 +493,15 @@ public final class Generator {
 				// add members
 				indent.right();
 				String s = Util.filter(t.getMemberOrAnnotation(), TEnumTypeMember.class) //
-						.map(x -> String.format("%s@%s(\"%s\")%s\n%s%s(\"%s\", \"%s\")", //
-								indent, //
-								imports.add(JsonProperty.class), //
-								x.getName(), //
-								names //
-	                                    .getOptions(schema) //
-	                                    .enumDefaultValues() //
-	                                    .contains(x.getName()) ?  //
-	                                        String.format("\n%s@%s", indent, imports.add(JsonEnumDefaultValue.class)) //
-	                                        : "", 
-								indent, //
-								names.getEnumInstanceName(t, x.getName()), //
-								x.getName(), //
-								x.getValue()))
+                        .map(x -> String.format("%s@%s(\"%s\")%s\n%s%s(\"%s\", \"%s\")", //
+                                indent, //
+                                imports.add(JsonProperty.class), //
+                                x.getName(), //
+                                jsonEnumDefaultValueAnnotation(schema, imports, indent, x),
+                                indent, //
+                                names.getEnumInstanceName(t, x.getName()), //
+                                x.getName(), //
+                                x.getValue()))
 						.collect(Collectors.joining(",\n\n"));
 				indent.left();
 				p.format("\n%s;\n\n", s);
@@ -542,6 +537,16 @@ public final class Generator {
 			throw new RuntimeException(e);
 		}
 	}
+
+    private String jsonEnumDefaultValueAnnotation(Schema schema, Imports imports, Indent indent, TEnumTypeMember x) {
+        return names //
+                .getOptions(schema) //
+                .enumDefaultValues() //
+                .contains(x.getName()) ? //
+                        String.format("\n%s@%s", indent,
+                                imports.add(JsonEnumDefaultValue.class)) //
+                        : "";
+    }
 
 	private void writeEntity(TEntityType entityType, Map<String, List<Action>> typeActions,
 			Map<String, List<Function>> typeFunctions) {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -39,6 +39,7 @@ import org.oasisopen.odata.csdl.v4.TSingleton;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -492,10 +493,16 @@ public final class Generator {
 				// add members
 				indent.right();
 				String s = Util.filter(t.getMemberOrAnnotation(), TEnumTypeMember.class) //
-						.map(x -> String.format("%s@%s(\"%s\")\n%s%s(\"%s\", \"%s\")", //
+						.map(x -> String.format("%s@%s(\"%s\")%s\n%s%s(\"%s\", \"%s\")", //
 								indent, //
 								imports.add(JsonProperty.class), //
 								x.getName(), //
+								names //
+	                                    .getOptions(schema) //
+	                                    .enumDefaultValues() //
+	                                    .contains(x.getName()) ?  //
+	                                        String.format("\n%s@%s", indent, imports.add(JsonEnumDefaultValue.class)) //
+	                                        : "", 
 								indent, //
 								names.getEnumInstanceName(t, x.getName()), //
 								x.getName(), //

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/SchemaOptions.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/SchemaOptions.java
@@ -1,5 +1,8 @@
 package com.github.davidmoten.odata.client.generator;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class SchemaOptions {
     public final String namespace;
     public final String pkg;
@@ -15,6 +18,7 @@ public class SchemaOptions {
     public final String entityRequestClassSuffix;
     public final boolean pageComplexTypes;
     public final boolean failOnMissingEntitySet;
+    public final Set<String> enumDefaultValues;
     
     // TODO make configurable
     private static final String PACKAGE_SUFFIX_COMPLEX_TYPE_COLLECTION_REQUEST = ".complex.collection.request";
@@ -25,7 +29,8 @@ public class SchemaOptions {
             String packageSuffixContainer,
             String packageSuffixSchema, String simpleClassNameSchema,
             String collectionRequestClassSuffix, String entityRequestClassSuffix,
-            boolean pageComplexTypes, boolean failOnMissingEntitySet) {
+            boolean pageComplexTypes, boolean failOnMissingEntitySet, //
+            Set<String> enumDefaultValues) {
         this.namespace = namespace;
         this.pkg = pkg;
         this.packageSuffixEnum = packageSuffixEnum;
@@ -40,11 +45,12 @@ public class SchemaOptions {
         this.entityRequestClassSuffix = entityRequestClassSuffix;
         this.pageComplexTypes = pageComplexTypes;
         this.failOnMissingEntitySet = failOnMissingEntitySet;
+        this.enumDefaultValues = enumDefaultValues;
     }
 
     public SchemaOptions(String namespace, String pkg) {
         this(namespace, pkg, ".enums", ".entity", ".complex", ".entity.request", ".collection.request",
-                ".container", ".schema", "SchemaInfo", "CollectionRequest", "EntityRequest", true, true);
+                ".container", ".schema", "SchemaInfo", "CollectionRequest", "EntityRequest", true, true, Collections.emptySet());
     }
 
     public String pkg() {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/SchemaOptions.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/SchemaOptions.java
@@ -109,5 +109,9 @@ public class SchemaOptions {
         // TODO make configurable
         return packageSuffixEntity() + ".set";
     }
+    
+    public Set<String> enumDefaultValues() {
+        return enumDefaultValues;
+    }
 
 }

--- a/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
+++ b/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
@@ -6,19 +6,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -31,6 +29,9 @@ import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
 import com.github.davidmoten.odata.client.generator.Generator;
 import com.github.davidmoten.odata.client.generator.Options;
 import com.github.davidmoten.odata.client.generator.SchemaOptions;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class GeneratorMojo extends AbstractMojo {
@@ -49,17 +50,23 @@ public class GeneratorMojo extends AbstractMojo {
 
     @Parameter(name = "pageComplexTypes", required = false, defaultValue = "true")
     boolean pageComplexTypes;
+    
+    @Parameter(name="enumDefaultValues", required = false) 
+    List<String> enumDefaultValues;
 
     @Parameter(name = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/java")
     File outputDirectory;
 
-    @Component
+    @Parameter( defaultValue = "${project}", readonly = true )
     MavenProject project;
 
     @Override
     public void execute() throws MojoExecutionException {
         if (schemas == null) {
             schemas = Collections.emptyList();
+        }
+        if (enumDefaultValues == null) {
+            enumDefaultValues = Collections.emptyList();
         }
         List<SchemaOptions> schemaOptionsList = schemas.stream()
                 .map(s -> new SchemaOptions(s.namespace, s.packageName, s.packageSuffixEnum,
@@ -69,7 +76,8 @@ public class GeneratorMojo extends AbstractMojo {
                         s.packageSuffixSchema, s.simpleClassNameSchema,
                         s.collectionRequestClassSuffix, s.entityRequestClassSuffix,
                         s.pageComplexTypes, //
-                        s.failOnMissingEntitySet))
+                        s.failOnMissingEntitySet, 
+                        new HashSet<>(enumDefaultValues)))
                 .collect(Collectors.toList());
 
         InputStream is = null;

--- a/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
+++ b/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
@@ -51,8 +51,8 @@ public class GeneratorMojo extends AbstractMojo {
     @Parameter(name = "pageComplexTypes", required = false, defaultValue = "true")
     boolean pageComplexTypes;
     
-    @Parameter(name="enumDefaultValues", required = false) 
-    List<String> enumDefaultValues;
+    @Parameter(name="enumDefaultValue", required = false) 
+    List<String> enumDefaultValue;
 
     @Parameter(name = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/java")
     File outputDirectory;
@@ -65,8 +65,8 @@ public class GeneratorMojo extends AbstractMojo {
         if (schemas == null) {
             schemas = Collections.emptyList();
         }
-        if (enumDefaultValues == null) {
-            enumDefaultValues = Collections.emptyList();
+        if (enumDefaultValue == null) {
+            enumDefaultValue = Collections.emptyList();
         }
         List<SchemaOptions> schemaOptionsList = schemas.stream()
                 .map(s -> new SchemaOptions(s.namespace, s.packageName, s.packageSuffixEnum,
@@ -77,7 +77,7 @@ public class GeneratorMojo extends AbstractMojo {
                         s.collectionRequestClassSuffix, s.entityRequestClassSuffix,
                         s.pageComplexTypes, //
                         s.failOnMissingEntitySet, 
-                        new HashSet<>(enumDefaultValues)))
+                        new HashSet<>(enumDefaultValue)))
                 .collect(Collectors.toList());
 
         InputStream is = null;

--- a/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
+++ b/odata-client-maven-plugin/src/main/java/org/davidmoten/odata/client/maven/GeneratorMojo.java
@@ -51,8 +51,8 @@ public class GeneratorMojo extends AbstractMojo {
     @Parameter(name = "pageComplexTypes", required = false, defaultValue = "true")
     boolean pageComplexTypes;
     
-    @Parameter(name="enumDefaultValue", required = false) 
-    List<String> enumDefaultValue;
+    @Parameter(name="enumDefaultValues", required = false) 
+    List<String> enumDefaultValues;
 
     @Parameter(name = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/java")
     File outputDirectory;
@@ -65,8 +65,8 @@ public class GeneratorMojo extends AbstractMojo {
         if (schemas == null) {
             schemas = Collections.emptyList();
         }
-        if (enumDefaultValue == null) {
-            enumDefaultValue = Collections.emptyList();
+        if (enumDefaultValues == null) {
+            enumDefaultValues = Collections.emptyList();
         }
         List<SchemaOptions> schemaOptionsList = schemas.stream()
                 .map(s -> new SchemaOptions(s.namespace, s.packageName, s.packageSuffixEnum,
@@ -77,7 +77,7 @@ public class GeneratorMojo extends AbstractMojo {
                         s.collectionRequestClassSuffix, s.entityRequestClassSuffix,
                         s.pageComplexTypes, //
                         s.failOnMissingEntitySet, 
-                        new HashSet<>(enumDefaultValue)))
+                        new HashSet<>(enumDefaultValues)))
                 .collect(Collectors.toList());
 
         InputStream is = null;
@@ -86,6 +86,7 @@ public class GeneratorMojo extends AbstractMojo {
             if (cis == null) {
                 File metadataFile = new File(metadata);
                 System.out.println("metadataFile = " + metadataFile.getAbsolutePath());
+                System.out.println("enumDefaultValues = " + enumDefaultValues);
                 if (metadataFile.exists()) {
                     is = new FileInputStream(metadataFile);
                 } else {

--- a/odata-client-msgraph-beta/pom.xml
+++ b/odata-client-msgraph-beta/pom.xml
@@ -66,6 +66,9 @@
                         </goals>
                         <configuration>
                             <metadata>src/main/odata/msgraph-beta-metadata.xml</metadata>
+                            <enumDefaultValues>
+                                 <enumDefaultValue>unknownFutureValue</enumDefaultValue>
+                            </enumDefaultValues>
                             <schemas>
                                 <schema>
                                     <namespace>microsoft.graph</namespace>

--- a/odata-client-msgraph/pom.xml
+++ b/odata-client-msgraph/pom.xml
@@ -67,6 +67,9 @@
                         </goals>
                         <configuration>
                             <metadata>../odata-client-generator/src/main/odata/msgraph-metadata.xml</metadata>
+                            <enumDefaultValues>
+                                <enumDefaultValue>unknownFutureValue</enumDefaultValue>
+                            </enumDefaultValues>
                             <schemas>
                                 <schema>
                                     <namespace>microsoft.graph</namespace>

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -71,7 +71,7 @@ public final class Serializer {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) //
                 .setSerializationInclusion(includeNulls ? Include.ALWAYS : Include.NON_NULL) //
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) //
-                
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE) //
                 // StdDateFormat is ISO8601 since jackson 2.9
                 .setDateFormat(new StdDateFormat().withColonInTimeZone(true));
     }

--- a/odata-client-test-unit/pom.xml
+++ b/odata-client-test-unit/pom.xml
@@ -87,6 +87,9 @@
                         </goals>
                         <configuration>
                             <metadata>src/main/odata/metadata3.xml</metadata>
+                            <enumDefaultValues>
+                               <enumDefaultValue>futureValue</enumDefaultValue>
+                            </enumDefaultValues>
                             <schemas>
                                 <schema>
                                     <namespace>Test3.A</namespace>

--- a/odata-client-test-unit/src/main/odata/metadata3.xml
+++ b/odata-client-test-unit/src/main/odata/metadata3.xml
@@ -12,6 +12,7 @@
                 <Member Name="thursday" Value="4" />
                 <Member Name="friday" Value="5" />
                 <Member Name="saturday" Value="6" />
+                <Member Name="futureValue" Value="7" />
             </EnumType>
         </Schema>
         <Schema Namespace="Test3.B"

--- a/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test3ServiceTest.java
+++ b/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test3ServiceTest.java
@@ -1,0 +1,20 @@
+package com.github.davidmoten.odata.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.github.davidmoten.odata.client.Serializer;
+
+import test3a.enums.DayOfWeek;
+
+public class Test3ServiceTest {
+    
+    @Test
+    public void testEnumDefaultValue() {
+        assertEquals("\"futureValue\"", Serializer.INSTANCE.serialize(DayOfWeek.FUTURE_VALUE));
+        assertEquals(DayOfWeek.MONDAY, Serializer.INSTANCE.deserialize("\"monday\"", DayOfWeek.class));
+        assertEquals(DayOfWeek.FUTURE_VALUE, Serializer.INSTANCE.deserialize("\"blah\"", DayOfWeek.class));
+    }
+
+}


### PR DESCRIPTION
As raised in #298, when a special request header (`Prefer: include-unknown-enum-members`) is set a returned value that is an EnumType may fail to deserialize (will throw). Microsoft Graph uses a sentinel value `unknownFutureValue` in enums that is an obvious target to use for unknown values. When this enum value is present we can annotate the member with `@JsonEnumDefaultValue` and deserialization will associate unknown values with that member (admittedly with the loss of the actual enumerated value).

This is an important enhancement because Microsoft add new members to existing Graph enumeration types all the time (I see them when I review metadata changes every month). Many enumerations appear to have the `unknownFutureValue` sentinel (231 of 429 EnumTypes across the Graph API have the sentinel now). If a new value is returned (without you specifying the special header) your application can break which is obviously bad. This PR provides protection against that scenario.

From https://learn.microsoft.com/en-us/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations:

>**Handling future members in evolvable enumerations**
>Adding members to existing enumerations can break applications already using these enums. Evolvable enums is a mechanism that Microsoft Graph API uses to add new members to existing enumerations without causing a breaking change for applications.
>
>Evolvable enums have a common sentinel member called unknownFutureValue that demarcates known members that have been defined in the enum initially, and unknown members that are added subsequently or will be defined in the future. Internally, known members are mapped to numeric values that are less than the sentinel member, and unknown members are greater than the sentinel member. The documentation for an evolvable enum lists the possible string values in ascending order: known members, followed by unknownFutureValue, followed by unknown members. Like other types of enumerations, you should always reference members of evolvable enums by their string values.
>
>By default, a GET operation returns only known members for properties of evolvable enum types and your application needs to handle only the known members. If you design your application to handle unknown members as well, you can opt-in to receive those members by using an HTTP  request header `Prefer: include-unknown-enum-members`.

This PR adds protection so that deserializing an unknown enum member will not fail but will be deserialized to an enum default value if specified. Enum default values are specified in the configuration of the odata-client-maven-plugin at the schema level like so:

https://github.com/davidmoten/odata-client/blob/4887d3c9c12d6e06b3b9eefa9546ad054cd0954b/odata-client-msgraph/pom.xml#L68-L72

The PR includes a unit test.

