### PR TITLE
ensure reserved words are checked using lower case

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
@@ -205,7 +205,7 @@ public final class Names {
         if (name.equalsIgnoreCase("class")) {
             name = "cls";
         }
-        if (javaReservedWords.contains(name)) {
+        if (javaReservedWords.contains(name.toLowerCase(Locale.ENGLISH))) {
             name += "_";
         }
         return lowerFirst(name);

--- a/odata-client-test-unit/src/main/odata/metadata1.xml
+++ b/odata-client-test-unit/src/main/odata/metadata1.xml
@@ -11,6 +11,14 @@
                 <Property Name="ID" Type="Edm.Int32"
                     Nullable="false" />
                 <Property Name="Name" Type="Edm.String" />
+                <NavigationProperty Name="Package" Type="Test1.A.Package" />
+            </EntityType>
+            <EntityType Name="Package">
+                <Key>
+                    <PropertyRef Name="ID" />
+                </Key>
+                <Property Name="ID" Type="Edm.Int32"
+                    Nullable="false" />
             </EntityType>
         </Schema>
         <Schema Namespace="Test1.B"
@@ -18,6 +26,9 @@
             <EntityContainer Name="Test1Service">
                 <EntitySet Name="Products"
                     EntityType="Test1.A.Product">
+                </EntitySet>
+                <EntitySet Name="Packages"
+                    EntityType="Test1.A.Package">
                 </EntitySet>
             </EntityContainer>
         </Schema>


### PR DESCRIPTION
... in method `Names.getGetterMethodWithoutGet`. 

Raised in #347

This PR includes a unit test that failed with a compile error to demonstrate the problem.