### PR TITLE
Ensure Function parameters are url query parameters when a collection is returned

### DIFF
--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -270,7 +270,7 @@ public class GraphServiceTest {
     @Test
     public void testUsersDeltaTokenLatest() {
         GraphService client = clientBuilder() //
-                .expectRequest("/users/delta?$deltatoken=latest") //
+                .expectRequest("/users/delta()?$deltatoken=latest") //
                 .withRequestHeadersStandard() //
                 .withResponse("/response-users-delta-latest.json") //
                 .expectRequest("/users/delta?$deltatoken=1234") //
@@ -294,9 +294,9 @@ public class GraphServiceTest {
     }
 
     @Test
-    public void testUsersDeltaNextDeltaWorsWithoutReadingStreamFully() {
+    public void testUsersDeltaNextDeltaWorksWithoutReadingStreamFully() {
         GraphService client = clientBuilder() //
-                .expectRequest("/users/delta?$deltatoken=latest") //
+                .expectRequest("/users/delta()?$deltatoken=latest") //
                 .withResponse("/response-users-delta-latest.json") //
                 .withRequestHeadersStandard() //
                 .expectRequest("/users/delta?$deltatoken=1234") //
@@ -626,7 +626,7 @@ public class GraphServiceTest {
     @Test
     public void testSupplementWithDeltaLinkWhenCollectionEmpty() {
         GraphService client = clientBuilder() //
-                .expectRequest("/users/delta?$deltatoken=latest") //
+                .expectRequest("/users/delta()?$deltatoken=latest") //
                 .withResponse("/response-users-delta-empty.json") //
                 .withRequestHeadersStandard() //
                 .build();
@@ -872,7 +872,7 @@ public class GraphServiceTest {
     public void testFunctionBoundToCollection() {
         GraphService client = clientBuilder() //
                 .expectRequest(
-                        "/users/fred/mailFolders/inbox/messages/delta?$filter=receivedDateTime%2Bge%2B12345&$orderby=receivedDateTime%2Bdesc") //
+                        "/users/fred/mailFolders/inbox/messages/delta()?$filter=receivedDateTime%2Bge%2B12345&$orderby=receivedDateTime%2Bdesc") //
                 .withPayload("/request-messages-delta.json") //
                 .withResponse("/response-messages-delta.json") //
                 .withRequestHeadersStandard() //

--- a/odata-client-test-unit/src/main/odata/metadata6.xml
+++ b/odata-client-test-unit/src/main/odata/metadata6.xml
@@ -79,6 +79,17 @@
                     Nullable="false" />
                 <ReturnType Type="Edm.Int32" Nullable="false" />
             </Function>
+            <Function Name="relatedProducts2" IsBound="true"
+                EntitySetPath="bindingParameter">
+                <Parameter Name="bindingParameter"
+                    Type="Test6.A.Product" Nullable="false" />
+                <Parameter Name="strength" Type="Edm.Int32"
+                    Nullable="false" />
+                <Parameter Name="thresholds"
+                    Type="Collection(Edm.Int32)" Nullable="false" />
+                <ReturnType Type="Collection(Edm.String)"
+                    Nullable="false" />
+            </Function>
             <EntityContainer Name="Test6ServiceA">
                 <EntitySet Name="Products"
                     EntityType="Test6.A.Product">

--- a/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test6ServiceTest.java
+++ b/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test6ServiceTest.java
@@ -33,6 +33,22 @@ public class Test6ServiceTest {
                 .metadataFull() //
                 .get();
     }
+    
+    @Test
+    public void testFunctionReturningCollection() {
+        Test6Service client = Test6Service.test() //
+                .expectRequest(
+                        "/Products/1/Test6.A.relatedProducts2(strength%3D123%2Cthresholds%3D%5B10%2C20%2C30%5D)?$select=Name") //
+                .withResponse("/response-function-returns-empty-collection.json") //
+                .withRequestHeaders( //
+                        RequestHeader.ODATA_VERSION, //
+                        RequestHeader.ACCEPT_JSON_METADATA_MINIMAL) //
+                .build();
+        CollectionPage<String> page = client.products(1) //
+                .relatedProducts2(123, Lists.newArrayList(10, 20, 30)) //
+                .select("Name") //
+                .get();
+    }
 
     // @Test
     // @Ignore

--- a/odata-client-test-unit/src/test/resources/response-function-returns-empty-collection.json
+++ b/odata-client-test-unit/src/test/resources/response-function-returns-empty-collection.json
@@ -1,0 +1,4 @@
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('48d31887-5fad-4d73-a9f5-3c356e68a038')/messages",
+    "value": [] 
+}


### PR DESCRIPTION
See #439

I checked the OData v4.01 [spec](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_Functions) on this and a Function should use *inline parameter syntax*. This PR ensure that.

A unit test is added to test this scenario.