### PR TITLE
return optional from post and patch calls in case no content in response #450

### DIFF
--- a/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
+++ b/odata-client-msgraph/src/main/java/com/github/davidmoten/msgraph/Email.java
@@ -272,7 +272,7 @@ public final class Email {
                     .collect(Collectors.toList());
                 builder = builder.internetMessageHeaders(headers);
             }
-            Message m = drafts.messages().post(builder.build());
+            Message m = drafts.messages().post(builder.build()).get();
 
             // upload attachments
             for (Attachment a : b.attachments) {

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/GraphServiceTest.java
@@ -451,7 +451,7 @@ public class GraphServiceTest {
                                 .build()) //
                         .build()) //
                 .build();
-        m = drafts.messages().post(m);
+        m = drafts.messages().post(m).get();
 
         AttachmentItem a = AttachmentItem //
                 .builder() //
@@ -1209,7 +1209,7 @@ public class GraphServiceTest {
                         UploadSession.class, //
                         HttpRequestOptions.EMPTY, //
                         RequestHeader.ODATA_VERSION, //
-                        RequestHeader.CONTENT_TYPE_JSON);
+                        RequestHeader.CONTENT_TYPE_JSON).get();
         assertEquals("https://blah", u.getUploadUrl().get());
     }
 

--- a/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
+++ b/odata-client-msgraph/src/test/java/com/github/davidmoten/msgraph/MsGraphMain.java
@@ -107,7 +107,7 @@ public class MsGraphMain {
                                     .build())
                             .build())
                     .build();
-            m = drafts.messages().post(m);
+            m = drafts.messages().post(m).get();
 
             System.out.println("file size=" + file.length());
             // upload a big attachment using an upload session
@@ -210,7 +210,7 @@ public class MsGraphMain {
                     .build();
 
             // Create the draft message
-            Message saved = drafts.messages().post(m);
+            Message saved = drafts.messages().post(m).get();
             System.out.println("saved=" + saved);
 
             // change subject

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ActionRequestReturningNonCollectionUnwrapped.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/ActionRequestReturningNonCollectionUnwrapped.java
@@ -22,7 +22,8 @@ public final class ActionRequestReturningNonCollectionUnwrapped<T>
                 ParameterMap.toMap(parameters), //
                 contextPath, //
                 returnClass, //
-                options()); //
+                options()) //
+                .get(); //
     }
 
 }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionEntityRequestOptionsBuilder.java
@@ -195,11 +195,11 @@ public final class CollectionEntityRequestOptionsBuilder<T extends ODataEntityTy
     	return function.apply(get());
     }
 
-    public T post(T entity) {
+    public Optional<T> post(T entity) {
         return request.post(build(), entity);
     }
     
-    public T patch(T entity) {
+    public Optional<T> patch(T entity) {
         return request.patch(build(), entity);
     }
 

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CollectionPageEntityRequest.java
@@ -56,11 +56,11 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
         }
     }
 
-    T post(CollectionRequestOptions options, T entity) {
+    Optional<T> post(CollectionRequestOptions options, T entity) {
         return RequestHelper.post(entity, contextPath, cls, options);
     }
     
-    T patch(CollectionRequestOptions options, T entity) {
+    Optional<T> patch(CollectionRequestOptions options, T entity) {
         return RequestHelper.patch(entity, contextPath, cls, options);
     }
 
@@ -93,11 +93,11 @@ public class CollectionPageEntityRequest<T extends ODataEntityType, R extends En
         return get().toList();
     }
 
-    public T post(T entity) {
+    public Optional<T> post(T entity) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).post(entity);
     }
     
