### PR TITLE
remove stream limit of 5MB so don't fail downloading big emails/files

### DIFF
--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/Serializer.java
@@ -59,8 +59,6 @@ public final class Serializer {
 
     public static final Serializer INSTANCE = new Serializer();
 
-    private static final int JACKSON_MAX_STRING_LENGTH = 100_000_000;
-
     private Serializer() {
         // prevent instantiation
     }
@@ -83,7 +81,7 @@ public final class Serializer {
             .getFactory()
             .setStreamReadConstraints(StreamReadConstraints //
                     .builder() //
-                    .maxStringLength(JACKSON_MAX_STRING_LENGTH) //
+                    .maxStringLength(Integer.MAX_VALUE) //
                     .build());
         return m;
     }


### PR DESCRIPTION
Jackson 2.15 introduced a stream size limit so that Jackson would not deserialize >5MB streams (!!!).

This PR modifies the ObjectMappers held in Serializer.java to allow unlimited streams as before. A later change will allow customizations of the Serializer ObjectMapper so that users can make adjustments themselves.