-    public T patch(T entity) {
+    public Optional<T> patch(T entity) {
         return new CollectionEntityRequestOptionsBuilder<T, R>(this).patch(entity);
     }
     

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/CustomRequest.java
@@ -79,29 +79,29 @@ public final class CustomRequest {
         RequestHelper.post(content, info.contextPath, contentClass, info);
     }
     
-    public <T> T submit(String url, Object content, Class<T> responseClass,
+    public <T> Optional<T> submit(String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
         UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         return RequestHelper.postAny(content, info.contextPath, responseClass, info);
     }
     
-    public <T> T submit(HttpMethod method, String url, Object content, Class<T> responseClass,
+    public <T> Optional<T> submit(HttpMethod method, String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
         UrlInfo info = getInfo(context, toAbsoluteUrl(url), headers, options);
         return RequestHelper.submitAny(method, content, info.contextPath, responseClass, info);
     }
 
-    public <T> T post(String url, Object content, Class<T> responseClass,
+    public <T> Optional<T> post(String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
         return submit(HttpMethod.POST, url, content, responseClass, options, headers);
     }
     
-    public <T> T put(String url, Object content, Class<T> responseClass,
+    public <T> Optional<T> put(String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
         return submit(HttpMethod.PUT, url, content, responseClass, options, headers);
     }
     
-    public <T> T patch(String url, Object content, Class<T> responseClass,
+    public <T> Optional<T> patch(String url, Object content, Class<T> responseClass,
             HttpRequestOptions options, RequestHeader... headers) {
         return submit(HttpMethod.PATCH, url, content, responseClass, options, headers);
     }

--- a/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
+++ b/odata-client-runtime/src/main/java/com/github/davidmoten/odata/client/internal/RequestHelper.java
@@ -126,13 +126,13 @@ public final class RequestHelper {
     }
 
     // designed for saving a new entity and returning that entity
-    public static <T extends ODataEntityType> T post(T entity, ContextPath contextPath,
+    public static <T extends ODataEntityType> Optional<T> post(T entity, ContextPath contextPath,
             Class<T> cls, RequestOptions options) {
         return postAny(entity, contextPath, cls, options);
     }
     
     // designed for saving a new entity and returning that entity
-    public static <T extends ODataEntityType> T patch(T entity, ContextPath contextPath,
+    public static <T extends ODataEntityType> Optional<T> patch(T entity, ContextPath contextPath,
             Class<T> cls, RequestOptions options) {
         return patchAny(entity, contextPath, cls, options);
     }
@@ -154,17 +154,17 @@ public final class RequestHelper {
         checkResponseCodeOk(cp, response);
     }
     
-    public static <T> T postAny(Object object, ContextPath contextPath, Class<T> responseClass,
+    public static <T> Optional<T> postAny(Object object, ContextPath contextPath, Class<T> responseClass,
             RequestOptions options) {
         return submitAny(HttpMethod.POST, object, contextPath, responseClass, options);
     }
     
-    public static <T> T patchAny(Object object, ContextPath contextPath, Class<T> responseClass,
+    public static <T> Optional<T> patchAny(Object object, ContextPath contextPath, Class<T> responseClass,
             RequestOptions options) {
         return submitAny(HttpMethod.PATCH, object, contextPath, responseClass, options);
     }
     
-    public static <T> T submitAny(HttpMethod method, Object object, ContextPath contextPath, Class<T> responseClass,
+    public static <T> Optional<T> submitAny(HttpMethod method, Object object, ContextPath contextPath, Class<T> responseClass,
             RequestOptions options) {
         // build the url
         ContextPath cp = contextPath.addQueries(options.getQueries());
@@ -186,12 +186,16 @@ public final class RequestHelper {
         checkResponseCodeOk(cp, response);
 
         String text = response.getText();
-        // deserialize
-        Class<? extends T> c = getSubClass(cp, contextPath.context().schemas(), responseClass,
-                text);
-        // check if we need to deserialize into a subclass of T (e.g. return a
-        // FileAttachment which is a subclass of Attachment)
-        return cp.context().serializer().deserialize(text, c, contextPath, false);
+        if (text == null) {
+            return Optional.empty();
+        } else {
+            // deserialize
+            Class<? extends T> c = getSubClass(cp, contextPath.context().schemas(), responseClass,
+                    text);
+         // check if we need to deserialize into a subclass of T (e.g. return a
+            // FileAttachment which is a subclass of Attachment)
+            return Optional.of(cp.context().serializer().deserialize(text, c, contextPath, false));
+        }
     }
 
     public static <T, S> T postAnyWithParametricType(Object object, ContextPath contextPath,

--- a/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test1ServiceTest.java
+++ b/odata-client-test-unit/src/test/java/com/github/davidmoten/odata/test/Test1ServiceTest.java
@@ -1,6 +1,7 @@
 package com.github.davidmoten.odata.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.net.HttpURLConnection;
 
@@ -57,10 +58,26 @@ public class Test1ServiceTest {
                         RequestHeader.ODATA_VERSION) //
                 .build();
         Product p = Product.builder().name("bingo").build();
-        Product p2 = client.products().post(p);
+        Product p2 = client.products().post(p).get();
         Product p3 = p2.withName(null);
         assertEquals("{\"@odata.type\":\"Test1.A.Product\",\"Name\":null}",
                 Serializer.INSTANCE.serializeChangesOnly(p3));
+    }
+    
+    @Test
+    public void testPostNoContentInResponse() {
+        Test1Service client = Test1Service //
+                .test() //
+                .expectRequest("/Products") //
+                .withPayload("/request-post.json") //
+                .withMethod(HttpMethod.POST) //
+                .withResponseStatusCode(HttpURLConnection.HTTP_NO_CONTENT) //
+                .withRequestHeaders(RequestHeader.ACCEPT_JSON_METADATA_MINIMAL, //
+                        RequestHeader.CONTENT_TYPE_JSON, //
+                        RequestHeader.ODATA_VERSION) //
+                .build();
+        Product p = Product.builder().name("bingo").build();
+        assertFalse(client.products().post(p).isPresent());
     }
     
     @Test


### PR DESCRIPTION
This PR is a breaking change to fix #450 in that calls like below instead of returning a `Message` will return an `Optional<Message>`. This is because certain headers will bring this us about with MsGraph and because Dynamics CRM returns HTTP No-Content by default for a lot of stuff (one actually has to set a header to ensure full response if desired). 

```java
client.me().messages().post(m)
```
This is of course a **breaking change** but necessary.
