### PR TITLE
update msgraph metadata v1 and fix heirarchy related compile errors

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -157,7 +157,7 @@ public final class Generator {
 			
 			log("  checking entities have keys");
             Util.types(schema, TEntityType.class) //
-                    .map(x -> new EntityType(x, names)) //
+                    .map(x -> new EntityType(schema, x, names)) //
                     .filter(x -> !x.hasKey()) //
                     .forEach(x -> log("    " + x.getFullType() + " has no keys"));
 
@@ -172,7 +172,7 @@ public final class Generator {
 			// write entityTypes
 			log("  writing entities");
 			Util.types(schema, TEntityType.class) // 
-					.forEach(x -> writeEntity(x, typeActions, typeFunctions));
+					.forEach(x -> writeEntity(schema, x, typeActions, typeFunctions));
 
 			// write complexTypes
 			log("  writing complex types");
@@ -548,9 +548,9 @@ public final class Generator {
                         : "";
     }
 
-	private void writeEntity(TEntityType entityType, Map<String, List<Action>> typeActions,
+	private void writeEntity(Schema schema, TEntityType entityType, Map<String, List<Action>> typeActions,
 			Map<String, List<Function>> typeFunctions) {
-		EntityType t = new EntityType(entityType, names);
+		EntityType t = new EntityType(schema, entityType, names);
 		t.getDirectoryEntity().mkdirs();
 		String simpleClassName = t.getSimpleClassName();
 		Imports imports = new Imports(t.getFullClassNameEntity());
@@ -1035,7 +1035,7 @@ public final class Generator {
 	}
 
 	private void writeComplexType(Schema schema, TComplexType complexType) {
-		ComplexType t = new ComplexType(complexType, names);
+		ComplexType t = new ComplexType(schema, complexType, names);
 		t.getDirectoryComplexType().mkdirs();
 		String simpleClassName = t.getSimpleClassName();
 		Imports imports = new Imports(t.getFullClassName());
@@ -1101,7 +1101,7 @@ public final class Generator {
 
 	private void writeEntityRequest(Schema schema, TEntityType entityType, Map<String, List<Action>> typeActions,
 			Map<String, List<Function>> typeFunctions) {
-		EntityType t = new EntityType(entityType, names);
+		EntityType t = new EntityType(schema, entityType, names);
 		names.getDirectoryEntityRequest(schema).mkdirs();
 		// TODO only write out those requests needed
 		String simpleClassName = t.getSimpleClassNameEntityRequest();
@@ -1417,7 +1417,7 @@ public final class Generator {
 	private void writeEntityCollectionRequest(Schema schema, TEntityType entityType,
 			Map<String, List<Action>> collectionTypeActions, Map<String, List<Function>> collectionTypeFunctions,
 			Set<String> collectionTypes) {
-		EntityType t = new EntityType(entityType, names);
+		EntityType t = new EntityType(schema, entityType, names);
 		if (!collectionTypes.contains(t.getFullType())) {
 			return;
 		}
@@ -1521,6 +1521,9 @@ public final class Generator {
 		// write Builder class
 		p.format("\n%spublic static final class Builder {\n", indent);
 		indent.right();
+		if (simpleClassName.equals("RunningOperation")) {
+		    System.out.println("here");
+		}
 		List<Field> fields = t.getFields(imports);
 
 		// write builder fields

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
@@ -565,7 +565,7 @@ public final class Names {
     }
 
     public EntityType getEntityType(String typeWithNamespace) {
-        return new EntityType(entityTypesFromNamespacedType.get(typeWithNamespace), this);
+        return new EntityType(getSchema(typeWithNamespace), entityTypesFromNamespacedType.get(typeWithNamespace), this);
     }
 
     public String getEnumInstanceName(TEnumType t, String name) {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/ComplexType.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/ComplexType.java
@@ -14,8 +14,8 @@ import com.github.davidmoten.odata.client.generator.Util;
 
 public final class ComplexType extends Structure<TComplexType> {
 
-    public ComplexType(TComplexType c, Names names) {
-        super(c, TComplexType.class, names);
+    public ComplexType(Schema schema, TComplexType c, Names names) {
+        super(schema, c, TComplexType.class, names);
     }
 
     @Override
@@ -41,8 +41,8 @@ public final class ComplexType extends Structure<TComplexType> {
     }
 
     @Override
-    public Structure<TComplexType> create(TComplexType t) {
-        return new ComplexType(t, names);
+    public Structure<TComplexType> create(Schema schema, TComplexType t) {
+        return new ComplexType(schema, t, names);
     }
 
     @Override
@@ -58,10 +58,6 @@ public final class ComplexType extends Structure<TComplexType> {
     @Override
     public String getSimpleClassName() {
         return names.getSimpleClassNameComplexType(schema(), getName());
-    }
-
-    private Schema schema() {
-        return names.getSchema(value);
     }
 
     @Override

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/EntityType.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/EntityType.java
@@ -16,10 +16,8 @@ import com.github.davidmoten.odata.client.generator.Util;
 
 public final class EntityType extends Structure<TEntityType> {
 
-    private Schema schema;
-
-    public EntityType(TEntityType c, Names names) {
-        super(c, TEntityType.class, names);
+    public EntityType(Schema schema, TEntityType c, Names names) {
+        super(schema, c, TEntityType.class, names);
     }
 
     @Override
@@ -47,8 +45,8 @@ public final class EntityType extends Structure<TEntityType> {
     }
 
     @Override
-    public Structure<TEntityType> create(TEntityType t) {
-        return new EntityType(t, names);
+    public Structure<TEntityType> create(Schema schema, TEntityType t) {
+        return new EntityType(schema, t, names);
     }
 
     @Override
@@ -83,13 +81,6 @@ public final class EntityType extends Structure<TEntityType> {
     @Override
     public String getPackage() {
         return names.getPackageEntity(schema());
-    }
-
-    private Schema schema() {
-        if (schema == null) {
-            schema = names.getSchema(value);
-        }
-        return schema;
     }
 
     public String getFullClassNameEntity() {

--- a/odata-client-generator/src/main/odata/msgraph-metadata.xml
+++ b/odata-client-generator/src/main/odata/msgraph-metadata.xml
@@ -28,6 +28,11 @@
         <Member Name="failed" Value="5"/>
         <Member Name="unknownFutureValue" Value="6"/>
       </EnumType>
+      <EnumType Name="membershipChangeType">
+        <Member Name="add" Value="1"/>
+        <Member Name="remove" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
       <EnumType Name="valueType">
         <Member Name="enum" Value="0"/>
         <Member Name="string" Value="1"/>
@@ -76,11 +81,19 @@
       <EntityType Name="lifecycleWorkflowsContainer" BaseType="graph.entity">
         <NavigationProperty Name="customTaskExtensions" Type="Collection(microsoft.graph.identityGovernance.customTaskExtension)" ContainsTarget="true"/>
         <NavigationProperty Name="deletedItems" Type="graph.deletedItemContainer" ContainsTarget="true"/>
+        <NavigationProperty Name="insights" Type="microsoft.graph.identityGovernance.insights" ContainsTarget="true"/>
         <NavigationProperty Name="settings" Type="microsoft.graph.identityGovernance.lifecycleManagementSettings" Nullable="false" ContainsTarget="true"/>
         <NavigationProperty Name="taskDefinitions" Type="Collection(microsoft.graph.identityGovernance.taskDefinition)" ContainsTarget="true"/>
         <NavigationProperty Name="workflows" Type="Collection(microsoft.graph.identityGovernance.workflow)" ContainsTarget="true"/>
         <NavigationProperty Name="workflowTemplates" Type="Collection(microsoft.graph.identityGovernance.workflowTemplate)" ContainsTarget="true"/>
       </EntityType>
+      <ComplexType Name="workflowExecutionTrigger" Abstract="true"/>
+      <ComplexType Name="attributeChangeTrigger" BaseType="microsoft.graph.identityGovernance.workflowExecutionTrigger">
+        <Property Name="triggerAttributes" Type="Collection(microsoft.graph.identityGovernance.triggerAttribute)" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="triggerAttribute">
+        <Property Name="name" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
       <ComplexType Name="customTaskExtensionCallbackConfiguration" BaseType="graph.customExtensionCallbackConfiguration">
         <NavigationProperty Name="authorizedApps" Type="Collection(graph.application)"/>
       </ComplexType>
@@ -113,6 +126,12 @@
         <NavigationProperty Name="subject" Type="graph.user" Nullable="false"/>
         <NavigationProperty Name="task" Type="microsoft.graph.identityGovernance.task" Nullable="false"/>
       </EntityType>
+      <ComplexType Name="groupBasedSubjectSet" BaseType="graph.subjectSet">
+        <NavigationProperty Name="groups" Type="Collection(graph.group)"/>
+      </ComplexType>
+      <ComplexType Name="membershipChangeTrigger" BaseType="microsoft.graph.identityGovernance.workflowExecutionTrigger">
+        <Property Name="changeType" Type="microsoft.graph.identityGovernance.membershipChangeType" Nullable="false"/>
+      </ComplexType>
       <ComplexType Name="workflowExecutionConditions" Abstract="true"/>
       <ComplexType Name="onDemandExecutionOnly" BaseType="microsoft.graph.identityGovernance.workflowExecutionConditions"/>
       <ComplexType Name="parameter">
@@ -137,10 +156,31 @@
         <Property Name="totalTasks" Type="Edm.Int32" Nullable="false"/>
         <Property Name="unprocessedTasks" Type="Edm.Int32" Nullable="false"/>
       </ComplexType>
-      <ComplexType Name="workflowExecutionTrigger" Abstract="true"/>
       <ComplexType Name="timeBasedAttributeTrigger" BaseType="microsoft.graph.identityGovernance.workflowExecutionTrigger">
         <Property Name="offsetInDays" Type="Edm.Int32" Nullable="false"/>
         <Property Name="timeBasedAttribute" Type="microsoft.graph.identityGovernance.workflowTriggerTimeBasedAttribute" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="topTasksInsightsSummary">
+        <Property Name="failedTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="taskDefinitionDisplayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="taskDefinitionId" Type="Edm.String" Nullable="false"/>
+        <Property Name="totalTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalUsers" Type="Edm.Int32" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="topWorkflowsInsightsSummary">
+        <Property Name="failedRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="workflowCategory" Type="microsoft.graph.identityGovernance.lifecycleWorkflowCategory" Nullable="false"/>
+        <Property Name="workflowDisplayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="workflowId" Type="Edm.String" Nullable="false"/>
+        <Property Name="workflowVersion" Type="Edm.Int32" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="triggerAndScopeBasedConditions" BaseType="microsoft.graph.identityGovernance.workflowExecutionConditions">
         <Property Name="scope" Type="graph.subjectSet"/>
@@ -160,6 +200,28 @@
         <Property Name="totalTasks" Type="Edm.Int32" Nullable="false"/>
         <Property Name="totalUsers" Type="Edm.Int32" Nullable="false"/>
       </ComplexType>
+      <ComplexType Name="workflowsInsightsByCategory">
+        <Property Name="failedJoinerRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedLeaverRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedMoverRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulJoinerRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulLeaverRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulMoverRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalJoinerRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalLeaverRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalMoverRuns" Type="Edm.Int32" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="workflowsInsightsSummary">
+        <Property Name="failedRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="failedUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="successfulUsers" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalRuns" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalTasks" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalUsers" Type="Edm.Int32" Nullable="false"/>
+      </ComplexType>
       <EntityType Name="customTaskExtension" BaseType="graph.customCalloutExtension">
         <Property Name="callbackConfiguration" Type="graph.customExtensionCallbackConfiguration"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
@@ -167,6 +229,7 @@
         <NavigationProperty Name="createdBy" Type="graph.user"/>
         <NavigationProperty Name="lastModifiedBy" Type="graph.user"/>
       </EntityType>
+      <EntityType Name="insights" BaseType="graph.entity"/>
       <EntityType Name="lifecycleManagementSettings" BaseType="graph.entity">
         <Property Name="emailSettings" Type="graph.emailSettings" Nullable="false"/>
         <Property Name="workflowScheduleIntervalInHours" Type="Edm.Int32" Nullable="false"/>
@@ -271,6 +334,30 @@
         <Parameter Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Parameter Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <ReturnType Type="microsoft.graph.identityGovernance.userSummary"/>
+      </Function>
+      <Function Name="topTasksProcessedSummary" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.identityGovernance.insights"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <ReturnType Type="Collection(microsoft.graph.identityGovernance.topTasksInsightsSummary)"/>
+      </Function>
+      <Function Name="topWorkflowsProcessedSummary" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.identityGovernance.insights"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <ReturnType Type="Collection(microsoft.graph.identityGovernance.topWorkflowsInsightsSummary)"/>
+      </Function>
+      <Function Name="workflowsProcessedByCategory" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.identityGovernance.insights"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <ReturnType Type="microsoft.graph.identityGovernance.workflowsInsightsByCategory"/>
+      </Function>
+      <Function Name="workflowsProcessedSummary" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.identityGovernance.insights"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <ReturnType Type="microsoft.graph.identityGovernance.workflowsInsightsSummary"/>
       </Function>
       <Annotations Target="microsoft.graph.bookingPriceType">
         <Annotation Term="Org.OData.Core.V1.Description" String="Represents the type of pricing of a booking service."/>
@@ -495,25 +582,25 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Foreground delivery optimization priority."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Contains all supported file system detection type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="A list of possible operations for rules used to make determinations about an application based on files or folders. Unless noted, can be used with either detection or requirement rules."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/notConfigured">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Not configured."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Default. Indicates that the rule does not have the operation type configured."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/exists">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Whether the specified file or folder exists."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule evaluates whether the specified file or folder exists."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/modifiedDate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Last modified date."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the modified date of the specified file against a provided comparison value by DateTime comparison."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/createdDate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Created date."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the created date of the specified file against a provided comparison value by DateTime comparison."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/version">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Version value type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the detected version of the specified file against a provided comparison value via version semantics (both operand values will be parsed as versions and directly compared). If the value read at the given registry value is not discovered to be in version-compatible format, a string comparison will be used instead."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppFileSystemOperationType/sizeInMB">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Size detection type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the size of the file in MiB (rounded down) against a provided comparison value by integer comparison."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppMsiPackageType">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the package type of an MSI Win32LobApp."/>
@@ -564,25 +651,25 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Output data type is boolean."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Contains all supported registry data detection type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="A list of possible operations for rules used to make determinations about an application based on registry keys or values. Unless noted, the values can be used with either detection or requirement rules."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/notConfigured">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Not configured."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Default. Indicates that the rule does not have the operation type configured."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/exists">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The specified registry key or value exists."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule evaluates whether the specified registry key or value exists."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/doesNotExist">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The specified registry key or value does not exist."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule evaluates whether the specified registry key or value does not exist. It is the functional inverse of an equivalent rule that uses operation type `exists`."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/string">
-        <Annotation Term="Org.OData.Core.V1.Description" String="String value type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the value read at the given registry value against a provided comparison value by string comparison."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/integer">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Integer value type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the value read at the given registry value against a provided comparison value by integer comparison."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRegistryRuleOperationType/version">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Version value type."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the rule compares the value read at the given registry value against a provided comparison value via version semantics (both operand values will be parsed as versions and directly compared). If the value read at the given registry value is not discovered to be in version-compatible format, a string comparison will be used instead."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRestartBehavior">
         <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the type of restart action."/>
@@ -649,6 +736,18 @@
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRuleType/requirement">
         <Annotation Term="Org.OData.Core.V1.Description" String="Requirement rule."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAutoUpdateSupersededAppsState">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Contains value for auto-update superseded apps."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAutoUpdateSupersededAppsState/notConfigured">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the auto-update superseded apps state is not configured and the app will not auto-update the superseded apps."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAutoUpdateSupersededAppsState/enabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the auto-update superseded apps state is enabled and the app will auto-update the superseded apps if the superseded apps are installed on the device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAutoUpdateSupersededAppsState/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
       </Annotations>
       <Annotations Target="microsoft.graph.windowsArchitecture">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties for Windows architecture."/>
@@ -2180,6 +2279,9 @@
       <Annotations Target="microsoft.graph.mobileThreatPartnerTenantState/unresponsive">
         <Annotation Term="Org.OData.Core.V1.Description" String="Partner is unresponsive."/>
       </Annotations>
+      <Annotations Target="microsoft.graph.mobileThreatPartnerTenantState/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.vppTokenState">
         <Annotation Term="Org.OData.Core.V1.Description" String="Possible states associated with an Apple Volume Purchase Program token."/>
       </Annotations>
@@ -2352,7 +2454,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Apple bulk enrollment without user challenge. (DEP, Apple Configurator, Mobile Config)"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/windowsAzureADJoin">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Azure AD Join."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Entra ID (Azure AD) Join."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/windowsBulkUserless">
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Bulk enrollment through ICD with certificate."/>
@@ -2361,19 +2463,19 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 automatic enrollment. (Add work account)"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/windowsBulkAzureDomainJoin">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 bulk Azure AD Join."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 bulk Entra ID (Azure AD) Join."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/windowsCoManagement">
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Co-Management triggered by AutoPilot or Group Policy."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/windowsAzureADJoinUsingDeviceAuth">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Azure AD Join using Device Auth."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Entra ID (Azure AD) Join using Device Auth."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/appleUserEnrollment">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device managed by Apple user enrollment"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the device is enrolled via Apple User Enrollment with Company Portal. It results in an enrollment with a new partition for managed apps and data and which supports a limited set of management capabilities"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentType/appleUserEnrollmentWithServiceAccount">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device managed by Apple user enrollment with service account"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the device is enrolled via Apple User Enrollment with Company Portal using a device enrollment manager user. It results in an enrollment with a new partition for managed apps and data and which supports a limited set of management capabilities"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceLogCollectionTemplateType">
         <Annotation Term="Org.OData.Core.V1.Description" String="Enum for the template type used for collecting logs"/>
@@ -2520,13 +2622,16 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Owner type of device."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedDeviceOwnerType/unknown">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Unknown."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Unknown device owner type."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedDeviceOwnerType/company">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Owned by company."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Corporate device owner type."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedDeviceOwnerType/personal">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Owned by person."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Personal device owner type."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.managedDeviceOwnerType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedDevicePartnerReportedHealthState">
         <Annotation Term="Org.OData.Core.V1.Description" String="Available health states for the Device Health API"/>
@@ -2596,9 +2701,6 @@
       </Annotations>
       <Annotations Target="microsoft.graph.managementAgentType/microsoft365ManagedMdm">
         <Annotation Term="Org.OData.Core.V1.Description" String="This device is managed by Microsoft 365 through Intune."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.managementAgentType/msSense">
-        <Annotation Term="Org.OData.Core.V1.Description" String=""/>
       </Annotations>
       <Annotations Target="microsoft.graph.obliterationBehavior">
         <Annotation Term="Org.OData.Core.V1.Description" String="In macOS 12 and later, this command uses Erase All Content and Settings (EACS) on Mac computers with the Apple M1 chip or the Apple T2 Security Chip. On those devices, if EACS can’t run, the device can use obliteration (macOS 11.x behavior). This key has no effect on machines prior to the T2 chip. Upon receiving this command, the device performs preflight checks to determine if the device is in a state that allows EACS. The ObliterationBehavior value defines the device's fallback behavior."/>
@@ -3137,6 +3239,33 @@
       <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentityUploadStatus/error">
         <Annotation Term="Org.OData.Core.V1.Description" String="Error status."/>
       </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeviceType/windowsPc">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Default. Indicates that the device type  is a Windows PC."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeviceType/holoLens">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the device type is a HoloLens."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeviceType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsDeviceUsageType/singleUser">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Default. Indicates that a device is a single-user device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsDeviceUsageType/shared">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that a device is a multi-user device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsDeviceUsageType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsUserType/administrator">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the user has administrator privileges."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsUserType/standard">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates that the user is a low-rights user without administrator privileges."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsUserType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.managedAppClipboardSharingLevel">
         <Annotation Term="Org.OData.Core.V1.Description" String="Represents the level to which the device's clipboard may be shared between apps"/>
       </Annotations>
@@ -3300,46 +3429,46 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The status reported when the system has successfully exchanged account information with TeamViewer and can now initiate remote assistance sessions with clients"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJobLocalizationType">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Configures how the requested export job is localized"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Configures how the requested export job is localized."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJobLocalizationType/localizedValuesAsAdditionalColumn">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Configures the export job to expose localized values as an additional column"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Configures the export job to expose localized values as an additional column."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJobLocalizationType/replaceLocalizableValues">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Configures the export job to replace enumerable values with their localized values"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Configures the export job to replace enumerable values with their localized values."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportFileFormat">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Possible values for the file format of a report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Possible values for the file format of a report to be exported."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportFileFormat/csv">
-        <Annotation Term="Org.OData.Core.V1.Description" String="CSV Format"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="CSV Format."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportFileFormat/pdf">
-        <Annotation Term="Org.OData.Core.V1.Description" String="PDF Format"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="PDF Format (Deprecate later)."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportFileFormat/json">
-        <Annotation Term="Org.OData.Core.V1.Description" String="JSON Format"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="JSON Format."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportFileFormat/unknownFutureValue">
         <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Possible statuses associated with a generated report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Possible statuses associated with a generated report."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus/unknown">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation status is unknown"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation status is unknown."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus/notStarted">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation has not started"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation has not started."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus/inProgress">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation is in progress"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation is in progress."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus/completed">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation is completed"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation is completed."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementReportStatus/failed">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation has failed"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Report generation has failed."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentFailureReason">
         <Annotation Term="Org.OData.Core.V1.Description" String="Top level failure categories for enrollment."/>
@@ -3389,6 +3518,294 @@
       <Annotations Target="microsoft.graph.applicationType/desktop">
         <Annotation Term="Org.OData.Core.V1.Description" String="The windows desktop application"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Supported platform types."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/android">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Android."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/androidForWork">
+        <Annotation Term="Org.OData.Core.V1.Description" String="AndroidForWork."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/iOS">
+        <Annotation Term="Org.OData.Core.V1.Description" String="iOS."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/macOS">
+        <Annotation Term="Org.OData.Core.V1.Description" String="MacOS."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/windowsPhone81">
+        <Annotation Term="Org.OData.Core.V1.Description" String="WindowsPhone 8.1."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/windows81AndLater">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 8.1 and later"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/windows10AndLater">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 and later."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/androidWorkProfile">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Android Work Profile."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/unknown">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Unknown."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/androidAOSP">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Android AOSP."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/androidMobileApplicationManagement">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates Mobile Application Management (MAM) for android devices."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/iOSMobileApplicationManagement">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates Mobile Application Management (MAM) for iOS devices"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.devicePlatformType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Evolvable enumeration sentinel value. Do not use"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertFeedback">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertSeverity">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertStatus">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.connectionDirection">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.connectionStatus">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.emailRole">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.fileHashType">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.logonType">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.processIntegrityLevel">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.registryHive">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.registryOperation">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.registryValueType">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.securityNetworkProtocol">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.securityResourceType">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userAccountSecurityType">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.communityPrivacy">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Types of communityPrivacy."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.communityPrivacy/public">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Any user from the tenant can join and participate in the community."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.communityPrivacy/private">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A community administrator must add tenant users to the community before they can participate."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.communityPrivacy/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A marker value for members added after the release of this API."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperationType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Types of engagementAsyncOperationType. Members will be added here as more async operations are supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperationType/createCommunity">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Operation to create a Viva Engage community."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperationType/unknownFutureValue">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A marker value for members added after the release of this API."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.directoryObject">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -3415,9 +3832,9 @@
             <PropertyValue Property="Referenceable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -3447,6 +3864,13 @@
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
             <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.application/federatedIdentityCredentials">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Upsertable" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -3487,9 +3911,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -3512,12 +3936,273 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.group">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Represents a Microsoft Entra group."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.resourceSpecificPermissionGrant">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
+          <Record>
+            <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/acceptedSenders">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/calendar">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/calendarView">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/conversations">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/events">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/rejectedSenders">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/threads">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/photo">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.group/photos">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.user">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
             <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Represents a Microsoft Entra user account."/>
       </Annotations>
       <Annotations Target="microsoft.graph.oAuth2PermissionGrant">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
@@ -3803,9 +4488,9 @@
             <PropertyValue Property="Filterable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -3908,9 +4593,9 @@
             <PropertyValue Property="Countable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -3936,9 +4621,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -3970,9 +4655,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4004,9 +4689,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4052,9 +4737,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4103,9 +4788,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4154,9 +4839,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4205,9 +4890,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4273,9 +4958,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4476,6 +5161,15 @@
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.relyingPartyDetailedSummary">
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.servicePrincipal">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -4494,9 +5188,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4518,9 +5212,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4542,9 +5236,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4571,12 +5265,56 @@
             <PropertyValue Property="Insertable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.policyRoot/deviceRegistrationPolicy">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.SortRestrictions">
+          <Record>
+            <PropertyValue Property="Sortable" Bool="false"/>
+          </Record>
+        </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
         <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
           <Record>
@@ -4629,9 +5367,14 @@
             <PropertyValue Property="Insertable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
+          <Record>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -4680,6 +5423,11 @@
             <PropertyValue Property="Insertable" Bool="false"/>
           </Record>
         </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
         <Annotation Term="Org.OData.Capabilities.V1.SortRestrictions">
           <Record>
@@ -4693,6 +5441,43 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/accessControl">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Access control on the Bookings page."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/bookingPageColorCode">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Custom color for bookings page. Value should be in Hex format. Example: `#123456`."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/businessTimeZone">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The time zone of the customer. For a list of possible values, see [dateTimeTimeZone](https://learn.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-beta)."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/customerConsentMessage">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Customer consent message that is displayed in the Booking page."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/enforceOneTimePassword">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enforcing One Time Password (OTP) during appointment creation."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/isBusinessLogoDisplayEnabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enable display of business logo display on the Bookings page."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/isCustomerConsentEnabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enforces customer consent on the customer consent message before appointment is booked."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/isSearchEngineIndexabilityDisabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Disable booking page to be indexed by search engines. False by default."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/isTimeSlotTimeZoneSetToBusinessTimeZone">
+        <Annotation Term="Org.OData.Core.V1.Description" String="If business time zone the default value for the time slots that we show in the bookings page. False by default."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/privacyPolicyWebUrl">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The URL of the business' Privacy Policy."/>
+        <Annotation Term="Org.OData.Core.V1.IsURL" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.LongDescription" String="Example: https://www.contoso.com"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingPageSettings/termsAndConditionsWebUrl">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The URL of the business' Terms and Conditions."/>
+        <Annotation Term="Org.OData.Core.V1.IsURL" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.LongDescription" String="Example: https://www.contoso.com"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.bookingReminder">
         <Annotation Term="Org.OData.Core.V1.Description" String="This type represents when and to whom to send an e-mail reminder."/>
       </Annotations>
@@ -4705,11 +5490,35 @@
       <Annotations Target="microsoft.graph.bookingReminder/recipients">
         <Annotation Term="Org.OData.Core.V1.Description" String="Who should receive the reminder."/>
       </Annotations>
+      <Annotations Target="microsoft.graph.bookingsAvailability/availabilityType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Allow customers to set the type of availability."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingWorkHours">
+        <Annotation Term="Org.OData.Core.V1.Description" String="This type represents the set of working hours in a single day of the week."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingsAvailability/businessHours">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The hours of operation in a week. This is set to null if the availability type is not customWeeklyHours"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingsAvailabilityWindow/endDate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Allow customers to end date of availability window."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingsAvailabilityWindow/startDate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Allow customers to start date of availability window."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.bookingSchedulingPolicy">
         <Annotation Term="Org.OData.Core.V1.Description" String="This type represents the set of policies that dictate how bookings can be created in a Booking Calendar."/>
       </Annotations>
       <Annotations Target="microsoft.graph.bookingSchedulingPolicy/allowStaffSelection">
         <Annotation Term="Org.OData.Core.V1.Description" String="Allow customers to choose a specific person for the booking."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingSchedulingPolicy/customAvailabilities">
+        <Annotation Term="Org.OData.Core.V1.Description" String="collection of custom availabilities for a given time range."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingSchedulingPolicy/generalAvailability">
+        <Annotation Term="Org.OData.Core.V1.Description" String="General availability "/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingSchedulingPolicy/isMeetingInviteToCustomersEnabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Enable sending meeting invite to customers. False by default."/>
       </Annotations>
       <Annotations Target="microsoft.graph.bookingSchedulingPolicy/maximumAdvance">
         <Annotation Term="Org.OData.Core.V1.Description" String="Maximum number of days in advance that a booking can be made."/>
@@ -4723,9 +5532,6 @@
       <Annotations Target="microsoft.graph.bookingSchedulingPolicy/timeSlotInterval">
         <Annotation Term="Org.OData.Core.V1.Description" String="Duration of each time slot."/>
       </Annotations>
-      <Annotations Target="microsoft.graph.bookingWorkHours">
-        <Annotation Term="Org.OData.Core.V1.Description" String="This type represents the set of working hours in a single day of the week."/>
-      </Annotations>
       <Annotations Target="microsoft.graph.bookingWorkHours/day">
         <Annotation Term="Org.OData.Core.V1.Description" String="The day of the week represented by this instance."/>
       </Annotations>
@@ -4737,6 +5543,14 @@
       </Annotations>
       <Annotations Target="microsoft.graph.bookingAppointment/anonymousJoinWebUrl">
         <Annotation Term="Org.OData.Core.V1.IsURL" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingAppointment/appointmentLabel">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Custom label that can be stamped on this appointment by users."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.bookingAppointment/customerNotes">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Notes from the customer associated with this appointment."/>
+        <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.LongDescription" String="The value of this property is only available when reading an individual booking appointment by id. Its value can only be set when creating a new appointment with a new customer, ie, without specifying a CustomerId. After that, the property is computed from the customer represented by CustomerId."/>
       </Annotations>
       <Annotations Target="microsoft.graph.bookingAppointment/duration">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
@@ -4855,6 +5669,360 @@
         <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="true"/>
         <Annotation Term="Org.OData.Capabilities.V1.BatchSupported" Bool="true"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.auditEvent">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A class containing the properties for Audit Event."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/auditEvents">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Audit Events"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.termsAndConditions">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/termsAndConditions">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The terms and conditions associated with device management of the company."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/intuneAccountId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Intune Account Id for given tenant"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/settings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Account level settings."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceCompliancePolicy">
+        <Annotation Term="Org.OData.Core.V1.Description" String="This is the base class for Compliance policy. Compliance policies are platform specific and individual per-platform compliance policies inherit from here. "/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicies">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The device compliance policies."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicyDeviceStateSummary">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The device compliance state summary for this account."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceCompliancePolicySettingStateSummary">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Device Compilance Policy Setting State summary across the account."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicySettingStateSummaries">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The summary states of compliance policy settings for this account."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceConfigurationDeviceStateSummaries">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The device configuration device state summary for this account."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceConfiguration">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Device Configuration."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceConfigurations">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The device configurations."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/iosUpdateStatuses">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The IOS software update installation statuses for this account."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/softwareUpdateStatusSummary">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The software update status summary."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.intuneBrand">
+        <Annotation Term="Org.OData.Core.V1.Description" String="intuneBrand contains data which is used in customizing the appearance of the Company Portal applications as well as the end user web portal."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/intuneBrand">
+        <Annotation Term="Org.OData.Core.V1.Description" String="intuneBrand contains data which is used in customizing the appearance of the Company Portal applications as well as the end user web portal."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.complianceManagementPartner">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Compliance management partner for all platforms"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/complianceManagementPartners">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Compliance Management Partners configured by the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.onPremisesConditionalAccessSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity which represents the Exchange OnPremises Conditional Access Settings for a tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/conditionalAccessSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Exchange on premises conditional access settings. On premises conditional access will require devices to be both enrolled and compliant for mail access"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceCategory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Device categories provides a way to organize your devices. Using device categories, company administrators can define their own categories that make sense to their company. These categories can then be applied to a device in the Intune Azure console or selected by a user during device enrollment. You can filter reports and create dynamic Azure Active Directory device groups based on device categories."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceCategories">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of device categories with the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceEnrollmentConfiguration">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Base Class of Device Enrollment Configuration"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceEnrollmentConfigurations">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of device enrollment configurations"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagementPartner">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to device management partner."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceManagementPartners">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Device Management Partners configured by the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagementExchangeConnector">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to an Exchange environment."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/exchangeConnectors">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Exchange Connectors configured by the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.mobileThreatDefenseConnector">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to Mobile Threat Defense partner."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/mobileThreatDefenseConnectors">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Mobile threat Defense connectors configured by the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceProtectionOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Hardware information of a given device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/deviceProtectionOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Device protection overview."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/subscriptionState">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Tenant mobile device management subscription state."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics insight is the recomendation to improve the user experience analytics score."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device settings"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsMalwareOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows device malware overview."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/windowsMalwareOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Malware overview for windows devices."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.applePushNotificationCertificate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Apple push notification certificate."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/applePushNotificationCertificate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Apple push notification certificate."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.detectedApp">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/detectedApps">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of detected apps associated with a device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.managedDeviceOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Summary data for managed devices"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/managedDeviceOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Device overview"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/managedDevices">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of managed devices."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/mobileAppTroubleshootingEvents">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The collection property of MobileAppTroubleshootingEvent."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthApplicationPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance by application version details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by App Version details"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance by application version device id."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by App Version Device Id"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByOSVersion">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains app performance details by OS version."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by OS Version"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDeviceModelPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device model performance entity contains device model performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDeviceModelPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Model Performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDevicePerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Device Performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformanceDetails">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDevicePerformanceDetails">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device performance details"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthOSVersionPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device OS version performance entity contains OS version performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthOSVersionPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth OS version Performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsCategory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics category entity contains the scores and insights for the various metrics of a category."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth overview"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsBaseline">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics baseline entity contains baseline values against which to compare the user experience analytics scores."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsBaselines">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics baselines"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsCategories">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics categories"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsDevicePerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device boot performance details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDevicePerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceScores">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device scores entity consolidates the various Endpoint Analytics scores."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceScores">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device scores"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup history entity contains device boot performance history details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup History"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupProcess">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup process details."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupProcesses">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Processes"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupProcessPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup process performance."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupProcessPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Process Performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsMetricHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics metric history."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsMetricHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics metric history"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsModelScores">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics model scores entity consolidates the various Endpoint Analytics scores."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsModelScores">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics model scores"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics overview entity contains the overall score and the scores and insights of every metric of all categories."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsOverview">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics overview"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsScoreHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup score history."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsScoreHistory">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Score History"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics hardware readiness entity contains account level information about hardware blockers for windows upgrade."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics work from anywhere hardware readiness metrics."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereMetric">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics metric for work from anywhere report."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereMetrics">
+        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics work from anywhere metrics."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereModelPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics work from anywhere model performance."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereModelPerformance">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics work from anywhere model performance"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsMalwareInformation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Malware information entity."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/windowsMalwareInformation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of affected malware in the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentity">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Imported windows autopilot devices."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/importedWindowsAutopilotDeviceIdentities">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Collection of imported Windows autopilot devices."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeviceIdentity">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The windowsAutopilotDeviceIdentity resource represents a Windows Autopilot Device."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/windowsAutopilotDeviceIdentities">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Windows autopilot device identities contained collection."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.notificationMessageTemplate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/notificationMessageTemplates">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Notification Message Templates."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.resourceOperation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Describes the resourceOperation resource (entity) of the Microsoft Graph API (REST), which supports Intune workflows related to role-based access control (RBAC)."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/resourceOperations">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Resource Operations."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.roleAssignment">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceAndAppManagementRoleAssignment">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/roleAssignments">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignments."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.roleDefinition">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/roleDefinitions">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Definitions."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.remoteAssistancePartner">
+        <Annotation Term="Org.OData.Core.V1.Description" String="RemoteAssistPartner resources represent the metadata and status of a given Remote Assistance partner service."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/remoteAssistancePartners">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The remote assist partners."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagementReports">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity that acts as a container for all reports functionality."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/reports">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Reports singleton"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.telecomExpenseManagementPartner">
+        <Annotation Term="Org.OData.Core.V1.Description" String="telecomExpenseManagementPartner resources represent the metadata and status of a given TEM service. Once your organization has onboarded with a partner, the partner can be enabled or disabled to switch TEM functionality on or off."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/telecomExpenseManagementPartners">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The telecom expense management partners."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/troubleshootingEvents">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of troubleshooting events for the tenant."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsInformationProtectionAppLearningSummary">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows Information Protection AppLearning Summary entity."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/windowsInformationProtectionAppLearningSummaries">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The windows information protection app learning summaries."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsInformationProtectionNetworkLearningSummary">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows Information Protection Network learning Summary entity."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagement/windowsInformationProtectionNetworkLearningSummaries">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The windows information protection network learning summaries."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.privacy/subjectRightsRequests">
         <Annotation Term="Org.OData.Core.V1.Revisions">
           <Collection>
@@ -4891,9 +6059,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4915,9 +6083,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4939,9 +6107,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4963,9 +6131,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -4975,6 +6143,19 @@
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.secureScoreControlProfile">
         <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
@@ -4987,9 +6168,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -5011,9 +6192,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -5024,259 +6205,8 @@
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="true"/>
       </Annotations>
-      <Annotations Target="microsoft.graph.group">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="true"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.resourceSpecificPermissionGrant">
-        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
-          <Record>
-            <PropertyValue Property="Countable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="true"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
-          <Record>
-            <PropertyValue Property="Filterable" Bool="true"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
-          <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
-        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/acceptedSenders">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/calendar">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-          <Record>
-            <PropertyValue Property="Insertable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/calendarView">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="true"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-          <Record>
-            <PropertyValue Property="Insertable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/conversations">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/events">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/rejectedSenders">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/threads">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/photo">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="true"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-          <Record>
-            <PropertyValue Property="Insertable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-      </Annotations>
-      <Annotations Target="microsoft.graph.group/photos">
-        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
-          <Record>
-            <PropertyValue Property="Supported" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
-          <Record>
-            <PropertyValue Property="Countable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-          <Record>
-            <PropertyValue Property="Deletable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
-          <Record>
-            <PropertyValue Property="Expandable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-          <Record>
-            <PropertyValue Property="Insertable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-          <Record>
-            <PropertyValue Property="Searchable" Bool="false"/>
-          </Record>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
-          <Record>
-            <PropertyValue Property="Updatable" Bool="false"/>
-          </Record>
-        </Annotation>
+      <Annotations Target="microsoft.graph.longRunningOperation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The status of a long-running operation."/>
       </Annotations>
       <Annotations Target="microsoft.graph.identityProvider">
         <Annotation Term="Org.OData.Core.V1.Revisions">
@@ -5308,6 +6238,31 @@
           </Collection>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.identityContainer/conditionalAccess">
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ReadRestrictions">
+          <Record>
+            <PropertyValue Property="Readable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.security.sensorSettings/networkAdapters">
+        <Annotation Term="Org.OData.Core.V1.AutoExpand" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.directory/deviceLocalCredentials">
         <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
           <Record>
@@ -5334,6 +6289,30 @@
             <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.companySubscription">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
       </Annotations>
       <Annotations Target="microsoft.graph.certification/certificationDetailsUrl">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
@@ -5362,9 +6341,9 @@
             <PropertyValue Property="Referenceable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -5391,9 +6370,9 @@
             <PropertyValue Property="Referenceable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -5448,6 +6427,100 @@
       <Annotations Target="microsoft.graph.directoryRoleTemplate">
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.multiTenantOrganization">
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="UpdateMethod">
+              <EnumMember>Org.OData.Capabilities.V1.HttpMethod/PUT</EnumMember>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.multiTenantOrganization/joinRequest">
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.multiTenantOrganizationMember">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+        <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.multiTenantOrganizationIdentitySyncPolicyTemplate">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.multiTenantOrganizationPartnerConfigurationTemplate">
+        <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
+          <Record>
+            <PropertyValue Property="Countable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
+          <Record>
+            <PropertyValue Property="Expandable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.FilterRestrictions">
+          <Record>
+            <PropertyValue Property="Filterable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+          <Record>
+            <PropertyValue Property="Referenceable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+          <Record>
+            <PropertyValue Property="Selectable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.organization/mobileDeviceManagementAuthority">
         <Annotation Term="Org.OData.Core.V1.Description" String="Mobile device management authority."/>
       </Annotations>
@@ -5482,13 +6555,20 @@
             <PropertyValue Property="Referenceable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.tenantRelationship/multiTenantOrganization">
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.browserSharedCookieHistory/comment">
         <Annotation Term="Org.OData.Core.V1.Description" String="The comment of the cookie"/>
@@ -5547,6 +6627,11 @@
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
           <Record>
             <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.UpdateRestrictions">
+          <Record>
+            <PropertyValue Property="Updatable" Bool="false"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -5708,6 +6793,24 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/createdBy">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/createdDateTime">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/lastModifiedBy">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/lastModifiedDateTime">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/resourcesFolderUrl">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationModule/status">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.educationRoot/classes">
         <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
           <Record>
@@ -5741,6 +6844,12 @@
       <Annotations Target="microsoft.graph.educationRubric/lastModifiedDateTime">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.educationSubmission/excusedBy">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.educationSubmission/excusedDateTime">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.educationSubmission/reassignedBy">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
       </Annotations>
@@ -5771,6 +6880,45 @@
       <Annotations Target="microsoft.graph.educationSubmission/unsubmittedDateTime">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.educationSubmission/webUrl">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.restorePointSearchResult/restorePoint">
+        <Annotation Term="Org.OData.Core.V1.AutoExpand" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.driveProtectionUnit/displayName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.driveProtectionUnit/email">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.driveRestoreArtifact/restoredSiteName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.driveRestoreArtifact/restoredSiteWebUrl">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.mailboxProtectionUnit/displayName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.mailboxProtectionUnit/email">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.mailboxRestoreArtifact/restoredFolderName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.siteProtectionUnit/siteName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.siteProtectionUnit/siteWebUrl">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.siteRestoreArtifact/restoredSiteName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.siteRestoreArtifact/restoredSiteWebUrl">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.subscription">
         <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
           <Record>
@@ -5792,9 +6940,9 @@
             <PropertyValue Property="Referenceable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -5804,6 +6952,13 @@
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.TopSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.list/items">
+        <Annotation Term="Org.OData.Capabilities.V1.ChangeTracking">
+          <Record>
+            <PropertyValue Property="Supported" Bool="true"/>
+          </Record>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.workbook/operations">
         <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
@@ -6392,6 +7547,54 @@
           </Collection>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.callRecords.participantEndpoint/identity">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2023-11-06"/>
+              <PropertyValue Property="Description" String="This property is deprecated and will be removed in a future version. Use associatedIdentity instead."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-11-06"/>
+              <PropertyValue Property="Version" String="2023-11/New_Properties_Added"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.callRecords.callRecord/organizer">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2023-11-06"/>
+              <PropertyValue Property="Description" String="This property is deprecated and will be removed in a future version. Use organizer_v2 instead."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-11-06"/>
+              <PropertyValue Property="Version" String="2023-06/New_Properties_Added"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.callRecords.callRecord/participants">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2023-11-06"/>
+              <PropertyValue Property="Description" String="This property is deprecated and will be removed in a future version. Use participants_v2 instead."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-11-06"/>
+              <PropertyValue Property="Version" String="2023-06/New_Properties_Added"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.callRecords.callRecord/organizer_v2">
+        <Annotation Term="Org.OData.Core.V1.AutoExpand" Bool="true"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.agreement">
         <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
           <Record>
@@ -6408,9 +7611,9 @@
             <PropertyValue Property="Filterable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6437,9 +7640,9 @@
             <PropertyValue Property="Filterable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6466,9 +7669,9 @@
             <PropertyValue Property="Filterable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6495,9 +7698,9 @@
             <PropertyValue Property="Filterable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6519,9 +7722,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6538,9 +7741,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -6555,9 +7758,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -6572,9 +7775,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -6586,9 +7789,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -6598,9 +7801,9 @@
             <PropertyValue Property="Filterable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
@@ -6892,6 +8095,12 @@
       <Annotations Target="microsoft.graph.win32LobAppAssignmentSettings">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties used to assign an Win32 LOB mobile app to a group."/>
       </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAppAutoUpdateSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties used to perform the auto-update of an application."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAppAssignmentSettings/autoUpdateSettings">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The auto-update settings to apply for this app assignment."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppAssignmentSettings/deliveryOptimizationPriority">
         <Annotation Term="Org.OData.Core.V1.Description" String="The delivery optimization priority for this app assignment. This setting is not supported in National Cloud environments."/>
       </Annotations>
@@ -6906,6 +8115,9 @@
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppAssignmentSettings/restartSettings">
         <Annotation Term="Org.OData.Core.V1.Description" String="The reboot settings to apply for this app assignment."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.win32LobAppAutoUpdateSettings/autoUpdateSupersededAppsState">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The auto-update superseded apps state setting for the app assignment. Possible values are notConfigured and enabled. Default value is notConfigured."/>
       </Annotations>
       <Annotations Target="microsoft.graph.win32LobAppRule">
         <Annotation Term="Org.OData.Core.V1.Description" String="A base complex type to store the detection or requirement rule data for a Win32 LOB app."/>
@@ -7100,7 +8312,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The value for the minimum applicable operating system."/>
       </Annotations>
       <Annotations Target="microsoft.graph.androidStoreApp/packageId">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The package identifier."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The package identifier. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceAppManagement">
         <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity that acts as a container for all device app management functionality."/>
@@ -7206,6 +8422,12 @@
       </Annotations>
       <Annotations Target="microsoft.graph.deviceAppManagement/windowsInformationProtectionPolicies">
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows information protection for apps running on devices which are not MDM enrolled."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagementExportJob">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity representing a job to export a report."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceManagementReports/exportJobs">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity representing a job to export a report."/>
       </Annotations>
       <Annotations Target="microsoft.graph.enterpriseCodeSigningCertificate/content">
         <Annotation Term="Org.OData.Core.V1.Description" String="The Windows Enterprise Code-Signing Certificate in the raw data format. Set to null once certificate has been uploaded and other properties have been populated."/>
@@ -7331,7 +8553,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, indicates that the app's version will NOT be used to detect if the app is installed on a device. When FALSE, indicates that the app's version will be used to detect if the app is installed on a device. Set this to true for apps that use a self update feature. The default value is FALSE."/>
       </Annotations>
       <Annotations Target="microsoft.graph.macOSDmgApp/includedApps">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of .apps expected to be installed by the DMG (Apple Disk Image)"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of .apps expected to be installed by the DMG (Apple Disk Image). This collection can contain a maximum of 500 elements."/>
       </Annotations>
       <Annotations Target="microsoft.graph.macOSDmgApp/minimumSupportedOperatingSystem">
         <Annotation Term="Org.OData.Core.V1.Description" String="ComplexType macOSMinimumOperatingSystem that indicates the minimum operating system applicable for the application."/>
@@ -7418,7 +8640,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The app's package ID."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedApp/appAvailability">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Application's availability."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Application's availability. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.managedApp/version">
         <Annotation Term="Org.OData.Core.V1.Description" String="The Application's version."/>
@@ -7595,13 +8821,21 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The name of the main Lob application file."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedMobileLobApp/size">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The total size, including all uploaded files."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The total size, including all uploaded files. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContent">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains content properties for a specific app version. Each mobileAppContent can have multiple mobileAppContentFile."/>
       </Annotations>
       <Annotations Target="microsoft.graph.managedMobileLobApp/contentVersions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of content versions for this app."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of content versions for this app. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.microsoftStoreForBusinessApp">
         <Annotation Term="Org.OData.Core.V1.Description" String="Microsoft Store for Business Apps. This class does not support Create, Delete, or Update."/>
@@ -7622,7 +8856,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The number of Microsoft Store for Business licenses in use."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileApp/createdDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the app was created."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the app was created. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileApp/description">
         <Annotation Term="Org.OData.Core.V1.Description" String="The description of the app."/>
@@ -7643,7 +8881,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The large icon, to be displayed in the app details and used for upload of the icon."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileApp/lastModifiedDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the app was last modified."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the app was last modified. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileApp/notes">
         <Annotation Term="Org.OData.Core.V1.Description" String="Notes for the app."/>
@@ -7658,7 +8900,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The publisher of the app."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileApp/publishingState">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The publishing state for the app. The app cannot be assigned unless the app is published."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The publishing state for the app. The app cannot be assigned unless the app is published. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppAssignment">
         <Annotation Term="Org.OData.Core.V1.Description" String="A class containing the properties used for Group Assignment of a Mobile App."/>
@@ -7682,7 +8928,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The name of the app category."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppCategory/lastModifiedDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the mobileAppCategory was last modified."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time the mobileAppCategory was last modified. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileContainedApp">
         <Annotation Term="Org.OData.Core.V1.Description" String="An abstract class that represents a contained app in a mobileApp acting as a package."/>
@@ -7697,31 +8947,54 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The list of files for this app content version."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/azureStorageUri">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Azure Storage URI."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the Azure Storage URI that the file is uploaded to. Created by the service upon receiving a valid mobileAppContentFile. Read-only. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/azureStorageUriExpirationDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The time the Azure storage Uri expires."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the date and time when the Azure storage URI expires, in ISO 8601 format. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/createdDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The time the file was created."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates created date and time associated with app content file, in ISO 8601 format. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/isCommitted">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A value indicating whether the file is committed."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="A value indicating whether the file is committed. A committed app content file has been fully uploaded and validated by the Intune service. TRUE means that app content file is committed, FALSE means that app content file is not committed. Defaults to FALSE. Read-only. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.mobileAppContentFile/isDependency">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether this content file is a dependency for the main content file. TRUE means that the content file is a dependency, FALSE means that the content file is not a dependency and is the main content file. Defaults to FALSE."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/manifest">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The manifest information."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the manifest information, containing file metadata."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/name">
-        <Annotation Term="Org.OData.Core.V1.Description" String="the file name."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the name of the file."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/size">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The size of the file prior to encryption."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The size of the file prior to encryption. To be deprecated, please use sizeInBytes property instead."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/sizeEncrypted">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The size of the file after encryption."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The size of the file after encryption. To be deprecated, please use sizeEncryptedInBytes property instead."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileAppContentFile/uploadState">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The state of the current upload request."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates the state of the current upload request. Possible values are: success, transientError, error, unknown, azureStorageUriRequestSuccess, azureStorageUriRequestPending, azureStorageUriRequestFailed, azureStorageUriRequestTimedOut, azureStorageUriRenewalSuccess, azureStorageUriRenewalPending, azureStorageUriRenewalFailed, azureStorageUriRenewalTimedOut, commitFileSuccess, commitFilePending, commitFileFailed, commitFileTimedOut. Default value is success. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileLobApp/committedContentVersion">
         <Annotation Term="Org.OData.Core.V1.Description" String="The internal committed content version."/>
@@ -7730,10 +9003,18 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The name of the main Lob application file."/>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileLobApp/size">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The total size, including all uploaded files."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The total size, including all uploaded files. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.mobileLobApp/contentVersions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of content versions for this app."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of content versions for this app. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.webApp">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties and inherited properties for web apps."/>
@@ -7862,7 +9143,11 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The value for the minimum applicable Windows operating system."/>
       </Annotations>
       <Annotations Target="microsoft.graph.windowsUniversalAppX/committedContainedApps">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The collection of contained apps in the committed mobileAppContent of a windowsUniversalAppX app."/>
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="The collection of contained apps in the committed mobileAppContent of a windowsUniversalAppX app. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.windowsUniversalAppXContainedApp">
         <Annotation Term="Org.OData.Core.V1.Description" String="A class that represents a contained app of a WindowsUniversalAppX app."/>
@@ -7930,9 +9215,6 @@
       <Annotations Target="microsoft.graph.auditResource/resourceId">
         <Annotation Term="Org.OData.Core.V1.Description" String="Audit resource's Id."/>
       </Annotations>
-      <Annotations Target="microsoft.graph.auditEvent">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A class containing the properties for Audit Event."/>
-      </Annotations>
       <Annotations Target="microsoft.graph.auditEvent/activity">
         <Annotation Term="Org.OData.Core.V1.Description" String="Friendly name of the activity."/>
       </Annotations>
@@ -7965,360 +9247,6 @@
       </Annotations>
       <Annotations Target="microsoft.graph.auditEvent/resources">
         <Annotation Term="Org.OData.Core.V1.Description" String="Resources being modified."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity that acts as a container for all device management functionality."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.termsAndConditions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&amp;C) policy. T&amp;C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/termsAndConditions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The terms and conditions associated with device management of the company."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/auditEvents">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Audit Events"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/intuneAccountId">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Intune Account Id for given tenant"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/settings">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Account level settings."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceCompliancePolicy">
-        <Annotation Term="Org.OData.Core.V1.Description" String="This is the base class for Compliance policy. Compliance policies are platform specific and individual per-platform compliance policies inherit from here. "/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicies">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The device compliance policies."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicyDeviceStateSummary">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The device compliance state summary for this account."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceCompliancePolicySettingStateSummary">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device Compilance Policy Setting State summary across the account."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceCompliancePolicySettingStateSummaries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The summary states of compliance policy settings for this account."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceConfigurationDeviceStateSummaries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The device configuration device state summary for this account."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceConfiguration">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device Configuration."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceConfigurations">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The device configurations."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/iosUpdateStatuses">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The IOS software update installation statuses for this account."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/softwareUpdateStatusSummary">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The software update status summary."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.intuneBrand">
-        <Annotation Term="Org.OData.Core.V1.Description" String="intuneBrand contains data which is used in customizing the appearance of the Company Portal applications as well as the end user web portal."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/intuneBrand">
-        <Annotation Term="Org.OData.Core.V1.Description" String="intuneBrand contains data which is used in customizing the appearance of the Company Portal applications as well as the end user web portal."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.complianceManagementPartner">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Compliance management partner for all platforms"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/complianceManagementPartners">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Compliance Management Partners configured by the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.onPremisesConditionalAccessSettings">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity which represents the Exchange OnPremises Conditional Access Settings for a tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/conditionalAccessSettings">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Exchange on premises conditional access settings. On premises conditional access will require devices to be both enrolled and compliant for mail access"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceCategory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device categories provides a way to organize your devices. Using device categories, company administrators can define their own categories that make sense to their company. These categories can then be applied to a device in the Intune Azure console or selected by a user during device enrollment. You can filter reports and create dynamic Azure Active Directory device groups based on device categories."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceCategories">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of device categories with the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceEnrollmentConfiguration">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Base Class of Device Enrollment Configuration"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceEnrollmentConfigurations">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of device enrollment configurations"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagementPartner">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to device management partner."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceManagementPartners">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Device Management Partners configured by the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagementExchangeConnector">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to an Exchange environment."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/exchangeConnectors">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Exchange Connectors configured by the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.mobileThreatDefenseConnector">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Entity which represents a connection to Mobile Threat Defense partner."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/mobileThreatDefenseConnectors">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of Mobile threat Defense connectors configured by the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceProtectionOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Hardware information of a given device."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/deviceProtectionOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device protection overview."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/subscriptionState">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Tenant mobile device management subscription state."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsSettings">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics insight is the recomendation to improve the user experience analytics score."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsSettings">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device settings"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.windowsMalwareOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows device malware overview."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/windowsMalwareOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Malware overview for windows devices."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.applePushNotificationCertificate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Apple push notification certificate."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/applePushNotificationCertificate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Apple push notification certificate."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.detectedApp">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/detectedApps">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of detected apps associated with a device."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.managedDeviceOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Summary data for managed devices"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/managedDeviceOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device overview"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/managedDevices">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of managed devices."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/mobileAppTroubleshootingEvents">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The collection property of MobileAppTroubleshootingEvent."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthApplicationPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance by application version details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by App Version details"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains application performance by application version device id."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by App Version Device Id"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByOSVersion">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics application performance entity contains app performance details by OS version."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Application Performance by OS Version"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDeviceModelPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device model performance entity contains device model performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDeviceModelPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Model Performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDevicePerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth Device Performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformanceDetails">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthDevicePerformanceDetails">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device performance details"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsAppHealthOSVersionPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device OS version performance entity contains OS version performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthOSVersionPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth OS version Performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsCategory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics category entity contains the scores and insights for the various metrics of a category."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsAppHealthOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics appHealth overview"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsBaseline">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics baseline entity contains baseline values against which to compare the user experience analytics scores."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsBaselines">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics baselines"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsCategories">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics categories"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsDevicePerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device performance entity contains device boot performance details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDevicePerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceScores">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device scores entity consolidates the various Endpoint Analytics scores."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceScores">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device scores"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup history entity contains device boot performance history details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup History"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupProcess">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup process details."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupProcesses">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Processes"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsDeviceStartupProcessPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup process performance."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsDeviceStartupProcessPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Process Performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsMetricHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics metric history."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsMetricHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics metric history"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsModelScores">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics model scores entity consolidates the various Endpoint Analytics scores."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsModelScores">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics model scores"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics overview entity contains the overall score and the scores and insights of every metric of all categories."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsOverview">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics overview"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsScoreHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics device startup score history."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsScoreHistory">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics device Startup Score History"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics hardware readiness entity contains account level information about hardware blockers for windows upgrade."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics work from anywhere hardware readiness metrics."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereMetric">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics metric for work from anywhere report."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereMetrics">
-        <Annotation Term="Org.OData.Core.V1.Description" String="User experience analytics work from anywhere metrics."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.userExperienceAnalyticsWorkFromAnywhereModelPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics work from anywhere model performance."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/userExperienceAnalyticsWorkFromAnywhereModelPerformance">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The user experience analytics work from anywhere model performance"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.windowsMalwareInformation">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Malware information entity."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/windowsMalwareInformation">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of affected malware in the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentity">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Imported windows autopilot devices."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/importedWindowsAutopilotDeviceIdentities">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Collection of imported Windows autopilot devices."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.windowsAutopilotDeviceIdentity">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The windowsAutopilotDeviceIdentity resource represents a Windows Autopilot Device."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/windowsAutopilotDeviceIdentities">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Windows autopilot device identities contained collection."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.notificationMessageTemplate">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/notificationMessageTemplates">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Notification Message Templates."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.resourceOperation">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Describes the resourceOperation resource (entity) of the Microsoft Graph API (REST), which supports Intune workflows related to role-based access control (RBAC)."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/resourceOperations">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Resource Operations."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.roleAssignment">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceAndAppManagementRoleAssignment">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/roleAssignments">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Assignments."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.roleDefinition">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/roleDefinitions">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The Role Definitions."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.remoteAssistancePartner">
-        <Annotation Term="Org.OData.Core.V1.Description" String="RemoteAssistPartner resources represent the metadata and status of a given Remote Assistance partner service."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/remoteAssistancePartners">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The remote assist partners."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagementReports">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Singleton entity that acts as a container for all reports functionality."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/reports">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Reports singleton"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.telecomExpenseManagementPartner">
-        <Annotation Term="Org.OData.Core.V1.Description" String="telecomExpenseManagementPartner resources represent the metadata and status of a given TEM service. Once your organization has onboarded with a partner, the partner can be enabled or disabled to switch TEM functionality on or off."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/telecomExpenseManagementPartners">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The telecom expense management partners."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/troubleshootingEvents">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The list of troubleshooting events for the tenant."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.windowsInformationProtectionAppLearningSummary">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows Information Protection AppLearning Summary entity."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/windowsInformationProtectionAppLearningSummaries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The windows information protection app learning summaries."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.windowsInformationProtectionNetworkLearningSummary">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows Information Protection Network learning Summary entity."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagement/windowsInformationProtectionNetworkLearningSummaries">
-        <Annotation Term="Org.OData.Core.V1.Description" String="The windows information protection network learning summaries."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceInstallState">
         <Annotation Term="Org.OData.Core.V1.Description" String="Contains properties for the installation state for a device."/>
@@ -9206,10 +10134,10 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="Require Google Play Services to be installed and enabled on the device."/>
       </Annotations>
       <Annotations Target="microsoft.graph.androidWorkProfileCompliancePolicy/securityRequireSafetyNetAttestationBasicIntegrity">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Require the device to pass the SafetyNet basic integrity check."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Require the device to pass the Play Integrity basic integrity check."/>
       </Annotations>
       <Annotations Target="microsoft.graph.androidWorkProfileCompliancePolicy/securityRequireSafetyNetAttestationCertifiedDevice">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Require the device to pass the SafetyNet certified device check."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Require the device to pass the Play Integrity device integrity check."/>
       </Annotations>
       <Annotations Target="microsoft.graph.androidWorkProfileCompliancePolicy/securityRequireUpToDateSecurityProviders">
         <Annotation Term="Org.OData.Core.V1.Description" String="Require the device to have up to date security providers. The device will require Google Play Services to be enabled and up to date."/>
@@ -9616,6 +10544,9 @@
       <Annotations Target="microsoft.graph.deviceConfiguration/deviceSettingStateSummaries">
         <Annotation Term="Org.OData.Core.V1.Description" String="Device Configuration Setting State Device Summary"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.deviceConfigurationDeviceStatus">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Support for this Entity is being deprecated starting May 2026 &amp; will no longer be supported."/>
+      </Annotations>
       <Annotations Target="microsoft.graph.deviceConfiguration/deviceStatuses">
         <Annotation Term="Org.OData.Core.V1.Description" String="Device configuration installation status by device."/>
       </Annotations>
@@ -9695,7 +10626,7 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="UserPrincipalName."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceConfigurationState">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device Configuration State for a given device."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Support for this Entity is being deprecated starting May 2026 &amp; will no longer be supported."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceConfigurationState/displayName">
         <Annotation Term="Org.OData.Core.V1.Description" String="The name of the policy for this policyBase"/>
@@ -10527,6 +11458,13 @@
       <Annotations Target="microsoft.graph.managedDevice/enrolledDateTime">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
         <Annotation Term="Org.OData.Core.V1.Description" String="Enrollment time of the device. Supports $filter operator 'lt' and 'gt'. This property is read-only."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.managedDevice/enrollmentProfileName">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Name of the enrollment profile assigned to the device. Default value is empty string, indicating no enrollment profile was assgined. This property is read-only."/>
         <Annotation Term="Org.OData.Core.V1.Permissions">
           <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
         </Annotation>
@@ -12372,22 +13310,22 @@
         <Annotation Term="Org.OData.Core.V1.Description" String="The maximum number of devices that a user can enroll"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Device Enrollment Configuration that restricts the types of devices a user can enroll"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Default Device Enrollment Platform Restrictions Configuration that restricts the types of devices a user can enroll"/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration/androidRestriction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Android restrictions based on platform, platform operating system version, and device ownership"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates restrictions for Android platform."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration/iosRestriction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Ios restrictions based on platform, platform operating system version, and device ownership"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates restrictions for IOS platform."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration/macOSRestriction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Mac restrictions based on platform, platform operating system version, and device ownership"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates restrictions for MacOS platform."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration/windowsMobileRestriction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows mobile restrictions based on platform, platform operating system version, and device ownership"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates restrictions for Windows Mobile platform."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentPlatformRestrictionsConfiguration/windowsRestriction">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Windows restrictions based on platform, platform operating system version, and device ownership"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates restrictions for Windows platform."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceEnrollmentWindowsHelloForBusinessConfiguration">
         <Annotation Term="Org.OData.Core.V1.Description" String="Windows Hello for Business settings lets users access their devices using a gesture, such as biometric authentication, or a PIN. Configure settings for enrolled Windows 10, Windows 10 Mobile and later."/>
@@ -12574,6 +13512,12 @@
       </Annotations>
       <Annotations Target="microsoft.graph.vppToken/vppTokenAccountType">
         <Annotation Term="Org.OData.Core.V1.Description" String="The type of volume purchase program which the given Apple Volume Purchase Program Token is associated with. Possible values are: `business`, `education`."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windows10EnrollmentCompletionPageConfiguration">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows 10 Enrollment Status Page Configuration"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windows10EnrollmentCompletionPageConfiguration/allowNonBlockingAppInstallation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, ESP (Enrollment Status Page) installs all required apps targeted during technician phase and ignores any failures for non-blocking apps. When FALSE, ESP fails on any error during app install. The default is false."/>
       </Annotations>
       <Annotations Target="microsoft.graph.appLogCollectionDownloadDetails/appLogDecryptionAlgorithm">
         <Annotation Term="Org.OData.Core.V1.Description" String="Decryption algorithm for Content. Default is ASE256."/>
@@ -12874,6 +13818,9 @@
       </Annotations>
       <Annotations Target="microsoft.graph.resetPasscodeActionResult">
         <Annotation Term="Org.OData.Core.V1.Description" String="Reset passcode action result"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.resetPasscodeActionResult/errorCode">
+        <Annotation Term="Org.OData.Core.V1.Description" String="RotateBitLockerKeys action error code. Valid values 0 to 2147483647"/>
       </Annotations>
       <Annotations Target="microsoft.graph.resetPasscodeActionResult/passcode">
         <Annotation Term="Org.OData.Core.V1.Description" String="Newly generated passcode for the device "/>
@@ -13956,6 +14903,27 @@
       <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentityState/deviceRegistrationId">
         <Annotation Term="Org.OData.Core.V1.Description" String="Device Registration ID for successfully added device reported by Device Directory Service(DDS)."/>
       </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Windows Autopilot Deployment Profile settings used by the device for the out-of-box experience. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/deviceUsageType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Entra join authentication type. Possible values are singleUser and shared. The default is singleUser."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/escapeLinkHidden">
+        <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, the link that allows user to start over with a different account on company sign-in is hidden. When false, the link that allows user to start over with a different account on company sign-in is available. Default value is FALSE."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/eulaHidden">
+        <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, EULA is hidden to the end user during OOBE. When FALSE, EULA is shown to the end user during OOBE. Default value is FALSE."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/keyboardSelectionPageSkipped">
+        <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, the keyboard selection page is hidden to the end user during OOBE if Language and Region are set. When FALSE, the keyboard selection page is skipped during OOBE."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/privacySettingsHidden">
+        <Annotation Term="Org.OData.Core.V1.Description" String="When TRUE, privacy settings is hidden to the end user during OOBE. When FALSE, privacy settings is shown to the end user during OOBE. Default value is FALSE."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.outOfBoxExperienceSetting/userType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The type of user. Possible values are administrator and standard. Default value is administrator. Yes No&#13;&#10;"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentity/assignedUserPrincipalName">
         <Annotation Term="Org.OData.Core.V1.Description" String="UPN of the user the device will be assigned"/>
       </Annotations>
@@ -13988,6 +14956,51 @@
       </Annotations>
       <Annotations Target="microsoft.graph.importedWindowsAutopilotDeviceIdentityUpload/deviceIdentities">
         <Annotation Term="Org.OData.Core.V1.Description" String="Collection of all Autopilot devices as a part of this upload."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Windows Autopilot Deployment Profile"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/createdDateTime">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time of when the deployment profile was created. The value cannot be modified and is automatically populated when the profile was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported. Read-Only."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/description">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A description of the deployment profile. Max allowed length is 1500 chars. Supports: $select, $top, $skip, $orderBy. $Search and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/deviceNameTemplate">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The template used to name the Autopilot device. This can be a custom text and can also contain either the serial number of the device, or a randomly generated number. The total length of the text generated by the template can be no more than 15 characters. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/deviceType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Windows device type that this profile is applicable to. Possible values include windowsPc, holoLens, and virtualMachine. The default is windowsPc. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/displayName">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The display name of the deployment profile. Max allowed length is 200 chars. Returned by default. Supports: $select, $top, $skip, $orderby. $Search and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/hardwareHashExtractionEnabled">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether the profile supports the extraction of hardware hash values and registration of the device into Windows Autopilot. When TRUE, indicates if hardware extraction and Windows Autopilot registration will happen on the next successful check-in. When FALSE, hardware hash extraction and Windows Autopilot registration will not happen. Default value is FALSE. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/lastModifiedDateTime">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The date and time of when the deployment profile was last modified. The value cannot be updated manually and is automatically populated when any changes are made to the profile. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported Read-Only."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/locale">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The locale (language) to be used when configuring the device. E.g. en-US. The default value is os-default. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/managementServiceAppId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Entra management service App ID which gets used during client device-based enrollment discovery. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/outOfBoxExperienceSetting">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Windows Autopilot Deployment Profile settings used by the device for the out-of-box experience. Supports: $select, $top, $skip. $Search, $orderBy and $filter are not supported."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/preprovisioningAllowed">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Indicates whether the user is allowed to use Windows Autopilot for pre-provisioned deployment mode during Out of Box experience (OOBE). When TRUE, indicates that Windows Autopilot for pre-provisioned deployment mode for OOBE is allowed to be used. When false, Windows Autopilot for pre-provisioned deployment mode for OOBE is not allowed. The default is FALSE."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/roleScopeTagIds">
+        <Annotation Term="Org.OData.Core.V1.Description" String="List of role scope tags for the deployment profile. "/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfile/assignedDevices">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The list of assigned devices for the profile."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.windowsAutopilotDeploymentProfileAssignment">
+        <Annotation Term="Org.OData.Core.V1.Description" String="An assignment of a Windows Autopilot deployment profile to an AAD group."/>
       </Annotations>
       <Annotations Target="microsoft.graph.windowsAutopilotDeviceIdentity/addressableUserName">
         <Annotation Term="Org.OData.Core.V1.Description" String="Addressable user name."/>
@@ -14714,41 +15727,38 @@
       <Annotations Target="microsoft.graph.remoteAssistancePartner/onboardingUrl">
         <Annotation Term="Org.OData.Core.V1.Description" String="URL of the partner's onboarding portal, where an administrator can configure their Remote Assistance service."/>
       </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagementExportJob">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Entity representing a job to export a report"/>
+      <Annotations Target="microsoft.graph.deviceManagementCachedReportConfiguration">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Entity representing the configuration of a cached report."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/expirationDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Time that the exported report expires"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Time that the exported report expires."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/filter">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Filters applied on the report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Filters applied on the report. The maximum length allowed for this property is 2000 characters."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/format">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Format of the exported report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Format of the exported report. Possible values are `csv` and `json`."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/localizationType">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Configures how the requested export job is localized"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Configures how the requested export job is localized. Possible values are `replaceLocalizableValues` and `localizedValuesAsAdditionalColumn`."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/reportName">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Name of the report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Name of the report. The maximum length allowed for this property is 2000 characters."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/requestDateTime">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Time that the exported report was requested"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Time that the exported report was requested."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/select">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Columns selected from the report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Columns selected from the report. The maximum number of allowed columns names is 256. The maximum length allowed for each column name in this property is 1000 characters."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/snapshotId">
-        <Annotation Term="Org.OData.Core.V1.Description" String="A snapshot is an identifiable subset of the dataset represented by the ReportName. A sessionId or CachedReportConfiguration id can be used here. If a sessionId is specified, Filter, Select, and OrderBy are applied to the data represented by the sessionId. Filter, Select, and OrderBy cannot be specified together with a CachedReportConfiguration id."/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="A snapshot is an identifiable subset of the dataset represented by the ReportName. A sessionId or CachedReportConfiguration id can be used here. If a sessionId is specified, Filter, Select, and OrderBy are applied to the data represented by the sessionId. Filter, Select, and OrderBy cannot be specified together with a CachedReportConfiguration id. The maximum length allowed for this property is 128 characters."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/status">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Status of the export job"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Status of the export job. Possible values are `unknown`, `notStarted`, `inProgress`, `completed` and `failed`."/>
       </Annotations>
       <Annotations Target="microsoft.graph.deviceManagementExportJob/url">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Temporary location of the exported report"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceManagementReports/exportJobs">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Entity representing a job to export a report"/>
+        <Annotation Term="Org.OData.Core.V1.Description" String="Temporary location of the exported report."/>
       </Annotations>
       <Annotations Target="microsoft.graph.telecomExpenseManagementPartner/appAuthorized">
         <Annotation Term="Org.OData.Core.V1.Description" String="Whether the partner's AAD app has been authorized to access Intune."/>
@@ -14849,18 +15859,288 @@
       <Annotations Target="microsoft.graph.usedInsight/resourceVisualization">
         <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.windowsSetting/instances">
+        <Annotation Term="Org.OData.Core.V1.AutoExpand" Bool="true"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.peopleAdminSettings/pronouns">
+        <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+          <Record>
+            <PropertyValue Property="Deletable" Bool="false"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+          <Record>
+            <PropertyValue Property="Insertable" Bool="false"/>
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="microsoft.graph.activityHistoryItem">
         <Annotation Term="Org.OData.Capabilities.V1.CountRestrictions">
           <Record>
             <PropertyValue Property="Countable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="false"/>
+            <PropertyValue Property="Supported" Bool="false"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertDetection">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertHistoryState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.alertTrigger">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.cloudAppSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.fileHash">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.fileSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.hostSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.investigationSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.malwareState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.messageSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.networkConnection">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.process">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.registryKeyState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.securityResource">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.uriClickSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.userSecurityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.vulnerabilityState">
+        <Annotation Term="Org.OData.Core.V1.Revisions">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Date" Date="2024-04-10"/>
+              <PropertyValue Property="Description" String="The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API."/>
+              <PropertyValue Property="Kind">
+                <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RemovalDate" Date="2026-04-10"/>
+              <PropertyValue Property="Version" String="2024-01/Deprecation"/>
+            </Record>
+          </Collection>
+        </Annotation>
       </Annotations>
       <Annotations Target="microsoft.graph.authentication/fido2Methods">
         <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
@@ -15028,9 +16308,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15057,9 +16337,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -15091,9 +16371,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15125,9 +16405,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15154,9 +16434,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15192,9 +16472,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15234,9 +16514,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -15263,9 +16543,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15292,9 +16572,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -15340,9 +16620,9 @@
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15388,9 +16668,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15417,9 +16697,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -15451,9 +16731,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="false"/>
@@ -15485,9 +16765,9 @@
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SelectRestrictions">
+        <Annotation Term="Org.OData.Capabilities.V1.SelectSupport">
           <Record>
-            <PropertyValue Property="Selectable" Bool="true"/>
+            <PropertyValue Property="Supported" Bool="true"/>
           </Record>
         </Annotation>
         <Annotation Term="Org.OData.Capabilities.V1.SkipSupported" Bool="true"/>
@@ -15551,6 +16831,60 @@
           </Record>
         </Annotation>
       </Annotations>
+      <Annotations Target="microsoft.graph.community">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Represents a community in Viva Engage that is a central place for conversations,&#10;files, events, and updates for people sharing a common interest or goal."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/description">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The description of the community. The maximum length is 1024 characters."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/displayName">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The name of the community. The maximum length is 255 characters."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/groupId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The ID of the Microsoft 365 group that manages the membership of this community."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/privacy">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Defines the privacy level of the community. The possible values are: public, private, unknownFutureValue."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/group">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The Microsoft 365 group that manages the membership of this community."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.community/owners">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The admins of the community. Limited to 100 users."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.employeeExperience">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Represents a container that exposes navigation properties for employee experience resources."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.employeeExperience/communities">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A collection of communities in Viva Engage."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperation">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Represents the status of a Viva Engage async operation that is an operation that transcends the&#10;lifetime of a single API request. These operations are long-running or too expensive to complete&#10;within the time frame of their original request."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.employeeExperience/engagementAsyncOperations">
+        <Annotation Term="Org.OData.Core.V1.Description" String="A collection of long-running, asynchronous operations related to Viva Engage."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperation/operationType">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The type of the long-running operation."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.engagementAsyncOperation/resourceId">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The ID of the object created or modified as a result of this async operation."/>
+        <Annotation Term="Org.OData.Core.V1.Permissions">
+          <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceConfigurationDeviceActivity(microsoft.graph.reportRoot)">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Metadata for the device configuration device activity report"/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.deviceConfigurationUserActivity(microsoft.graph.reportRoot)">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Metadata for the device configuration user activity report"/>
+      </Annotations>
       <Annotations Target="microsoft.graph.cancel(microsoft.graph.bookingAppointment, Edm.String)">
         <Annotation Term="Org.OData.Core.V1.Description" String="Cancels the giving booking appointment, sending a message to the involved parties."/>
       </Annotations>
@@ -15598,12 +16932,6 @@
       </Annotations>
       <Annotations Target="microsoft.graph.renewUpload(microsoft.graph.mobileAppContentFile)">
         <Annotation Term="Org.OData.Core.V1.Description" String="Renews the SAS URI for an application file upload."/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceConfigurationDeviceActivity(microsoft.graph.reportRoot)">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Metadata for the device configuration device activity report"/>
-      </Annotations>
-      <Annotations Target="microsoft.graph.deviceConfigurationUserActivity(microsoft.graph.reportRoot)">
-        <Annotation Term="Org.OData.Core.V1.Description" String="Metadata for the device configuration user activity report"/>
       </Annotations>
       <Annotations Target="microsoft.graph.syncLicenses(microsoft.graph.vppToken)">
         <Annotation Term="Org.OData.Core.V1.Description" String="Syncs licenses associated with a specific appleVolumePurchaseProgramToken"/>
@@ -15677,6 +17005,12 @@
       <Annotations Target="microsoft.graph.disconnect(microsoft.graph.remoteAssistancePartner)">
         <Annotation Term="Org.OData.Core.V1.Description" String="A request to remove the active TeamViewer connector"/>
       </Annotations>
+      <Annotations Target="microsoft.graph.endWorkingTime(microsoft.graph.workingTimeSchedule)">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Triggers the policies associated with the end of working hours for user."/>
+      </Annotations>
+      <Annotations Target="microsoft.graph.startWorkingTime(microsoft.graph.workingTimeSchedule)">
+        <Annotation Term="Org.OData.Core.V1.Description" String="Triggers the policies associated with the start of working hours for user."/>
+      </Annotations>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph" Alias="graph">
       <EnumType Name="appliedConditionalAccessPolicyResult">
@@ -15686,6 +17020,10 @@
         <Member Name="notEnabled" Value="3"/>
         <Member Name="unknown" Value="4"/>
         <Member Name="unknownFutureValue" Value="5"/>
+        <Member Name="reportOnlySuccess" Value="6"/>
+        <Member Name="reportOnlyFailure" Value="7"/>
+        <Member Name="reportOnlyNotApplied" Value="8"/>
+        <Member Name="reportOnlyInterrupted" Value="9"/>
       </EnumType>
       <EnumType Name="authenticationMethodFeature">
         <Member Name="ssprRegistered" Value="0"/>
@@ -15728,6 +17066,12 @@
         <Member Name="user" Value="0"/>
         <Member Name="application" Value="1"/>
         <Member Name="system" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="migrationStatus">
+        <Member Name="ready" Value="0"/>
+        <Member Name="needsReview" Value="1"/>
+        <Member Name="additionalStepsRequired" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="operationResult">
@@ -15791,6 +17135,9 @@
         <Member Name="adminConfirmedServicePrincipalCompromised" Value="13"/>
         <Member Name="adminDismissedAllRiskForServicePrincipal" Value="14"/>
         <Member Name="m365DAdminDismissedDetection" Value="12"/>
+        <Member Name="userChangedPasswordOnPremises" Value="15"/>
+        <Member Name="adminDismissedRiskForSignIn" Value="16"/>
+        <Member Name="adminConfirmedAccountSafe" Value="17"/>
       </EnumType>
       <EnumType Name="riskEventType">
         <Member Name="unlikelyTravel" Value="0"/>
@@ -15928,15 +17275,26 @@
         <Member Name="push" Value="1"/>
         <Member Name="any" Value="2"/>
       </EnumType>
+      <EnumType Name="x509CertificateAffinityLevel">
+        <Member Name="low" Value="0"/>
+        <Member Name="high" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="x509CertificateAuthenticationMode">
         <Member Name="x509CertificateSingleFactor" Value="0"/>
         <Member Name="x509CertificateMultiFactor" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="x509CertificateCRLValidationConfigurationState">
+        <Member Name="disabled" Value="0"/>
+        <Member Name="enabled" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="x509CertificateRuleType">
         <Member Name="issuerSubject" Value="0"/>
         <Member Name="policyOID" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
+        <Member Name="issuerSubjectAndPolicyOID" Value="3"/>
       </EnumType>
       <EnumType Name="volumeType">
         <Member Name="operatingSystemVolume" Value="1"/>
@@ -15947,6 +17305,11 @@
       <EnumType Name="answerInputType">
         <Member Name="text" Value="0"/>
         <Member Name="radioButton" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="bookingPageAccessControl">
+        <Member Name="unrestricted" Value="0"/>
+        <Member Name="restrictedToOrganization" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="bookingPriceType">
@@ -15972,6 +17335,18 @@
         <Member Name="slotsAvailable" Value="2"/>
         <Member Name="outOfOffice" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="bookingsServiceAvailabilityType">
+        <Member Name="bookWhenStaffAreFree" Value="0"/>
+        <Member Name="notBookable" Value="1"/>
+        <Member Name="customWeeklyHours" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="bookingStaffMembershipStatus">
+        <Member Name="active" Value="0"/>
+        <Member Name="pendingAcceptance" Value="1"/>
+        <Member Name="rejectedByStaff" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="bookingStaffRole">
         <Member Name="guest" Value="0"/>
@@ -16028,6 +17403,191 @@
         <Member Name="business" Value="2"/>
         <Member Name="other" Value="3"/>
       </EnumType>
+      <EnumType Name="cloudPcAuditActivityOperationType">
+        <Member Name="create" Value="0"/>
+        <Member Name="delete" Value="1"/>
+        <Member Name="patch" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="cloudPcAuditActivityResult">
+        <Member Name="success" Value="0"/>
+        <Member Name="clientError" Value="1"/>
+        <Member Name="failure" Value="2"/>
+        <Member Name="timeout" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="cloudPcAuditCategory">
+        <Member Name="cloudPC" Value="0"/>
+        <Member Name="unknownFutureValue" Value="1"/>
+      </EnumType>
+      <EnumType Name="cloudPcDeviceImageErrorCode">
+        <Member Name="internalServerError" Value="0"/>
+        <Member Name="sourceImageNotFound" Value="1"/>
+        <Member Name="osVersionNotSupported" Value="2"/>
+        <Member Name="sourceImageInvalid" Value="3"/>
+        <Member Name="sourceImageNotGeneralized" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+        <Member Name="vmAlreadyAzureAdjoined" Value="6"/>
+        <Member Name="paidSourceImageNotSupport" Value="7"/>
+        <Member Name="sourceImageNotSupportCustomizeVMName" Value="8"/>
+        <Member Name="sourceImageSizeExceedsLimitation" Value="9"/>
+      </EnumType>
+      <EnumType Name="cloudPcDeviceImageOsStatus">
+        <Member Name="supported" Value="0"/>
+        <Member Name="supportedWithWarning" Value="1"/>
+        <Member Name="unknown" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="cloudPcDeviceImageStatus">
+        <Member Name="pending" Value="0"/>
+        <Member Name="ready" Value="1"/>
+        <Member Name="failed" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="cloudPcDomainJoinType">
+        <Member Name="azureADJoin" Value="0"/>
+        <Member Name="hybridAzureADJoin" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="cloudPcGalleryImageStatus">
+        <Member Name="supported" Value="0"/>
+        <Member Name="supportedWithWarning" Value="1"/>
+        <Member Name="notSupported" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="cloudPcOnPremisesConnectionHealthCheckErrorType">
+        <Member Name="dnsCheckFqdnNotFound" Value="100"/>
+        <Member Name="dnsCheckNameWithInvalidCharacter" Value="101"/>
+        <Member Name="dnsCheckUnknownError" Value="199"/>
+        <Member Name="adJoinCheckFqdnNotFound" Value="200"/>
+        <Member Name="adJoinCheckIncorrectCredentials" Value="201"/>
+        <Member Name="adJoinCheckOrganizationalUnitNotFound" Value="202"/>
+        <Member Name="adJoinCheckOrganizationalUnitIncorrectFormat" Value="203"/>
+        <Member Name="adJoinCheckComputerObjectAlreadyExists" Value="204"/>
+        <Member Name="adJoinCheckAccessDenied" Value="205"/>
+        <Member Name="adJoinCheckCredentialsExpired" Value="206"/>
+        <Member Name="adJoinCheckAccountLockedOrDisabled" Value="207"/>
+        <Member Name="adJoinCheckAccountQuotaExceeded" Value="208"/>
+        <Member Name="adJoinCheckServerNotOperational" Value="209"/>
+        <Member Name="adJoinCheckUnknownError" Value="299"/>
+        <Member Name="endpointConnectivityCheckCloudPcUrlNotAllowListed" Value="300"/>
+        <Member Name="endpointConnectivityCheckWVDUrlNotAllowListed" Value="301"/>
+        <Member Name="endpointConnectivityCheckIntuneUrlNotAllowListed" Value="302"/>
+        <Member Name="endpointConnectivityCheckAzureADUrlNotAllowListed" Value="303"/>
+        <Member Name="endpointConnectivityCheckLocaleUrlNotAllowListed" Value="304"/>
+        <Member Name="endpointConnectivityCheckUnknownError" Value="399"/>
+        <Member Name="azureAdDeviceSyncCheckDeviceNotFound" Value="400"/>
+        <Member Name="azureAdDeviceSyncCheckLongSyncCircle" Value="401"/>
+        <Member Name="azureAdDeviceSyncCheckConnectDisabled" Value="402"/>
+        <Member Name="azureAdDeviceSyncCheckDurationExceeded" Value="403"/>
+        <Member Name="azureAdDeviceSyncCheckScpNotConfigured" Value="404"/>
+        <Member Name="azureAdDeviceSyncCheckTransientServiceError" Value="498"/>
+        <Member Name="azureAdDeviceSyncCheckUnknownError" Value="499"/>
+        <Member Name="resourceAvailabilityCheckNoSubnetIP" Value="500"/>
+        <Member Name="resourceAvailabilityCheckSubscriptionDisabled" Value="501"/>
+        <Member Name="resourceAvailabilityCheckAzurePolicyViolation" Value="502"/>
+        <Member Name="resourceAvailabilityCheckSubscriptionNotFound" Value="503"/>
+        <Member Name="resourceAvailabilityCheckSubscriptionTransferred" Value="504"/>
+        <Member Name="resourceAvailabilityCheckGeneralSubscriptionError" Value="505"/>
+        <Member Name="resourceAvailabilityCheckUnsupportedVNetRegion" Value="506"/>
+        <Member Name="resourceAvailabilityCheckResourceGroupInvalid" Value="507"/>
+        <Member Name="resourceAvailabilityCheckVNetInvalid" Value="508"/>
+        <Member Name="resourceAvailabilityCheckSubnetInvalid" Value="509"/>
+        <Member Name="resourceAvailabilityCheckResourceGroupBeingDeleted" Value="510"/>
+        <Member Name="resourceAvailabilityCheckVNetBeingMoved" Value="511"/>
+        <Member Name="resourceAvailabilityCheckSubnetDelegationFailed" Value="512"/>
+        <Member Name="resourceAvailabilityCheckSubnetWithExternalResources" Value="513"/>
+        <Member Name="resourceAvailabilityCheckResourceGroupLockedForReadonly" Value="514"/>
+        <Member Name="resourceAvailabilityCheckResourceGroupLockedForDelete" Value="515"/>
+        <Member Name="resourceAvailabilityCheckNoIntuneReaderRoleError" Value="516"/>
+        <Member Name="resourceAvailabilityCheckIntuneDefaultWindowsRestrictionViolation" Value="517"/>
+        <Member Name="resourceAvailabilityCheckIntuneCustomWindowsRestrictionViolation" Value="518"/>
+        <Member Name="resourceAvailabilityCheckDeploymentQuotaLimitReached" Value="519"/>
+        <Member Name="resourceAvailabilityCheckTransientServiceError" Value="598"/>
+        <Member Name="resourceAvailabilityCheckUnknownError" Value="599"/>
+        <Member Name="permissionCheckNoSubscriptionReaderRole" Value="600"/>
+        <Member Name="permissionCheckNoResourceGroupOwnerRole" Value="601"/>
+        <Member Name="permissionCheckNoVNetContributorRole" Value="602"/>
+        <Member Name="permissionCheckNoResourceGroupNetworkContributorRole" Value="603"/>
+        <Member Name="permissionCheckNoWindows365NetworkUserRole" Value="604"/>
+        <Member Name="permissionCheckNoWindows365NetworkInterfaceContributorRole" Value="605"/>
+        <Member Name="permissionCheckTransientServiceError" Value="698"/>
+        <Member Name="permissionCheckUnknownError" Value="699"/>
+        <Member Name="udpConnectivityCheckStunUrlNotAllowListed" Value="800"/>
+        <Member Name="udpConnectivityCheckTurnUrlNotAllowListed" Value="801"/>
+        <Member Name="udpConnectivityCheckUrlsNotAllowListed" Value="802"/>
+        <Member Name="udpConnectivityCheckUnknownError" Value="899"/>
+        <Member Name="internalServerErrorDeploymentCanceled" Value="900"/>
+        <Member Name="internalServerErrorAllocateResourceFailed" Value="901"/>
+        <Member Name="internalServerErrorVMDeploymentTimeout" Value="902"/>
+        <Member Name="internalServerErrorUnableToRunDscScript" Value="903"/>
+        <Member Name="ssoCheckKerberosConfigurationError" Value="904"/>
+        <Member Name="internalServerUnknownError" Value="999"/>
+        <Member Name="unknownFutureValue" Value="1000"/>
+      </EnumType>
+      <EnumType Name="cloudPcOnPremisesConnectionStatus">
+        <Member Name="pending" Value="0"/>
+        <Member Name="running" Value="1"/>
+        <Member Name="passed" Value="2"/>
+        <Member Name="failed" Value="3"/>
+        <Member Name="warning" Value="4"/>
+        <Member Name="informational" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
+      </EnumType>
+      <EnumType Name="cloudPcOnPremisesConnectionType">
+        <Member Name="hybridAzureADJoin" Value="0"/>
+        <Member Name="azureADJoin" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="cloudPcProvisioningPolicyImageType">
+        <Member Name="gallery" Value="0"/>
+        <Member Name="custom" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="cloudPcProvisioningType">
+        <Member Name="dedicated" Value="0"/>
+        <Member Name="shared" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="cloudPcRegionGroup">
+        <Member Name="default" Value="0"/>
+        <Member Name="australia" Value="1"/>
+        <Member Name="canada" Value="2"/>
+        <Member Name="usCentral" Value="3"/>
+        <Member Name="usEast" Value="4"/>
+        <Member Name="usWest" Value="5"/>
+        <Member Name="france" Value="6"/>
+        <Member Name="germany" Value="7"/>
+        <Member Name="europeUnion" Value="8"/>
+        <Member Name="unitedKingdom" Value="9"/>
+        <Member Name="japan" Value="10"/>
+        <Member Name="asia" Value="11"/>
+        <Member Name="india" Value="12"/>
+        <Member Name="southAmerica" Value="13"/>
+        <Member Name="euap" Value="14"/>
+        <Member Name="usGovernment" Value="15"/>
+        <Member Name="usGovernmentDOD" Value="16"/>
+        <Member Name="unknownFutureValue" Value="20"/>
+        <Member Name="norway" Value="17"/>
+        <Member Name="switzerland" Value="18"/>
+        <Member Name="southKorea" Value="19"/>
+      </EnumType>
+      <EnumType Name="cloudPcRestorePointFrequencyType">
+        <Member Name="default" Value="0"/>
+        <Member Name="fourHours" Value="1"/>
+        <Member Name="sixHours" Value="2"/>
+        <Member Name="twelveHours" Value="3"/>
+        <Member Name="sixteenHours" Value="4"/>
+        <Member Name="twentyFourHours" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
+      </EnumType>
+      <EnumType Name="microsoftManagedDesktopType">
+        <Member Name="notManaged" Value="0"/>
+        <Member Name="premiumManaged" Value="1"/>
+        <Member Name="standardManaged" Value="2"/>
+        <Member Name="starterManaged" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
       <EnumType Name="bodyType">
         <Member Name="text" Value="0"/>
         <Member Name="html" Value="1"/>
@@ -16072,6 +17632,13 @@
         <Member Name="tagForAction" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="authenticationAttributeCollectionInputType">
+        <Member Name="text" Value="1"/>
+        <Member Name="radioSingleSelect" Value="2"/>
+        <Member Name="checkboxMultiSelect" Value="3"/>
+        <Member Name="boolean" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+      </EnumType>
       <EnumType Name="identityUserFlowAttributeDataType">
         <Member Name="string" Value="1"/>
         <Member Name="boolean" Value="2"/>
@@ -16103,6 +17670,11 @@
         <Member Name="resourceOwner" Value="6"/>
         <Member Name="unknownFutureValue" Value="7"/>
       </EnumType>
+      <EnumType Name="userType">
+        <Member Name="member" Value="0"/>
+        <Member Name="guest" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="lobbyBypassScope">
         <Member Name="organizer" Value="0"/>
         <Member Name="organization" Value="1"/>
@@ -16125,6 +17697,11 @@
         <Member Name="organizer" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="multiFactorAuthConfiguration">
+        <Member Name="notRequired" Value="0"/>
+        <Member Name="required" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="allowInvitesFrom">
         <Member Name="none" Value="0"/>
         <Member Name="adminsAndGuestInviters" Value="1"/>
@@ -16144,10 +17721,24 @@
         <Member Name="asymmetricKeyLifetime" Value="0"/>
         <Member Name="unknownFutureValue" Value="99"/>
       </EnumType>
+      <EnumType Name="appManagementRestrictionState">
+        <Member Name="enabled" Value="1"/>
+        <Member Name="disabled" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
       <EnumType Name="authenticationProtocol">
         <Member Name="wsFed" Value="0"/>
         <Member Name="saml" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="b2bIdentityProvidersType">
+        <Member Name="azureActiveDirectory" Value="1"/>
+        <Member Name="externalFederation" Value="2"/>
+        <Member Name="socialIdentityProviders" Value="3"/>
+        <Member Name="emailOneTimePasscode" Value="4"/>
+        <Member Name="microsoftAccount" Value="5"/>
+        <Member Name="defaultConfiguredIdp" Value="6"/>
+        <Member Name="unknownFutureValue" Value="7"/>
       </EnumType>
       <EnumType Name="crossTenantAccessPolicyTargetConfigurationAccessType">
         <Member Name="allowed" Value="1"/>
@@ -16170,6 +17761,34 @@
         <Member Name="default" Value="0"/>
         <Member Name="verticalSplit" Value="1"/>
         <Member Name="unknownFutureValue" Value="10"/>
+      </EnumType>
+      <EnumType Name="multiTenantOrganizationMemberProcessingStatus">
+        <Member Name="notStarted" Value="0"/>
+        <Member Name="running" Value="1"/>
+        <Member Name="succeeded" Value="2"/>
+        <Member Name="failed" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="multiTenantOrganizationMemberRole">
+        <Member Name="owner" Value="0"/>
+        <Member Name="member" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="multiTenantOrganizationMemberState">
+        <Member Name="pending" Value="0"/>
+        <Member Name="active" Value="1"/>
+        <Member Name="removed" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="multiTenantOrganizationState">
+        <Member Name="active" Value="0"/>
+        <Member Name="inactive" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="nativeAuthenticationApisEnabled" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="all" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="onPremisesDirectorySynchronizationDeletionPreventionType">
         <Member Name="disabled" Value="0"/>
@@ -16202,6 +17821,12 @@
         <Member Name="nativeSupport" Value="1"/>
         <Member Name="disabled" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="templateApplicationLevel" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="newPartners" Value="1"/>
+        <Member Name="existingPartners" Value="2"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="weakAlgorithms" IsFlags="true">
         <Member Name="rsaSha1" Value="1"/>
@@ -16275,6 +17900,7 @@
         <Member Name="published" Value="1"/>
         <Member Name="assigned" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+        <Member Name="inactive" Value="4"/>
       </EnumType>
       <EnumType Name="educationFeedbackResourceOutcomeStatus">
         <Member Name="notPublished" Value="0"/>
@@ -16283,6 +17909,11 @@
         <Member Name="failedPublish" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="educationModuleStatus">
+        <Member Name="draft" Value="0"/>
+        <Member Name="published" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="educationSubmissionStatus">
         <Member Name="working" Value="0"/>
         <Member Name="submitted" Value="1"/>
@@ -16290,6 +17921,7 @@
         <Member Name="returned" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
         <Member Name="reassigned" Value="5"/>
+        <Member Name="excused" Value="6"/>
       </EnumType>
       <EnumType Name="contactRelationship">
         <Member Name="parent" Value="0"/>
@@ -16317,6 +17949,91 @@
         <Member Name="teacher" Value="1"/>
         <Member Name="none" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="artifactRestoreStatus">
+        <Member Name="added" Value="0"/>
+        <Member Name="scheduling" Value="1"/>
+        <Member Name="scheduled" Value="2"/>
+        <Member Name="inProgress" Value="3"/>
+        <Member Name="succeeded" Value="4"/>
+        <Member Name="failed" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
+      </EnumType>
+      <EnumType Name="backupServiceConsumer">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="firstparty" Value="1"/>
+        <Member Name="thirdparty" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="backupServiceStatus">
+        <Member Name="disabled" Value="0"/>
+        <Member Name="enabled" Value="1"/>
+        <Member Name="protectionChangeLocked" Value="2"/>
+        <Member Name="restoreLocked" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="destinationType">
+        <Member Name="new" Value="0"/>
+        <Member Name="inPlace" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="disableReason">
+        <Member Name="none" Value="0"/>
+        <Member Name="invalidBillingProfile" Value="1"/>
+        <Member Name="userRequested" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="protectionPolicyStatus">
+        <Member Name="inactive" Value="0"/>
+        <Member Name="activeWithErrors" Value="1"/>
+        <Member Name="updating" Value="2"/>
+        <Member Name="active" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="protectionRuleStatus">
+        <Member Name="draft" Value="0"/>
+        <Member Name="active" Value="1"/>
+        <Member Name="completed" Value="2"/>
+        <Member Name="completedWithErrors" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="protectionUnitStatus">
+        <Member Name="protectRequested" Value="0"/>
+        <Member Name="protected" Value="1"/>
+        <Member Name="unprotectRequested" Value="2"/>
+        <Member Name="unprotected" Value="3"/>
+        <Member Name="removeRequested" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+      </EnumType>
+      <EnumType Name="restorableArtifact">
+        <Member Name="message" Value="0"/>
+        <Member Name="unknownFutureValue" Value="1"/>
+      </EnumType>
+      <EnumType Name="restorePointPreference">
+        <Member Name="latest" Value="0"/>
+        <Member Name="oldest" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="restorePointTags" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="fastRestore" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="restoreSessionStatus">
+        <Member Name="draft" Value="0"/>
+        <Member Name="activating" Value="1"/>
+        <Member Name="active" Value="2"/>
+        <Member Name="completedWithError" Value="3"/>
+        <Member Name="completed" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+        <Member Name="failed" Value="6"/>
+      </EnumType>
+      <EnumType Name="serviceAppStatus">
+        <Member Name="inactive" Value="0"/>
+        <Member Name="active" Value="1"/>
+        <Member Name="pendingActive" Value="2"/>
+        <Member Name="pendingInactive" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="workbookOperationStatus">
         <Member Name="notStarted" Value="0"/>
@@ -16572,6 +18289,11 @@
         <Member Name="fourth" Value="3"/>
         <Member Name="last" Value="4"/>
       </EnumType>
+      <EnumType Name="fileStorageContainerStatus">
+        <Member Name="inactive" Value="0"/>
+        <Member Name="active" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="imageTaggingChoice">
         <Member Name="disabled" Value="0"/>
         <Member Name="basic" Value="1"/>
@@ -16612,6 +18334,29 @@
         <Member Name="approvalStatus" Value="17"/>
         <Member Name="unknownFutureValue" Value="18"/>
       </EnumType>
+      <EnumType Name="driveItemSourceApplication">
+        <Member Name="teams" Value="0"/>
+        <Member Name="yammer" Value="1"/>
+        <Member Name="sharePoint" Value="2"/>
+        <Member Name="oneDrive" Value="3"/>
+        <Member Name="stream" Value="4"/>
+        <Member Name="powerPoint" Value="5"/>
+        <Member Name="office" Value="6"/>
+        <Member Name="loki" Value="7"/>
+        <Member Name="loop" Value="8"/>
+        <Member Name="other" Value="9"/>
+        <Member Name="unknownFutureValue" Value="10"/>
+      </EnumType>
+      <EnumType Name="horizontalSectionLayoutType">
+        <Member Name="none" Value="0"/>
+        <Member Name="oneColumn" Value="1"/>
+        <Member Name="twoColumns" Value="2"/>
+        <Member Name="threeColumns" Value="3"/>
+        <Member Name="oneThirdLeftColumn" Value="4"/>
+        <Member Name="oneThirdRightColumn" Value="5"/>
+        <Member Name="fullWidth" Value="6"/>
+        <Member Name="unknownFutureValue" Value="7"/>
+      </EnumType>
       <EnumType Name="longRunningOperationStatus">
         <Member Name="notStarted" Value="0"/>
         <Member Name="running" Value="1"/>
@@ -16619,11 +18364,77 @@
         <Member Name="failed" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="mediaSourceContentCategory">
+        <Member Name="meeting" Value="0"/>
+        <Member Name="liveStream" Value="1"/>
+        <Member Name="presentation" Value="2"/>
+        <Member Name="screenRecording" Value="3"/>
+        <Member Name="story" Value="4"/>
+        <Member Name="profile" Value="5"/>
+        <Member Name="chat" Value="6"/>
+        <Member Name="note" Value="7"/>
+        <Member Name="comment" Value="8"/>
+        <Member Name="unknownFutureValue" Value="9"/>
+      </EnumType>
+      <EnumType Name="pageLayoutType">
+        <Member Name="microsoftReserved" Value="0"/>
+        <Member Name="article" Value="1"/>
+        <Member Name="home" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="pagePromotionType">
+        <Member Name="microsoftReserved" Value="0"/>
+        <Member Name="page" Value="1"/>
+        <Member Name="newsPost" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="sectionEmphasisType">
+        <Member Name="none" Value="0"/>
+        <Member Name="neutral" Value="1"/>
+        <Member Name="soft" Value="2"/>
+        <Member Name="strong" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
       <EnumType Name="sensitivityLabelAssignmentMethod">
         <Member Name="standard" Value="0"/>
         <Member Name="privileged" Value="1"/>
         <Member Name="auto" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="siteArchiveStatus">
+        <Member Name="recentlyArchived" Value="0"/>
+        <Member Name="fullyArchived" Value="1"/>
+        <Member Name="reactivating" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="siteLockState">
+        <Member Name="unlocked" Value="0"/>
+        <Member Name="lockedReadOnly" Value="1"/>
+        <Member Name="lockedNoAccess" Value="2"/>
+        <Member Name="lockedNoAdditions" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="titleAreaLayoutType">
+        <Member Name="imageAndTitle" Value="0"/>
+        <Member Name="plain" Value="1"/>
+        <Member Name="colorBlock" Value="2"/>
+        <Member Name="overlap" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="titleAreaTextAlignmentType">
+        <Member Name="left" Value="0"/>
+        <Member Name="center" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="remindBeforeTimeInMinutesType">
+        <Member Name="mins15" Value="0"/>
+        <Member Name="unknownFutureValue" Value="100"/>
+      </EnumType>
+      <EnumType Name="virtualAppointmentMessageType">
+        <Member Name="confirmation" Value="0"/>
+        <Member Name="reschedule" Value="1"/>
+        <Member Name="cancellation" Value="2"/>
+        <Member Name="unknownFutureValue" Value="10"/>
       </EnumType>
       <EnumType Name="stagedFeatureName">
         <Member Name="passthroughAuthentication" Value="0"/>
@@ -16831,6 +18642,13 @@
         <Member Name="Failed" Value="1"/>
         <Member Name="EntryLevelErrors" Value="2"/>
       </EnumType>
+      <EnumType Name="endpointType">
+        <Member Name="default" Value="0"/>
+        <Member Name="voicemail" Value="1"/>
+        <Member Name="skypeForBusiness" Value="2"/>
+        <Member Name="skypeForBusinessVoipPhone" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
       <EnumType Name="accessReviewHistoryDecisionFilter">
         <Member Name="approve" Value="0"/>
         <Member Name="deny" Value="1"/>
@@ -16938,10 +18756,22 @@
         <Member Name="serviceProvider" Value="32"/>
         <Member Name="unknownFutureValue" Value="64"/>
       </EnumType>
+      <EnumType Name="conditionalAccessInsiderRiskLevels" IsFlags="true">
+        <Member Name="minor" Value="1"/>
+        <Member Name="moderate" Value="2"/>
+        <Member Name="elevated" Value="4"/>
+        <Member Name="unknownFutureValue" Value="8"/>
+      </EnumType>
       <EnumType Name="conditionalAccessPolicyState">
         <Member Name="enabled" Value="0"/>
         <Member Name="disabled" Value="1"/>
         <Member Name="enabledForReportingButNotEnforced" Value="2"/>
+      </EnumType>
+      <EnumType Name="conditionalAccessTransferMethods" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="deviceCodeFlow" Value="1"/>
+        <Member Name="authenticationTransfer" Value="2"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="countryLookupMethodType">
         <Member Name="clientIpAddress" Value="0"/>
@@ -17112,6 +18942,10 @@
         <Member Name="proposed" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
+      <EnumType Name="socialIdentitySourceType">
+        <Member Name="facebook" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="certificateStatus">
         <Member Name="notProvisioned" Value="0"/>
         <Member Name="provisioned" Value="1"/>
@@ -17248,6 +19082,11 @@
       <EnumType Name="win32LobAppRuleType">
         <Member Name="detection" Value="0"/>
         <Member Name="requirement" Value="1"/>
+      </EnumType>
+      <EnumType Name="win32LobAutoUpdateSupersededAppsState">
+        <Member Name="notConfigured" Value="0"/>
+        <Member Name="enabled" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="windowsArchitecture" IsFlags="true">
         <Member Name="none" Value="0"/>
@@ -17861,6 +19700,7 @@
         <Member Name="available" Value="1"/>
         <Member Name="enabled" Value="2"/>
         <Member Name="unresponsive" Value="3"/>
+        <Member Name="unknownFutureValue" Value="6"/>
       </EnumType>
       <EnumType Name="vppTokenState">
         <Member Name="unknown" Value="0"/>
@@ -17995,6 +19835,7 @@
         <Member Name="unknown" Value="0"/>
         <Member Name="company" Value="1"/>
         <Member Name="personal" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="managedDevicePartnerReportedHealthState">
         <Member Name="unknown" Value="0"/>
@@ -18222,6 +20063,21 @@
         <Member Name="complete" Value="2"/>
         <Member Name="error" Value="3"/>
       </EnumType>
+      <EnumType Name="windowsAutopilotDeviceType">
+        <Member Name="windowsPc" Value="0"/>
+        <Member Name="holoLens" Value="1"/>
+        <Member Name="unknownFutureValue" Value="99"/>
+      </EnumType>
+      <EnumType Name="windowsDeviceUsageType">
+        <Member Name="singleUser" Value="0"/>
+        <Member Name="shared" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="windowsUserType">
+        <Member Name="administrator" Value="0"/>
+        <Member Name="standard" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="managedAppClipboardSharingLevel">
         <Member Name="allApps" Value="0"/>
         <Member Name="managedAppsWithPasteIn" Value="1"/>
@@ -18322,6 +20178,12 @@
       <EnumType Name="applicationType">
         <Member Name="universal" Value="1"/>
         <Member Name="desktop" Value="2"/>
+      </EnumType>
+      <EnumType Name="appsUpdateChannelType">
+        <Member Name="current" Value="0"/>
+        <Member Name="monthlyEnterprise" Value="1"/>
+        <Member Name="semiAnnual" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="postType">
         <Member Name="regular" Value="0"/>
@@ -18459,6 +20321,7 @@
       <EnumType Name="delegatedAdminRelationshipOperationType">
         <Member Name="delegatedAdminAccessAssignmentUpdate" Value="0"/>
         <Member Name="unknownFutureValue" Value="1"/>
+        <Member Name="delegatedAdminRelationshipUpdate" Value="2"/>
       </EnumType>
       <EnumType Name="delegatedAdminRelationshipRequestAction">
         <Member Name="lockForApproval" Value="0"/>
@@ -18486,6 +20349,11 @@
         <Member Name="terminating" Value="8"/>
         <Member Name="terminationRequested" Value="9"/>
         <Member Name="unknownFutureValue" Value="10"/>
+      </EnumType>
+      <EnumType Name="windowsSettingType">
+        <Member Name="roaming" Value="0"/>
+        <Member Name="backup" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="assignmentScheduleFilterByCurrentUserOptions">
         <Member Name="principal" Value="1"/>
@@ -19471,6 +21339,52 @@
         <Member Name="stapleDualRight" Value="30"/>
         <Member Name="stapleDualBottom" Value="31"/>
         <Member Name="unknownFutureValue" Value="32"/>
+        <Member Name="stapleTripleLeft" Value="33"/>
+        <Member Name="stapleTripleTop" Value="34"/>
+        <Member Name="stapleTripleRight" Value="35"/>
+        <Member Name="stapleTripleBottom" Value="36"/>
+        <Member Name="bindLeft" Value="37"/>
+        <Member Name="bindTop" Value="38"/>
+        <Member Name="bindRight" Value="39"/>
+        <Member Name="bindBottom" Value="40"/>
+        <Member Name="foldAccordion" Value="41"/>
+        <Member Name="foldDoubleGate" Value="42"/>
+        <Member Name="foldGate" Value="43"/>
+        <Member Name="foldHalf" Value="44"/>
+        <Member Name="foldHalfZ" Value="45"/>
+        <Member Name="foldLeftGate" Value="46"/>
+        <Member Name="foldLetter" Value="47"/>
+        <Member Name="foldParallel" Value="48"/>
+        <Member Name="foldPoster" Value="49"/>
+        <Member Name="foldRightGate" Value="50"/>
+        <Member Name="foldZ" Value="51"/>
+        <Member Name="foldEngineeringZ" Value="52"/>
+        <Member Name="punchTopLeft" Value="53"/>
+        <Member Name="punchBottomLeft" Value="54"/>
+        <Member Name="punchTopRight" Value="55"/>
+        <Member Name="punchBottomRight" Value="56"/>
+        <Member Name="punchDualLeft" Value="57"/>
+        <Member Name="punchDualTop" Value="58"/>
+        <Member Name="punchDualRight" Value="59"/>
+        <Member Name="punchDualBottom" Value="60"/>
+        <Member Name="punchTripleLeft" Value="61"/>
+        <Member Name="punchTripleTop" Value="62"/>
+        <Member Name="punchTripleRight" Value="63"/>
+        <Member Name="punchTripleBottom" Value="64"/>
+        <Member Name="punchQuadLeft" Value="65"/>
+        <Member Name="punchQuadTop" Value="66"/>
+        <Member Name="punchQuadRight" Value="67"/>
+        <Member Name="punchQuadBottom" Value="68"/>
+        <Member Name="fold" Value="69"/>
+        <Member Name="trim" Value="70"/>
+        <Member Name="bale" Value="71"/>
+        <Member Name="bookletMaker" Value="72"/>
+        <Member Name="coat" Value="73"/>
+        <Member Name="laminate" Value="74"/>
+        <Member Name="trimAfterPages" Value="75"/>
+        <Member Name="trimAfterDocuments" Value="76"/>
+        <Member Name="trimAfterCopies" Value="77"/>
+        <Member Name="trimAfterJob" Value="78"/>
       </EnumType>
       <EnumType Name="printJobProcessingState">
         <Member Name="unknown" Value="0"/>
@@ -19553,6 +21467,21 @@
         <Member Name="failed" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="devicePlatformType">
+        <Member Name="android" Value="0"/>
+        <Member Name="androidForWork" Value="1"/>
+        <Member Name="iOS" Value="2"/>
+        <Member Name="macOS" Value="3"/>
+        <Member Name="windowsPhone81" Value="4"/>
+        <Member Name="windows81AndLater" Value="5"/>
+        <Member Name="windows10AndLater" Value="6"/>
+        <Member Name="androidWorkProfile" Value="7"/>
+        <Member Name="unknown" Value="8"/>
+        <Member Name="androidAOSP" Value="9"/>
+        <Member Name="androidMobileApplicationManagement" Value="10"/>
+        <Member Name="iOSMobileApplicationManagement" Value="11"/>
+        <Member Name="unknownFutureValue" Value="12"/>
+      </EnumType>
       <EnumType Name="accountTargetContentType">
         <Member Name="unknown" Value="0"/>
         <Member Name="includeAll" Value="1"/>
@@ -19563,6 +21492,12 @@
         <Member Name="createSimualation" Value="0"/>
         <Member Name="updateSimulation" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="clickSource">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="qrCode" Value="1"/>
+        <Member Name="phishingUrl" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="coachmarkLocationType">
         <Member Name="unknown" Value="0"/>
@@ -19963,6 +21898,11 @@
         <Member Name="administrator" Value="3"/>
         <Member Name="unknownFutureValue" Value="127"/>
       </EnumType>
+      <EnumType Name="allowedLobbyAdmitterRoles">
+        <Member Name="organizerAndCoOrganizersAndPresenters" Value="0"/>
+        <Member Name="organizerAndCoOrganizers" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
       <EnumType Name="broadcastMeetingAudience">
         <Member Name="roleIsAttendee" Value="0"/>
         <Member Name="organization" Value="1"/>
@@ -19996,13 +21936,6 @@
         <Member Name="updated" Value="1"/>
         <Member Name="deleted" Value="2"/>
       </EnumType>
-      <EnumType Name="endpointType">
-        <Member Name="default" Value="0"/>
-        <Member Name="voicemail" Value="1"/>
-        <Member Name="skypeForBusiness" Value="2"/>
-        <Member Name="skypeForBusinessVoipPhone" Value="3"/>
-        <Member Name="unknownFutureValue" Value="4"/>
-      </EnumType>
       <EnumType Name="mediaDirection">
         <Member Name="inactive" Value="0"/>
         <Member Name="sendOnly" Value="1"/>
@@ -20022,6 +21955,11 @@
       <EnumType Name="meetingChatHistoryDefaultMode">
         <Member Name="none" Value="0"/>
         <Member Name="all" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="meetingLiveShareOptions">
+        <Member Name="enabled" Value="0"/>
+        <Member Name="disabled" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="modality">
@@ -20074,6 +22012,12 @@
         <Member Name="viewer" Value="0"/>
         <Member Name="sharer" Value="1"/>
       </EnumType>
+      <EnumType Name="sendDtmfCompletionReason">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="completedSuccessfully" Value="1"/>
+        <Member Name="mediaOperationCanceled" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
       <EnumType Name="tone">
         <Member Name="tone0" Value="0"/>
         <Member Name="tone1" Value="1"/>
@@ -20100,6 +22044,25 @@
         <Member Name="pendingApproval" Value="3"/>
         <Member Name="rejectedByOrganizer" Value="4"/>
         <Member Name="unknownFutureValue" Value="11"/>
+      </EnumType>
+      <EnumType Name="virtualEventRegistrationPredefinedQuestionLabel">
+        <Member Name="street" Value="0"/>
+        <Member Name="city" Value="1"/>
+        <Member Name="state" Value="2"/>
+        <Member Name="postalCode" Value="3"/>
+        <Member Name="countryOrRegion" Value="4"/>
+        <Member Name="industry" Value="5"/>
+        <Member Name="jobTitle" Value="6"/>
+        <Member Name="organization" Value="7"/>
+        <Member Name="unknownFutureValue" Value="8"/>
+      </EnumType>
+      <EnumType Name="virtualEventRegistrationQuestionAnswerInputType">
+        <Member Name="text" Value="0"/>
+        <Member Name="multilineText" Value="1"/>
+        <Member Name="singleChoice" Value="2"/>
+        <Member Name="multiChoice" Value="3"/>
+        <Member Name="boolean" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
       </EnumType>
       <EnumType Name="virtualEventStatus">
         <Member Name="draft" Value="0"/>
@@ -20242,6 +22205,8 @@
         <Member Name="unknownFutureValue" Value="5"/>
         <Member Name="teamifyGroup" Value="6"/>
         <Member Name="createChannel" Value="7"/>
+        <Member Name="archiveChannel" Value="8"/>
+        <Member Name="unarchiveChannel" Value="9"/>
       </EnumType>
       <EnumType Name="teamSpecialization">
         <Member Name="none" Value="0"/>
@@ -20298,6 +22263,19 @@
         <Member Name="unknownFutureValue" Value="7"/>
         <Member Name="emailUser" Value="8"/>
       </EnumType>
+      <EnumType Name="confirmedBy" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="user" Value="1"/>
+        <Member Name="manager" Value="2"/>
+        <Member Name="unknownFutureValue" Value="1024"/>
+      </EnumType>
+      <EnumType Name="eligibilityFilteringEnabledEntities" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="swapRequest" Value="1"/>
+        <Member Name="offerShiftRequest" Value="2"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+        <Member Name="timeOffReason" Value="8"/>
+      </EnumType>
       <EnumType Name="scheduleChangeRequestActor">
         <Member Name="sender" Value="0"/>
         <Member Name="recipient" Value="1"/>
@@ -20325,6 +22303,12 @@
         <Member Name="darkPink" Value="10"/>
         <Member Name="darkYellow" Value="11"/>
         <Member Name="unknownFutureValue" Value="12"/>
+      </EnumType>
+      <EnumType Name="timeCardState">
+        <Member Name="clockedIn" Value="0"/>
+        <Member Name="onBreak" Value="1"/>
+        <Member Name="clockedOut" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EnumType Name="timeOffReasonIconType">
         <Member Name="none" Value="0"/>
@@ -20363,6 +22347,10 @@
         <Member Name="openShiftRequest" Value="32"/>
         <Member Name="offerShiftRequest" Value="64"/>
         <Member Name="unknownFutureValue" Value="1024"/>
+        <Member Name="timeCard" Value="2048"/>
+        <Member Name="timeOffReason" Value="4096"/>
+        <Member Name="timeOff" Value="8192"/>
+        <Member Name="timeOffRequest" Value="16384"/>
       </EnumType>
       <EnumType Name="mailDestinationRoutingReason">
         <Member Name="none" Value="0"/>
@@ -20425,15 +22413,31 @@
         <Member Name="flaggedEmails" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
+      <EnumType Name="communityPrivacy">
+        <Member Name="public" Value="0"/>
+        <Member Name="private" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="engagementAsyncOperationType">
+        <Member Name="createCommunity" Value="0"/>
+        <Member Name="unknownFutureValue" Value="1"/>
+      </EnumType>
       <EnumType Name="assignmentType">
         <Member Name="required" Value="0"/>
         <Member Name="recommended" Value="1"/>
         <Member Name="unknownFutureValue" Value="2"/>
+        <Member Name="peerRecommended" Value="3"/>
       </EnumType>
       <EnumType Name="courseStatus">
         <Member Name="notStarted" Value="0"/>
         <Member Name="inProgress" Value="1"/>
         <Member Name="completed" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="level">
+        <Member Name="beginner" Value="0"/>
+        <Member Name="intermediate" Value="1"/>
+        <Member Name="advanced" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
       </EnumType>
       <EntityType Name="entity" Abstract="true">
@@ -20459,6 +22463,7 @@
         <Property Name="type" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="customExtensionClientConfiguration">
+        <Property Name="maximumRetries" Type="Edm.Int32"/>
         <Property Name="timeoutInMilliseconds" Type="Edm.Int32"/>
       </ComplexType>
       <ComplexType Name="customExtensionEndpointConfiguration" Abstract="true"/>
@@ -20490,6 +22495,7 @@
         <Property Name="appId" Type="Edm.String"/>
         <Property Name="applicationTemplateId" Type="Edm.String"/>
         <Property Name="appRoles" Type="Collection(graph.appRole)" Nullable="false"/>
+        <Property Name="authenticationBehaviors" Type="graph.authenticationBehaviors"/>
         <Property Name="certification" Type="graph.certification"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="defaultRedirectUri" Type="Edm.String"/>
@@ -20503,6 +22509,7 @@
         <Property Name="isFallbackPublicClient" Type="Edm.Boolean"/>
         <Property Name="keyCredentials" Type="Collection(graph.keyCredential)" Nullable="false"/>
         <Property Name="logo" Type="Edm.Stream" Nullable="false"/>
+        <Property Name="nativeAuthenticationApisEnabled" Type="graph.nativeAuthenticationApisEnabled"/>
         <Property Name="notes" Type="Edm.String"/>
         <Property Name="oauth2RequirePostResponse" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="optionalClaims" Type="graph.optionalClaims"/>
@@ -20519,6 +22526,7 @@
         <Property Name="spa" Type="graph.spaApplication"/>
         <Property Name="tags" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="tokenEncryptionKeyId" Type="Edm.Guid"/>
+        <Property Name="uniqueName" Type="Edm.String"/>
         <Property Name="verifiedPublisher" Type="graph.verifiedPublisher"/>
         <Property Name="web" Type="graph.webApplication"/>
         <NavigationProperty Name="appManagementPolicies" Type="Collection(graph.appManagementPolicy)"/>
@@ -20538,6 +22546,16 @@
                   <Record Type="Org.OData.Core.V1.PropertyRef">
                     <PropertyValue Property="Alias" String="appId"/>
                     <PropertyValue Property="Name" PropertyPath="appId"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="uniqueName"/>
+                    <PropertyValue Property="Name" PropertyPath="uniqueName"/>
                   </Record>
                 </Collection>
               </PropertyValue>
@@ -20565,6 +22583,11 @@
         <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="origin" Type="Edm.String"/>
         <Property Name="value" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="authenticationBehaviors">
+        <Property Name="blockAzureADGraphAccess" Type="Edm.Boolean"/>
+        <Property Name="removeUnverifiedEmailClaim" Type="Edm.Boolean"/>
+        <Property Name="requireClientServicePrincipal" Type="Edm.Boolean"/>
       </ComplexType>
       <ComplexType Name="certification">
         <Property Name="certificationDetailsUrl" Type="Edm.String"/>
@@ -20647,7 +22670,7 @@
       </EntityType>
       <EntityType Name="appManagementPolicy" BaseType="graph.policyBase">
         <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="restrictions" Type="graph.appManagementConfiguration"/>
+        <Property Name="restrictions" Type="graph.customAppManagementConfiguration"/>
         <NavigationProperty Name="appliesTo" Type="Collection(graph.directoryObject)"/>
       </EntityType>
       <EntityType Name="extensionProperty" BaseType="graph.directoryObject" OpenType="true">
@@ -20664,6 +22687,20 @@
         <Property Name="issuer" Type="Edm.String" Nullable="false"/>
         <Property Name="name" Type="Edm.String" Nullable="false"/>
         <Property Name="subject" Type="Edm.String" Nullable="false"/>
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="name"/>
+                    <PropertyValue Property="Name" PropertyPath="name"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
       </EntityType>
       <EntityType Name="stsPolicy" BaseType="graph.policyBase" Abstract="true">
         <Property Name="definition" Type="Collection(Edm.String)" Nullable="false"/>
@@ -20687,6 +22724,323 @@
       </EntityType>
       <EntityType Name="deletedItemContainer" BaseType="graph.entity">
         <NavigationProperty Name="workflows" Type="Collection(microsoft.graph.identityGovernance.workflow)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="group" BaseType="graph.directoryObject" OpenType="true">
+        <Property Name="assignedLabels" Type="Collection(graph.assignedLabel)"/>
+        <Property Name="assignedLicenses" Type="Collection(graph.assignedLicense)"/>
+        <Property Name="classification" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="groupTypes" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="hasMembersWithLicenseErrors" Type="Edm.Boolean"/>
+        <Property Name="isAssignableToRole" Type="Edm.Boolean"/>
+        <Property Name="isManagementRestricted" Type="Edm.Boolean"/>
+        <Property Name="licenseProcessingState" Type="graph.licenseProcessingState"/>
+        <Property Name="mail" Type="Edm.String"/>
+        <Property Name="mailEnabled" Type="Edm.Boolean"/>
+        <Property Name="mailNickname" Type="Edm.String"/>
+        <Property Name="membershipRule" Type="Edm.String"/>
+        <Property Name="membershipRuleProcessingState" Type="Edm.String"/>
+        <Property Name="onPremisesDomainName" Type="Edm.String"/>
+        <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="onPremisesNetBiosName" Type="Edm.String"/>
+        <Property Name="onPremisesProvisioningErrors" Type="Collection(graph.onPremisesProvisioningError)"/>
+        <Property Name="onPremisesSamAccountName" Type="Edm.String"/>
+        <Property Name="onPremisesSecurityIdentifier" Type="Edm.String"/>
+        <Property Name="onPremisesSyncEnabled" Type="Edm.Boolean"/>
+        <Property Name="preferredDataLocation" Type="Edm.String"/>
+        <Property Name="preferredLanguage" Type="Edm.String"/>
+        <Property Name="proxyAddresses" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="renewedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="securityEnabled" Type="Edm.Boolean"/>
+        <Property Name="securityIdentifier" Type="Edm.String"/>
+        <Property Name="serviceProvisioningErrors" Type="Collection(graph.serviceProvisioningError)"/>
+        <Property Name="theme" Type="Edm.String"/>
+        <Property Name="uniqueName" Type="Edm.String"/>
+        <Property Name="visibility" Type="Edm.String"/>
+        <Property Name="allowExternalSenders" Type="Edm.Boolean"/>
+        <Property Name="autoSubscribeNewMembers" Type="Edm.Boolean"/>
+        <Property Name="hideFromAddressLists" Type="Edm.Boolean"/>
+        <Property Name="hideFromOutlookClients" Type="Edm.Boolean"/>
+        <Property Name="isSubscribedByMail" Type="Edm.Boolean"/>
+        <Property Name="unseenCount" Type="Edm.Int32"/>
+        <Property Name="isArchived" Type="Edm.Boolean"/>
+        <NavigationProperty Name="appRoleAssignments" Type="Collection(graph.appRoleAssignment)" ContainsTarget="true"/>
+        <NavigationProperty Name="createdOnBehalfOf" Type="graph.directoryObject"/>
+        <NavigationProperty Name="memberOf" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="members" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="membersWithLicenseErrors" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="owners" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="permissionGrants" Type="Collection(graph.resourceSpecificPermissionGrant)" ContainsTarget="true"/>
+        <NavigationProperty Name="settings" Type="Collection(graph.groupSetting)" ContainsTarget="true"/>
+        <NavigationProperty Name="transitiveMemberOf" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="transitiveMembers" Type="Collection(graph.directoryObject)"/>
+        <NavigationProperty Name="acceptedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
+        <NavigationProperty Name="calendar" Type="graph.calendar" ContainsTarget="true"/>
+        <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true"/>
+        <NavigationProperty Name="conversations" Type="Collection(graph.conversation)" ContainsTarget="true"/>
+        <NavigationProperty Name="events" Type="Collection(graph.event)" ContainsTarget="true"/>
+        <NavigationProperty Name="rejectedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
+        <NavigationProperty Name="threads" Type="Collection(graph.conversationThread)" ContainsTarget="true"/>
+        <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true"/>
+        <NavigationProperty Name="drives" Type="Collection(graph.drive)" ContainsTarget="true"/>
+        <NavigationProperty Name="sites" Type="Collection(graph.site)" ContainsTarget="true"/>
+        <NavigationProperty Name="extensions" Type="Collection(graph.extension)" ContainsTarget="true"/>
+        <NavigationProperty Name="groupLifecyclePolicies" Type="Collection(graph.groupLifecyclePolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="planner" Type="graph.plannerGroup" ContainsTarget="true"/>
+        <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
+        <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true"/>
+        <NavigationProperty Name="photos" Type="Collection(graph.profilePhoto)" ContainsTarget="true"/>
+        <NavigationProperty Name="team" Type="graph.team" ContainsTarget="true"/>
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="uniqueName"/>
+                    <PropertyValue Property="Name" PropertyPath="uniqueName"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <ComplexType Name="assignedLabel">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="labelId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="assignedLicense">
+        <Property Name="disabledPlans" Type="Collection(Edm.Guid)" Nullable="false"/>
+        <Property Name="skuId" Type="Edm.Guid"/>
+      </ComplexType>
+      <ComplexType Name="licenseProcessingState">
+        <Property Name="state" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="onPremisesProvisioningError">
+        <Property Name="category" Type="Edm.String"/>
+        <Property Name="occurredDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="propertyCausingError" Type="Edm.String"/>
+        <Property Name="value" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="serviceProvisioningError" Abstract="true">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="isResolved" Type="Edm.Boolean"/>
+        <Property Name="serviceInstance" Type="Edm.String"/>
+      </ComplexType>
+      <EntityType Name="appRoleAssignment" BaseType="graph.directoryObject">
+        <Property Name="appRoleId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="principalDisplayName" Type="Edm.String"/>
+        <Property Name="principalId" Type="Edm.Guid"/>
+        <Property Name="principalType" Type="Edm.String"/>
+        <Property Name="resourceDisplayName" Type="Edm.String"/>
+        <Property Name="resourceId" Type="Edm.Guid"/>
+      </EntityType>
+      <EntityType Name="resourceSpecificPermissionGrant" BaseType="graph.directoryObject">
+        <Property Name="clientAppId" Type="Edm.String"/>
+        <Property Name="clientId" Type="Edm.String"/>
+        <Property Name="permission" Type="Edm.String"/>
+        <Property Name="permissionType" Type="Edm.String"/>
+        <Property Name="resourceAppId" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="groupSetting" BaseType="graph.entity" OpenType="true">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="templateId" Type="Edm.String"/>
+        <Property Name="values" Type="Collection(graph.settingValue)" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="calendar" BaseType="graph.entity">
+        <Property Name="allowedOnlineMeetingProviders" Type="Collection(graph.onlineMeetingProviderType)"/>
+        <Property Name="canEdit" Type="Edm.Boolean"/>
+        <Property Name="canShare" Type="Edm.Boolean"/>
+        <Property Name="canViewPrivateItems" Type="Edm.Boolean"/>
+        <Property Name="changeKey" Type="Edm.String"/>
+        <Property Name="color" Type="graph.calendarColor"/>
+        <Property Name="defaultOnlineMeetingProvider" Type="graph.onlineMeetingProviderType"/>
+        <Property Name="hexColor" Type="Edm.String"/>
+        <Property Name="isDefaultCalendar" Type="Edm.Boolean"/>
+        <Property Name="isRemovable" Type="Edm.Boolean"/>
+        <Property Name="isTallyingResponses" Type="Edm.Boolean"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="owner" Type="graph.emailAddress"/>
+        <NavigationProperty Name="calendarPermissions" Type="Collection(graph.calendarPermission)" ContainsTarget="true"/>
+        <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true"/>
+        <NavigationProperty Name="events" Type="Collection(graph.event)" ContainsTarget="true"/>
+        <NavigationProperty Name="multiValueExtendedProperties" Type="Collection(graph.multiValueLegacyExtendedProperty)" ContainsTarget="true"/>
+        <NavigationProperty Name="singleValueExtendedProperties" Type="Collection(graph.singleValueLegacyExtendedProperty)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="outlookItem" BaseType="graph.entity" Abstract="true">
+        <Property Name="categories" Type="Collection(Edm.String)"/>
+        <Property Name="changeKey" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+      </EntityType>
+      <EntityType Name="event" BaseType="graph.outlookItem" OpenType="true">
+        <Property Name="allowNewTimeProposals" Type="Edm.Boolean"/>
+        <Property Name="attendees" Type="Collection(graph.attendee)"/>
+        <Property Name="body" Type="graph.itemBody"/>
+        <Property Name="bodyPreview" Type="Edm.String"/>
+        <Property Name="end" Type="graph.dateTimeTimeZone"/>
+        <Property Name="hasAttachments" Type="Edm.Boolean"/>
+        <Property Name="hideAttendees" Type="Edm.Boolean"/>
+        <Property Name="iCalUId" Type="Edm.String"/>
+        <Property Name="importance" Type="graph.importance"/>
+        <Property Name="isAllDay" Type="Edm.Boolean"/>
+        <Property Name="isCancelled" Type="Edm.Boolean"/>
+        <Property Name="isDraft" Type="Edm.Boolean"/>
+        <Property Name="isOnlineMeeting" Type="Edm.Boolean"/>
+        <Property Name="isOrganizer" Type="Edm.Boolean"/>
+        <Property Name="isReminderOn" Type="Edm.Boolean"/>
+        <Property Name="location" Type="graph.location"/>
+        <Property Name="locations" Type="Collection(graph.location)"/>
+        <Property Name="onlineMeeting" Type="graph.onlineMeetingInfo"/>
+        <Property Name="onlineMeetingProvider" Type="graph.onlineMeetingProviderType"/>
+        <Property Name="onlineMeetingUrl" Type="Edm.String"/>
+        <Property Name="organizer" Type="graph.recipient"/>
+        <Property Name="originalEndTimeZone" Type="Edm.String"/>
+        <Property Name="originalStart" Type="Edm.DateTimeOffset"/>
+        <Property Name="originalStartTimeZone" Type="Edm.String"/>
+        <Property Name="recurrence" Type="graph.patternedRecurrence"/>
+        <Property Name="reminderMinutesBeforeStart" Type="Edm.Int32"/>
+        <Property Name="responseRequested" Type="Edm.Boolean"/>
+        <Property Name="responseStatus" Type="graph.responseStatus"/>
+        <Property Name="sensitivity" Type="graph.sensitivity"/>
+        <Property Name="seriesMasterId" Type="Edm.String"/>
+        <Property Name="showAs" Type="graph.freeBusyStatus"/>
+        <Property Name="start" Type="graph.dateTimeTimeZone"/>
+        <Property Name="subject" Type="Edm.String"/>
+        <Property Name="transactionId" Type="Edm.String"/>
+        <Property Name="type" Type="graph.eventType"/>
+        <Property Name="webLink" Type="Edm.String"/>
+        <NavigationProperty Name="attachments" Type="Collection(graph.attachment)" ContainsTarget="true"/>
+        <NavigationProperty Name="calendar" Type="graph.calendar" ContainsTarget="true"/>
+        <NavigationProperty Name="extensions" Type="Collection(graph.extension)" ContainsTarget="true"/>
+        <NavigationProperty Name="instances" Type="Collection(graph.event)" ContainsTarget="true"/>
+        <NavigationProperty Name="multiValueExtendedProperties" Type="Collection(graph.multiValueLegacyExtendedProperty)" ContainsTarget="true"/>
+        <NavigationProperty Name="singleValueExtendedProperties" Type="Collection(graph.singleValueLegacyExtendedProperty)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="conversation" BaseType="graph.entity">
+        <Property Name="hasAttachments" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastDeliveredDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="preview" Type="Edm.String" Nullable="false"/>
+        <Property Name="topic" Type="Edm.String" Nullable="false"/>
+        <Property Name="uniqueSenders" Type="Collection(Edm.String)" Nullable="false"/>
+        <NavigationProperty Name="threads" Type="Collection(graph.conversationThread)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="conversationThread" BaseType="graph.entity">
+        <Property Name="ccRecipients" Type="Collection(graph.recipient)" Nullable="false"/>
+        <Property Name="hasAttachments" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isLocked" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastDeliveredDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="preview" Type="Edm.String" Nullable="false"/>
+        <Property Name="topic" Type="Edm.String" Nullable="false"/>
+        <Property Name="toRecipients" Type="Collection(graph.recipient)" Nullable="false"/>
+        <Property Name="uniqueSenders" Type="Collection(Edm.String)" Nullable="false"/>
+        <NavigationProperty Name="posts" Type="Collection(graph.post)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="baseItem" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="eTag" Type="Edm.String"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="parentReference" Type="graph.itemReference"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+        <NavigationProperty Name="createdByUser" Type="graph.user"/>
+        <NavigationProperty Name="lastModifiedByUser" Type="graph.user"/>
+      </EntityType>
+      <EntityType Name="drive" BaseType="graph.baseItem">
+        <Property Name="driveType" Type="Edm.String"/>
+        <Property Name="owner" Type="graph.identitySet"/>
+        <Property Name="quota" Type="graph.quota"/>
+        <Property Name="sharePointIds" Type="graph.sharepointIds"/>
+        <Property Name="system" Type="graph.systemFacet"/>
+        <NavigationProperty Name="bundles" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
+        <NavigationProperty Name="following" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
+        <NavigationProperty Name="items" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
+        <NavigationProperty Name="list" Type="graph.list" ContainsTarget="true"/>
+        <NavigationProperty Name="root" Type="graph.driveItem" ContainsTarget="true"/>
+        <NavigationProperty Name="special" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="site" BaseType="graph.baseItem">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="error" Type="graph.publicError"/>
+        <Property Name="isPersonalSite" Type="Edm.Boolean"/>
+        <Property Name="root" Type="graph.root"/>
+        <Property Name="sharepointIds" Type="graph.sharepointIds"/>
+        <Property Name="siteCollection" Type="graph.siteCollection"/>
+        <NavigationProperty Name="analytics" Type="graph.itemAnalytics"/>
+        <NavigationProperty Name="columns" Type="Collection(graph.columnDefinition)" ContainsTarget="true"/>
+        <NavigationProperty Name="contentTypes" Type="Collection(graph.contentType)" ContainsTarget="true"/>
+        <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true"/>
+        <NavigationProperty Name="drives" Type="Collection(graph.drive)" ContainsTarget="true"/>
+        <NavigationProperty Name="externalColumns" Type="Collection(graph.columnDefinition)"/>
+        <NavigationProperty Name="items" Type="Collection(graph.baseItem)" ContainsTarget="true"/>
+        <NavigationProperty Name="lists" Type="Collection(graph.list)" ContainsTarget="true"/>
+        <NavigationProperty Name="operations" Type="Collection(graph.richLongRunningOperation)" ContainsTarget="true"/>
+        <NavigationProperty Name="pages" Type="Collection(graph.baseSitePage)" ContainsTarget="true"/>
+        <NavigationProperty Name="permissions" Type="Collection(graph.permission)" ContainsTarget="true"/>
+        <NavigationProperty Name="sites" Type="Collection(graph.site)" ContainsTarget="true"/>
+        <NavigationProperty Name="termStore" Type="microsoft.graph.termStore.store" ContainsTarget="true"/>
+        <NavigationProperty Name="termStores" Type="Collection(microsoft.graph.termStore.store)" ContainsTarget="true"/>
+        <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="extension" BaseType="graph.entity" Abstract="true" OpenType="true"/>
+      <EntityType Name="groupLifecyclePolicy" BaseType="graph.entity">
+        <Property Name="alternateNotificationEmails" Type="Edm.String"/>
+        <Property Name="groupLifetimeInDays" Type="Edm.Int32"/>
+        <Property Name="managedGroupTypes" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="plannerGroup" BaseType="graph.entity">
+        <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)"/>
+      </EntityType>
+      <EntityType Name="onenote" BaseType="graph.entity">
+        <NavigationProperty Name="notebooks" Type="Collection(graph.notebook)" ContainsTarget="true"/>
+        <NavigationProperty Name="operations" Type="Collection(graph.onenoteOperation)" ContainsTarget="true"/>
+        <NavigationProperty Name="pages" Type="Collection(graph.onenotePage)" ContainsTarget="true"/>
+        <NavigationProperty Name="resources" Type="Collection(graph.onenoteResource)" ContainsTarget="true"/>
+        <NavigationProperty Name="sectionGroups" Type="Collection(graph.sectionGroup)" ContainsTarget="true"/>
+        <NavigationProperty Name="sections" Type="Collection(graph.onenoteSection)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="profilePhoto" BaseType="graph.entity" HasStream="true">
+        <Property Name="height" Type="Edm.Int32"/>
+        <Property Name="width" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="team" BaseType="graph.entity" OpenType="true">
+        <Property Name="classification" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="firstChannelName" Type="Edm.String"/>
+        <Property Name="funSettings" Type="graph.teamFunSettings"/>
+        <Property Name="guestSettings" Type="graph.teamGuestSettings"/>
+        <Property Name="internalId" Type="Edm.String"/>
+        <Property Name="isArchived" Type="Edm.Boolean"/>
+        <Property Name="memberSettings" Type="graph.teamMemberSettings"/>
+        <Property Name="messagingSettings" Type="graph.teamMessagingSettings"/>
+        <Property Name="specialization" Type="graph.teamSpecialization"/>
+        <Property Name="summary" Type="graph.teamSummary"/>
+        <Property Name="tenantId" Type="Edm.String"/>
+        <Property Name="visibility" Type="graph.teamVisibilityType"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+        <NavigationProperty Name="allChannels" Type="Collection(graph.channel)"/>
+        <NavigationProperty Name="channels" Type="Collection(graph.channel)" ContainsTarget="true"/>
+        <NavigationProperty Name="group" Type="graph.group"/>
+        <NavigationProperty Name="incomingChannels" Type="Collection(graph.channel)"/>
+        <NavigationProperty Name="installedApps" Type="Collection(graph.teamsAppInstallation)" ContainsTarget="true"/>
+        <NavigationProperty Name="members" Type="Collection(graph.conversationMember)" ContainsTarget="true"/>
+        <NavigationProperty Name="operations" Type="Collection(graph.teamsAsyncOperation)" ContainsTarget="true"/>
+        <NavigationProperty Name="permissionGrants" Type="Collection(graph.resourceSpecificPermissionGrant)" ContainsTarget="true"/>
+        <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true"/>
+        <NavigationProperty Name="primaryChannel" Type="graph.channel" ContainsTarget="true"/>
+        <NavigationProperty Name="tags" Type="Collection(graph.teamworkTag)" ContainsTarget="true"/>
+        <NavigationProperty Name="template" Type="graph.teamsTemplate"/>
+        <NavigationProperty Name="schedule" Type="graph.schedule" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="identityGovernance">
         <NavigationProperty Name="lifecycleWorkflows" Type="microsoft.graph.identityGovernance.lifecycleWorkflowsContainer" ContainsTarget="true"/>
@@ -20752,6 +23106,7 @@
         <Property Name="givenName" Type="Edm.String"/>
         <Property Name="identities" Type="Collection(graph.objectIdentity)"/>
         <Property Name="imAddresses" Type="Collection(Edm.String)"/>
+        <Property Name="isManagementRestricted" Type="Edm.Boolean"/>
         <Property Name="isResourceAccount" Type="Edm.Boolean"/>
         <Property Name="jobTitle" Type="Edm.String"/>
         <Property Name="lastPasswordChangeDateTime" Type="Edm.DateTimeOffset"/>
@@ -20813,6 +23168,7 @@
         <NavigationProperty Name="ownedObjects" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="registeredDevices" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="scopedRoleMemberOf" Type="Collection(graph.scopedRoleMembership)" ContainsTarget="true"/>
+        <NavigationProperty Name="sponsors" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="transitiveMemberOf" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="calendar" Type="graph.calendar" ContainsTarget="true"/>
         <NavigationProperty Name="calendarGroups" Type="Collection(graph.calendarGroup)" ContainsTarget="true"/>
@@ -20835,9 +23191,10 @@
         <NavigationProperty Name="managedAppRegistrations" Type="Collection(graph.managedAppRegistration)"/>
         <NavigationProperty Name="deviceManagementTroubleshootingEvents" Type="Collection(graph.deviceManagementTroubleshootingEvent)" ContainsTarget="true"/>
         <NavigationProperty Name="planner" Type="graph.plannerUser" ContainsTarget="true"/>
-        <NavigationProperty Name="insights" Type="graph.officeGraphInsights" ContainsTarget="true"/>
+        <NavigationProperty Name="insights" Type="graph.itemInsights" ContainsTarget="true"/>
         <NavigationProperty Name="settings" Type="graph.userSettings" ContainsTarget="true"/>
         <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
+        <NavigationProperty Name="cloudClipboard" Type="graph.cloudClipboardRoot" ContainsTarget="true"/>
         <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true"/>
         <NavigationProperty Name="photos" Type="Collection(graph.profilePhoto)" ContainsTarget="true"/>
         <NavigationProperty Name="activities" Type="Collection(graph.userActivity)" ContainsTarget="true"/>
@@ -20846,19 +23203,33 @@
         <NavigationProperty Name="authentication" Type="graph.authentication" ContainsTarget="true"/>
         <NavigationProperty Name="chats" Type="Collection(graph.chat)" ContainsTarget="true"/>
         <NavigationProperty Name="joinedTeams" Type="Collection(graph.team)" ContainsTarget="true"/>
+        <NavigationProperty Name="permissionGrants" Type="Collection(graph.resourceSpecificPermissionGrant)" ContainsTarget="true"/>
         <NavigationProperty Name="teamwork" Type="graph.userTeamwork" ContainsTarget="true"/>
+        <NavigationProperty Name="solutions" Type="graph.userSolutionRoot" ContainsTarget="true"/>
         <NavigationProperty Name="todo" Type="graph.todo" ContainsTarget="true"/>
         <NavigationProperty Name="employeeExperience" Type="graph.employeeExperienceUser" ContainsTarget="true"/>
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="userPrincipalName"/>
+                    <PropertyValue Property="Name" PropertyPath="userPrincipalName"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
       </EntityType>
       <ComplexType Name="signInActivity">
         <Property Name="lastNonInteractiveSignInDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="lastNonInteractiveSignInRequestId" Type="Edm.String"/>
         <Property Name="lastSignInDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="lastSignInRequestId" Type="Edm.String"/>
-      </ComplexType>
-      <ComplexType Name="assignedLicense">
-        <Property Name="disabledPlans" Type="Collection(Edm.Guid)" Nullable="false"/>
-        <Property Name="skuId" Type="Edm.Guid"/>
+        <Property Name="lastSuccessfulSignInDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="lastSuccessfulSignInRequestId" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="assignedPlan">
         <Property Name="assignedDateTime" Type="Edm.DateTimeOffset"/>
@@ -20904,12 +23275,6 @@
         <Property Name="extensionAttribute8" Type="Edm.String"/>
         <Property Name="extensionAttribute9" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="onPremisesProvisioningError">
-        <Property Name="category" Type="Edm.String"/>
-        <Property Name="occurredDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="propertyCausingError" Type="Edm.String"/>
-        <Property Name="value" Type="Edm.String"/>
-      </ComplexType>
       <ComplexType Name="passwordProfile">
         <Property Name="forceChangePasswordNextSignIn" Type="Edm.Boolean"/>
         <Property Name="forceChangePasswordNextSignInWithMfa" Type="Edm.Boolean"/>
@@ -20920,20 +23285,6 @@
         <Property Name="provisioningStatus" Type="Edm.String"/>
         <Property Name="service" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="serviceProvisioningError" Abstract="true">
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="isResolved" Type="Edm.Boolean"/>
-        <Property Name="serviceInstance" Type="Edm.String"/>
-      </ComplexType>
-      <EntityType Name="appRoleAssignment" BaseType="graph.directoryObject">
-        <Property Name="appRoleId" Type="Edm.Guid" Nullable="false"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="principalDisplayName" Type="Edm.String"/>
-        <Property Name="principalId" Type="Edm.Guid"/>
-        <Property Name="principalType" Type="Edm.String"/>
-        <Property Name="resourceDisplayName" Type="Edm.String"/>
-        <Property Name="resourceId" Type="Edm.Guid"/>
-      </EntityType>
       <EntityType Name="licenseDetails" BaseType="graph.entity">
         <Property Name="servicePlans" Type="Collection(graph.servicePlanInfo)" Nullable="false"/>
         <Property Name="skuId" Type="Edm.Guid"/>
@@ -20962,81 +23313,11 @@
         <Property Name="userPurpose" Type="graph.userPurpose"/>
         <Property Name="workingHours" Type="graph.workingHours"/>
       </ComplexType>
-      <EntityType Name="calendar" BaseType="graph.entity">
-        <Property Name="allowedOnlineMeetingProviders" Type="Collection(graph.onlineMeetingProviderType)"/>
-        <Property Name="canEdit" Type="Edm.Boolean"/>
-        <Property Name="canShare" Type="Edm.Boolean"/>
-        <Property Name="canViewPrivateItems" Type="Edm.Boolean"/>
-        <Property Name="changeKey" Type="Edm.String"/>
-        <Property Name="color" Type="graph.calendarColor"/>
-        <Property Name="defaultOnlineMeetingProvider" Type="graph.onlineMeetingProviderType"/>
-        <Property Name="hexColor" Type="Edm.String"/>
-        <Property Name="isDefaultCalendar" Type="Edm.Boolean"/>
-        <Property Name="isRemovable" Type="Edm.Boolean"/>
-        <Property Name="isTallyingResponses" Type="Edm.Boolean"/>
-        <Property Name="name" Type="Edm.String"/>
-        <Property Name="owner" Type="graph.emailAddress"/>
-        <NavigationProperty Name="calendarPermissions" Type="Collection(graph.calendarPermission)" ContainsTarget="true"/>
-        <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true"/>
-        <NavigationProperty Name="events" Type="Collection(graph.event)" ContainsTarget="true"/>
-        <NavigationProperty Name="multiValueExtendedProperties" Type="Collection(graph.multiValueLegacyExtendedProperty)" ContainsTarget="true"/>
-        <NavigationProperty Name="singleValueExtendedProperties" Type="Collection(graph.singleValueLegacyExtendedProperty)" ContainsTarget="true"/>
-      </EntityType>
       <EntityType Name="calendarGroup" BaseType="graph.entity">
         <Property Name="changeKey" Type="Edm.String"/>
         <Property Name="classId" Type="Edm.Guid"/>
         <Property Name="name" Type="Edm.String"/>
         <NavigationProperty Name="calendars" Type="Collection(graph.calendar)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="outlookItem" BaseType="graph.entity" Abstract="true">
-        <Property Name="categories" Type="Collection(Edm.String)"/>
-        <Property Name="changeKey" Type="Edm.String"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
-      </EntityType>
-      <EntityType Name="event" BaseType="graph.outlookItem" OpenType="true">
-        <Property Name="allowNewTimeProposals" Type="Edm.Boolean"/>
-        <Property Name="attendees" Type="Collection(graph.attendee)"/>
-        <Property Name="body" Type="graph.itemBody"/>
-        <Property Name="bodyPreview" Type="Edm.String"/>
-        <Property Name="end" Type="graph.dateTimeTimeZone"/>
-        <Property Name="hasAttachments" Type="Edm.Boolean"/>
-        <Property Name="hideAttendees" Type="Edm.Boolean"/>
-        <Property Name="iCalUId" Type="Edm.String"/>
-        <Property Name="importance" Type="graph.importance"/>
-        <Property Name="isAllDay" Type="Edm.Boolean"/>
-        <Property Name="isCancelled" Type="Edm.Boolean"/>
-        <Property Name="isDraft" Type="Edm.Boolean"/>
-        <Property Name="isOnlineMeeting" Type="Edm.Boolean"/>
-        <Property Name="isOrganizer" Type="Edm.Boolean"/>
-        <Property Name="isReminderOn" Type="Edm.Boolean"/>
-        <Property Name="location" Type="graph.location"/>
-        <Property Name="locations" Type="Collection(graph.location)"/>
-        <Property Name="onlineMeeting" Type="graph.onlineMeetingInfo"/>
-        <Property Name="onlineMeetingProvider" Type="graph.onlineMeetingProviderType"/>
-        <Property Name="onlineMeetingUrl" Type="Edm.String"/>
-        <Property Name="organizer" Type="graph.recipient"/>
-        <Property Name="originalEndTimeZone" Type="Edm.String"/>
-        <Property Name="originalStart" Type="Edm.DateTimeOffset"/>
-        <Property Name="originalStartTimeZone" Type="Edm.String"/>
-        <Property Name="recurrence" Type="graph.patternedRecurrence"/>
-        <Property Name="reminderMinutesBeforeStart" Type="Edm.Int32"/>
-        <Property Name="responseRequested" Type="Edm.Boolean"/>
-        <Property Name="responseStatus" Type="graph.responseStatus"/>
-        <Property Name="sensitivity" Type="graph.sensitivity"/>
-        <Property Name="seriesMasterId" Type="Edm.String"/>
-        <Property Name="showAs" Type="graph.freeBusyStatus"/>
-        <Property Name="start" Type="graph.dateTimeTimeZone"/>
-        <Property Name="subject" Type="Edm.String"/>
-        <Property Name="transactionId" Type="Edm.String"/>
-        <Property Name="type" Type="graph.eventType"/>
-        <Property Name="webLink" Type="Edm.String"/>
-        <NavigationProperty Name="attachments" Type="Collection(graph.attachment)" ContainsTarget="true"/>
-        <NavigationProperty Name="calendar" Type="graph.calendar" ContainsTarget="true"/>
-        <NavigationProperty Name="extensions" Type="Collection(graph.extension)" ContainsTarget="true"/>
-        <NavigationProperty Name="instances" Type="Collection(graph.event)" ContainsTarget="true"/>
-        <NavigationProperty Name="multiValueExtendedProperties" Type="Collection(graph.multiValueLegacyExtendedProperty)" ContainsTarget="true"/>
-        <NavigationProperty Name="singleValueExtendedProperties" Type="Collection(graph.singleValueLegacyExtendedProperty)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="contactFolder" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String"/>
@@ -21157,55 +23438,6 @@
         <Property Name="websites" Type="Collection(graph.website)"/>
         <Property Name="yomiCompany" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="baseItem" BaseType="graph.entity" Abstract="true">
-        <Property Name="createdBy" Type="graph.identitySet"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="eTag" Type="Edm.String"/>
-        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="name" Type="Edm.String"/>
-        <Property Name="parentReference" Type="graph.itemReference"/>
-        <Property Name="webUrl" Type="Edm.String"/>
-        <NavigationProperty Name="createdByUser" Type="graph.user"/>
-        <NavigationProperty Name="lastModifiedByUser" Type="graph.user"/>
-      </EntityType>
-      <EntityType Name="drive" BaseType="graph.baseItem">
-        <Property Name="driveType" Type="Edm.String"/>
-        <Property Name="owner" Type="graph.identitySet"/>
-        <Property Name="quota" Type="graph.quota"/>
-        <Property Name="sharePointIds" Type="graph.sharepointIds"/>
-        <Property Name="system" Type="graph.systemFacet"/>
-        <NavigationProperty Name="bundles" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
-        <NavigationProperty Name="following" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
-        <NavigationProperty Name="items" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
-        <NavigationProperty Name="list" Type="graph.list" ContainsTarget="true"/>
-        <NavigationProperty Name="root" Type="graph.driveItem" ContainsTarget="true"/>
-        <NavigationProperty Name="special" Type="Collection(graph.driveItem)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="site" BaseType="graph.baseItem">
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="error" Type="graph.publicError"/>
-        <Property Name="isPersonalSite" Type="Edm.Boolean"/>
-        <Property Name="root" Type="graph.root"/>
-        <Property Name="sharepointIds" Type="graph.sharepointIds"/>
-        <Property Name="siteCollection" Type="graph.siteCollection"/>
-        <NavigationProperty Name="analytics" Type="graph.itemAnalytics"/>
-        <NavigationProperty Name="columns" Type="Collection(graph.columnDefinition)" ContainsTarget="true"/>
-        <NavigationProperty Name="contentTypes" Type="Collection(graph.contentType)" ContainsTarget="true"/>
-        <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true"/>
-        <NavigationProperty Name="drives" Type="Collection(graph.drive)" ContainsTarget="true"/>
-        <NavigationProperty Name="externalColumns" Type="Collection(graph.columnDefinition)"/>
-        <NavigationProperty Name="items" Type="Collection(graph.baseItem)" ContainsTarget="true"/>
-        <NavigationProperty Name="lists" Type="Collection(graph.list)" ContainsTarget="true"/>
-        <NavigationProperty Name="operations" Type="Collection(graph.richLongRunningOperation)" ContainsTarget="true"/>
-        <NavigationProperty Name="permissions" Type="Collection(graph.permission)" ContainsTarget="true"/>
-        <NavigationProperty Name="sites" Type="Collection(graph.site)" ContainsTarget="true"/>
-        <NavigationProperty Name="termStore" Type="microsoft.graph.termStore.store" ContainsTarget="true"/>
-        <NavigationProperty Name="termStores" Type="Collection(microsoft.graph.termStore.store)" ContainsTarget="true"/>
-        <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="extension" BaseType="graph.entity" Abstract="true" OpenType="true"/>
       <EntityType Name="agreementAcceptance" BaseType="graph.entity">
         <Property Name="agreementFileId" Type="Edm.String"/>
         <Property Name="agreementId" Type="Edm.String"/>
@@ -21240,6 +23472,7 @@
         <Property Name="easDeviceId" Type="Edm.String"/>
         <Property Name="emailAddress" Type="Edm.String"/>
         <Property Name="enrolledDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="enrollmentProfileName" Type="Edm.String"/>
         <Property Name="ethernetMacAddress" Type="Edm.String"/>
         <Property Name="exchangeAccessState" Type="graph.deviceManagementExchangeAccessState" Nullable="false"/>
         <Property Name="exchangeAccessStateReason" Type="graph.deviceManagementExchangeAccessStateReason" Nullable="false"/>
@@ -21312,22 +23545,17 @@
         <NavigationProperty Name="trending" Type="Collection(graph.trending)" ContainsTarget="true"/>
         <NavigationProperty Name="used" Type="Collection(graph.usedInsight)" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="itemInsights" BaseType="graph.officeGraphInsights"/>
       <EntityType Name="userSettings" BaseType="graph.entity">
         <Property Name="contributionToContentDiscoveryAsOrganizationDisabled" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="contributionToContentDiscoveryDisabled" Type="Edm.Boolean" Nullable="false"/>
+        <NavigationProperty Name="itemInsights" Type="graph.userInsightsSettings" ContainsTarget="true"/>
+        <NavigationProperty Name="windows" Type="Collection(graph.windowsSetting)" ContainsTarget="true"/>
         <NavigationProperty Name="shiftPreferences" Type="graph.shiftPreferences" ContainsTarget="true"/>
+        <NavigationProperty Name="storage" Type="graph.userStorage" ContainsTarget="true"/>
       </EntityType>
-      <EntityType Name="onenote" BaseType="graph.entity">
-        <NavigationProperty Name="notebooks" Type="Collection(graph.notebook)" ContainsTarget="true"/>
-        <NavigationProperty Name="operations" Type="Collection(graph.onenoteOperation)" ContainsTarget="true"/>
-        <NavigationProperty Name="pages" Type="Collection(graph.onenotePage)" ContainsTarget="true"/>
-        <NavigationProperty Name="resources" Type="Collection(graph.onenoteResource)" ContainsTarget="true"/>
-        <NavigationProperty Name="sectionGroups" Type="Collection(graph.sectionGroup)" ContainsTarget="true"/>
-        <NavigationProperty Name="sections" Type="Collection(graph.onenoteSection)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="profilePhoto" BaseType="graph.entity" HasStream="true">
-        <Property Name="height" Type="Edm.Int32"/>
-        <Property Name="width" Type="Edm.Int32"/>
+      <EntityType Name="cloudClipboardRoot" BaseType="graph.entity">
+        <NavigationProperty Name="items" Type="Collection(graph.cloudClipboardItem)" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="userPrint">
         <NavigationProperty Name="recentPrinterShares" Type="Collection(graph.printerShare)" ContainsTarget="true"/>
@@ -21351,12 +23579,20 @@
       <EntityType Name="onlineMeetingBase" BaseType="graph.entity" Abstract="true" OpenType="true">
         <Property Name="allowAttendeeToEnableCamera" Type="Edm.Boolean"/>
         <Property Name="allowAttendeeToEnableMic" Type="Edm.Boolean"/>
+        <Property Name="allowBreakoutRooms" Type="Edm.Boolean"/>
+        <Property Name="allowedLobbyAdmitters" Type="graph.allowedLobbyAdmitterRoles"/>
         <Property Name="allowedPresenters" Type="graph.onlineMeetingPresenters"/>
+        <Property Name="allowLiveShare" Type="graph.meetingLiveShareOptions"/>
         <Property Name="allowMeetingChat" Type="graph.meetingChatMode"/>
         <Property Name="allowParticipantsToChangeName" Type="Edm.Boolean"/>
+        <Property Name="allowPowerPointSharing" Type="Edm.Boolean"/>
+        <Property Name="allowRecording" Type="Edm.Boolean"/>
         <Property Name="allowTeamworkReactions" Type="Edm.Boolean"/>
+        <Property Name="allowTranscription" Type="Edm.Boolean"/>
+        <Property Name="allowWhiteboard" Type="Edm.Boolean"/>
         <Property Name="audioConferencing" Type="graph.audioConferencing"/>
         <Property Name="chatInfo" Type="graph.chatInfo"/>
+        <Property Name="chatRestrictions" Type="graph.chatRestrictions"/>
         <Property Name="isEntryExitAnnounced" Type="Edm.Boolean"/>
         <Property Name="joinInformation" Type="graph.itemBody"/>
         <Property Name="joinMeetingIdSettings" Type="graph.joinMeetingIdSettings"/>
@@ -21376,6 +23612,7 @@
         <Property Name="endDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="externalId" Type="Edm.String"/>
         <Property Name="isBroadcast" Type="Edm.Boolean"/>
+        <Property Name="meetingTemplateId" Type="Edm.String"/>
         <Property Name="participants" Type="graph.meetingParticipants"/>
         <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
         <NavigationProperty Name="recordings" Type="Collection(graph.callRecording)" ContainsTarget="true"/>
@@ -21401,6 +23638,7 @@
       <EntityType Name="chat" BaseType="graph.entity">
         <Property Name="chatType" Type="graph.chatType" Nullable="false"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="isHiddenForAllMembers" Type="Edm.Boolean"/>
         <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="onlineMeetingInfo" Type="graph.teamworkOnlineMeetingInfo"/>
         <Property Name="tenantId" Type="Edm.String"/>
@@ -21415,39 +23653,14 @@
         <NavigationProperty Name="pinnedMessages" Type="Collection(graph.pinnedChatMessageInfo)" ContainsTarget="true"/>
         <NavigationProperty Name="tabs" Type="Collection(graph.teamsTab)" ContainsTarget="true"/>
       </EntityType>
-      <EntityType Name="team" BaseType="graph.entity" OpenType="true">
-        <Property Name="classification" Type="Edm.String"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="funSettings" Type="graph.teamFunSettings"/>
-        <Property Name="guestSettings" Type="graph.teamGuestSettings"/>
-        <Property Name="internalId" Type="Edm.String"/>
-        <Property Name="isArchived" Type="Edm.Boolean"/>
-        <Property Name="memberSettings" Type="graph.teamMemberSettings"/>
-        <Property Name="messagingSettings" Type="graph.teamMessagingSettings"/>
-        <Property Name="specialization" Type="graph.teamSpecialization"/>
-        <Property Name="summary" Type="graph.teamSummary"/>
-        <Property Name="tenantId" Type="Edm.String"/>
-        <Property Name="visibility" Type="graph.teamVisibilityType"/>
-        <Property Name="webUrl" Type="Edm.String"/>
-        <NavigationProperty Name="allChannels" Type="Collection(graph.channel)"/>
-        <NavigationProperty Name="channels" Type="Collection(graph.channel)" ContainsTarget="true"/>
-        <NavigationProperty Name="group" Type="graph.group"/>
-        <NavigationProperty Name="incomingChannels" Type="Collection(graph.channel)"/>
-        <NavigationProperty Name="installedApps" Type="Collection(graph.teamsAppInstallation)" ContainsTarget="true"/>
-        <NavigationProperty Name="members" Type="Collection(graph.conversationMember)" ContainsTarget="true"/>
-        <NavigationProperty Name="operations" Type="Collection(graph.teamsAsyncOperation)" ContainsTarget="true"/>
-        <NavigationProperty Name="permissionGrants" Type="Collection(graph.resourceSpecificPermissionGrant)" ContainsTarget="true"/>
-        <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true"/>
-        <NavigationProperty Name="primaryChannel" Type="graph.channel" ContainsTarget="true"/>
-        <NavigationProperty Name="tags" Type="Collection(graph.teamworkTag)" ContainsTarget="true"/>
-        <NavigationProperty Name="template" Type="graph.teamsTemplate"/>
-        <NavigationProperty Name="schedule" Type="graph.schedule" ContainsTarget="true"/>
-      </EntityType>
       <EntityType Name="userTeamwork" BaseType="graph.entity">
+        <Property Name="locale" Type="Edm.String"/>
+        <Property Name="region" Type="Edm.String"/>
         <NavigationProperty Name="associatedTeams" Type="Collection(graph.associatedTeamInfo)" ContainsTarget="true"/>
         <NavigationProperty Name="installedApps" Type="Collection(graph.userScopeTeamsAppInstallation)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="userSolutionRoot" BaseType="graph.entity">
+        <NavigationProperty Name="workingTimeSchedule" Type="graph.workingTimeSchedule" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="todo" BaseType="graph.entity">
         <NavigationProperty Name="lists" Type="Collection(graph.todoTaskList)" ContainsTarget="true"/>
@@ -21661,13 +23874,30 @@
         <NavigationProperty Name="lastModifiedBy" Type="graph.user"/>
         <NavigationProperty Name="member" Type="graph.directoryObject"/>
       </EntityType>
+      <EntityType Name="relyingPartyDetailedSummary" BaseType="graph.entity">
+        <Property Name="failedSignInCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="migrationStatus" Type="graph.migrationStatus" Nullable="false"/>
+        <Property Name="migrationValidationDetails" Type="Collection(graph.keyValuePair)" Nullable="false"/>
+        <Property Name="relyingPartyId" Type="Edm.String" Nullable="false"/>
+        <Property Name="relyingPartyName" Type="Edm.String" Nullable="false"/>
+        <Property Name="replyUrls" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="serviceId" Type="Edm.String" Nullable="false"/>
+        <Property Name="signInSuccessRate" Type="Edm.Double" Nullable="false"/>
+        <Property Name="successfulSignInCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="totalSignInCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="uniqueUserCount" Type="Edm.Int64" Nullable="false"/>
+      </EntityType>
       <EntityType Name="reportRoot">
         <NavigationProperty Name="authenticationMethods" Type="graph.authenticationMethodsRoot" ContainsTarget="true"/>
+        <NavigationProperty Name="partners" Type="graph.partners" ContainsTarget="true"/>
         <NavigationProperty Name="dailyPrintUsageByPrinter" Type="Collection(graph.printUsageByPrinter)" ContainsTarget="true"/>
         <NavigationProperty Name="dailyPrintUsageByUser" Type="Collection(graph.printUsageByUser)" ContainsTarget="true"/>
         <NavigationProperty Name="monthlyPrintUsageByPrinter" Type="Collection(graph.printUsageByPrinter)" ContainsTarget="true"/>
         <NavigationProperty Name="monthlyPrintUsageByUser" Type="Collection(graph.printUsageByUser)" ContainsTarget="true"/>
         <NavigationProperty Name="security" Type="graph.securityReportsRoot" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="partners" BaseType="graph.entity">
+        <NavigationProperty Name="billing" Type="microsoft.graph.partners.billing.billing" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="printUsage" BaseType="graph.entity" Abstract="true">
         <Property Name="blackAndWhitePageCount" Type="Edm.Int64"/>
@@ -21713,6 +23943,7 @@
         <Property Name="sendInvitationMessage" Type="Edm.Boolean"/>
         <Property Name="status" Type="Edm.String"/>
         <NavigationProperty Name="invitedUser" Type="graph.user"/>
+        <NavigationProperty Name="invitedUserSponsors" Type="Collection(graph.directoryObject)"/>
       </EntityType>
       <ComplexType Name="applicationServicePrincipal">
         <NavigationProperty Name="application" Type="graph.application"/>
@@ -21879,14 +24110,23 @@
       <ComplexType Name="x509CertificateAuthenticationModeConfiguration">
         <Property Name="rules" Type="Collection(graph.x509CertificateRule)"/>
         <Property Name="x509CertificateAuthenticationDefaultMode" Type="graph.x509CertificateAuthenticationMode"/>
+        <Property Name="x509CertificateDefaultRequiredAffinityLevel" Type="graph.x509CertificateAffinityLevel"/>
       </ComplexType>
       <ComplexType Name="x509CertificateRule">
         <Property Name="identifier" Type="Edm.String"/>
+        <Property Name="issuerSubjectIdentifier" Type="Edm.String"/>
+        <Property Name="policyOidIdentifier" Type="Edm.String"/>
         <Property Name="x509CertificateAuthenticationMode" Type="graph.x509CertificateAuthenticationMode"/>
+        <Property Name="x509CertificateRequiredAffinityLevel" Type="graph.x509CertificateAffinityLevel"/>
         <Property Name="x509CertificateRuleType" Type="graph.x509CertificateRuleType"/>
+      </ComplexType>
+      <ComplexType Name="x509CertificateCRLValidationConfiguration">
+        <Property Name="exemptedCertificateAuthoritiesSubjectKeyIdentifiers" Type="Collection(Edm.String)"/>
+        <Property Name="state" Type="graph.x509CertificateCRLValidationConfigurationState" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="x509CertificateUserBinding">
         <Property Name="priority" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="trustAffinityLevel" Type="graph.x509CertificateAffinityLevel"/>
         <Property Name="userProperty" Type="Edm.String"/>
         <Property Name="x509CertificateField" Type="Edm.String"/>
       </ComplexType>
@@ -21989,6 +24229,7 @@
         <NavigationProperty Name="authenticationMethodsPolicy" Type="graph.authenticationMethodsPolicy" ContainsTarget="true"/>
         <NavigationProperty Name="authenticationStrengthPolicies" Type="Collection(graph.authenticationStrengthPolicy)" ContainsTarget="true"/>
         <NavigationProperty Name="authenticationFlowsPolicy" Type="graph.authenticationFlowsPolicy" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceRegistrationPolicy" Type="graph.deviceRegistrationPolicy" ContainsTarget="true"/>
         <NavigationProperty Name="activityBasedTimeoutPolicies" Type="Collection(graph.activityBasedTimeoutPolicy)" ContainsTarget="true"/>
         <NavigationProperty Name="appManagementPolicies" Type="Collection(graph.appManagementPolicy)" ContainsTarget="true"/>
         <NavigationProperty Name="authorizationPolicy" Type="graph.authorizationPolicy" ContainsTarget="true"/>
@@ -22011,6 +24252,15 @@
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="selfServiceSignUp" Type="graph.selfServiceSignUpAuthenticationFlowConfiguration"/>
       </EntityType>
+      <EntityType Name="deviceRegistrationPolicy" BaseType="graph.entity">
+        <Property Name="azureADJoin" Type="graph.azureADJoinPolicy"/>
+        <Property Name="azureADRegistration" Type="graph.azureADRegistrationPolicy"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="localAdminPassword" Type="graph.localAdminPasswordSettings"/>
+        <Property Name="multiFactorAuthConfiguration" Type="graph.multiFactorAuthConfiguration" Nullable="false"/>
+        <Property Name="userDeviceQuota" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
       <EntityType Name="activityBasedTimeoutPolicy" BaseType="graph.stsPolicy"/>
       <EntityType Name="authorizationPolicy" BaseType="graph.policyBase">
         <Property Name="allowedToSignUpEmailBasedSubscriptions" Type="Edm.Boolean" Nullable="false"/>
@@ -22026,11 +24276,12 @@
         <Property Name="allowedCloudEndpoints" Type="Collection(Edm.String)" Nullable="false"/>
         <NavigationProperty Name="default" Type="graph.crossTenantAccessPolicyConfigurationDefault" ContainsTarget="true"/>
         <NavigationProperty Name="partners" Type="Collection(graph.crossTenantAccessPolicyConfigurationPartner)" ContainsTarget="true"/>
+        <NavigationProperty Name="templates" Type="graph.policyTemplate" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="tenantAppManagementPolicy" BaseType="graph.policyBase">
-        <Property Name="applicationRestrictions" Type="graph.appManagementConfiguration"/>
+        <Property Name="applicationRestrictions" Type="graph.appManagementApplicationConfiguration"/>
         <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="servicePrincipalRestrictions" Type="graph.appManagementConfiguration"/>
+        <Property Name="servicePrincipalRestrictions" Type="graph.appManagementServicePrincipalConfiguration"/>
       </EntityType>
       <EntityType Name="permissionGrantPolicy" BaseType="graph.policyBase">
         <NavigationProperty Name="excludes" Type="Collection(graph.permissionGrantConditionSet)" ContainsTarget="true"/>
@@ -22097,7 +24348,12 @@
       <EntityType Name="x509CertificateAuthenticationMethodConfiguration" BaseType="graph.authenticationMethodConfiguration">
         <Property Name="authenticationModeConfiguration" Type="graph.x509CertificateAuthenticationModeConfiguration"/>
         <Property Name="certificateUserBindings" Type="Collection(graph.x509CertificateUserBinding)"/>
+        <Property Name="crlValidationConfiguration" Type="graph.x509CertificateCRLValidationConfiguration" Nullable="false"/>
         <NavigationProperty Name="includeTargets" Type="Collection(graph.authenticationMethodTarget)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="x509CertificateCombinationConfiguration" BaseType="graph.authenticationCombinationConfiguration">
+        <Property Name="allowedIssuerSkis" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="allowedPolicyOIDs" Type="Collection(Edm.String)" Nullable="false"/>
       </EntityType>
       <EntityType Name="bitlocker" BaseType="graph.entity">
         <NavigationProperty Name="recoveryKeys" Type="Collection(graph.bitlockerRecoveryKey)" ContainsTarget="true"/>
@@ -22162,6 +24418,19 @@
         <Property Name="uniqueId" Type="Edm.String"/>
         <Property Name="uniqueIdType" Type="graph.locationUniqueIdType"/>
       </ComplexType>
+      <ComplexType Name="bookingPageSettings">
+        <Property Name="accessControl" Type="graph.bookingPageAccessControl" Nullable="false"/>
+        <Property Name="bookingPageColorCode" Type="Edm.String" Nullable="false"/>
+        <Property Name="businessTimeZone" Type="Edm.String" Nullable="false"/>
+        <Property Name="customerConsentMessage" Type="Edm.String" Nullable="false"/>
+        <Property Name="enforceOneTimePassword" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isBusinessLogoDisplayEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isCustomerConsentEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isSearchEngineIndexabilityDisabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isTimeSlotTimeZoneSetToBusinessTimeZone" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="privacyPolicyWebUrl" Type="Edm.String" Nullable="false"/>
+        <Property Name="termsAndConditionsWebUrl" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
       <ComplexType Name="bookingQuestionAssignment">
         <Property Name="isRequired" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="questionId" Type="Edm.String" Nullable="false"/>
@@ -22171,16 +24440,27 @@
         <Property Name="offset" Type="Edm.Duration" Nullable="false"/>
         <Property Name="recipients" Type="graph.bookingReminderRecipients" Nullable="false"/>
       </ComplexType>
-      <ComplexType Name="bookingSchedulingPolicy">
-        <Property Name="allowStaffSelection" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="maximumAdvance" Type="Edm.Duration" Nullable="false"/>
-        <Property Name="minimumLeadTime" Type="Edm.Duration" Nullable="false"/>
-        <Property Name="sendConfirmationsToOwner" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="timeSlotInterval" Type="Edm.Duration" Nullable="false"/>
+      <ComplexType Name="bookingsAvailability">
+        <Property Name="availabilityType" Type="graph.bookingsServiceAvailabilityType" Nullable="false"/>
+        <Property Name="businessHours" Type="Collection(graph.bookingWorkHours)"/>
       </ComplexType>
       <ComplexType Name="bookingWorkHours">
         <Property Name="day" Type="graph.dayOfWeek" Nullable="false"/>
         <Property Name="timeSlots" Type="Collection(graph.bookingWorkTimeSlot)"/>
+      </ComplexType>
+      <ComplexType Name="bookingsAvailabilityWindow" BaseType="graph.bookingsAvailability">
+        <Property Name="endDate" Type="Edm.Date"/>
+        <Property Name="startDate" Type="Edm.Date"/>
+      </ComplexType>
+      <ComplexType Name="bookingSchedulingPolicy">
+        <Property Name="allowStaffSelection" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="customAvailabilities" Type="Collection(graph.bookingsAvailabilityWindow)"/>
+        <Property Name="generalAvailability" Type="graph.bookingsAvailability"/>
+        <Property Name="isMeetingInviteToCustomersEnabled" Type="Edm.Boolean"/>
+        <Property Name="maximumAdvance" Type="Edm.Duration" Nullable="false"/>
+        <Property Name="minimumLeadTime" Type="Edm.Duration" Nullable="false"/>
+        <Property Name="sendConfirmationsToOwner" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="timeSlotInterval" Type="Edm.Duration" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="bookingWorkTimeSlot">
         <Property Name="endTime" Type="Edm.TimeOfDay" Nullable="false"/>
@@ -22217,13 +24497,21 @@
       <EntityType Name="bookingAppointment" BaseType="graph.entity">
         <Property Name="additionalInformation" Type="Edm.String"/>
         <Property Name="anonymousJoinWebUrl" Type="Edm.String"/>
+        <Property Name="appointmentLabel" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="customerEmailAddress" Type="Edm.String"/>
+        <Property Name="customerName" Type="Edm.String"/>
+        <Property Name="customerNotes" Type="Edm.String"/>
+        <Property Name="customerPhone" Type="Edm.String"/>
         <Property Name="customers" Type="Collection(graph.bookingCustomerInformationBase)" Nullable="false"/>
         <Property Name="customerTimeZone" Type="Edm.String"/>
         <Property Name="duration" Type="Edm.Duration" Nullable="false"/>
         <Property Name="endDateTime" Type="graph.dateTimeTimeZone" Nullable="false"/>
         <Property Name="filledAttendeesCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="isCustomerAllowedToManageBooking" Type="Edm.Boolean"/>
         <Property Name="isLocationOnline" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="joinWebUrl" Type="Edm.String"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="maximumAttendeesCount" Type="Edm.Int32" Nullable="false"/>
         <Property Name="optOutOfCustomerEmail" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="postBuffer" Type="Edm.Duration" Nullable="false"/>
@@ -22242,13 +24530,16 @@
       </EntityType>
       <EntityType Name="bookingBusiness" BaseType="graph.entity">
         <Property Name="address" Type="graph.physicalAddress"/>
+        <Property Name="bookingPageSettings" Type="graph.bookingPageSettings"/>
         <Property Name="businessHours" Type="Collection(graph.bookingWorkHours)"/>
         <Property Name="businessType" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="defaultCurrencyIso" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="email" Type="Edm.String"/>
         <Property Name="isPublished" Type="Edm.Boolean"/>
         <Property Name="languageTag" Type="Edm.String"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="phone" Type="Edm.String"/>
         <Property Name="publicUrl" Type="Edm.String"/>
         <Property Name="schedulingPolicy" Type="graph.bookingSchedulingPolicy"/>
@@ -22264,10 +24555,13 @@
       <EntityType Name="bookingCustomQuestion" BaseType="graph.entity">
         <Property Name="answerInputType" Type="graph.answerInputType"/>
         <Property Name="answerOptions" Type="Collection(Edm.String)"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
       </EntityType>
       <EntityType Name="bookingService" BaseType="graph.entity">
         <Property Name="additionalInformation" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="customQuestions" Type="Collection(graph.bookingQuestionAssignment)"/>
         <Property Name="defaultDuration" Type="Edm.Duration" Nullable="false"/>
         <Property Name="defaultLocation" Type="graph.location"/>
@@ -22277,9 +24571,11 @@
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="isAnonymousJoinEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isCustomerAllowedToManageBooking" Type="Edm.Boolean"/>
         <Property Name="isHiddenFromCustomers" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="isLocationOnline" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="languageTag" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="maximumAttendeesCount" Type="Edm.Int32" Nullable="false"/>
         <Property Name="notes" Type="Edm.String"/>
         <Property Name="postBuffer" Type="Edm.Duration" Nullable="false"/>
@@ -22295,15 +24591,20 @@
       </EntityType>
       <EntityType Name="bookingCustomer" BaseType="graph.bookingCustomerBase">
         <Property Name="addresses" Type="Collection(graph.physicalAddress)"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="emailAddress" Type="Edm.String"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="phones" Type="Collection(graph.phone)"/>
       </EntityType>
       <EntityType Name="bookingStaffMember" BaseType="graph.bookingStaffMemberBase">
         <Property Name="availabilityIsAffectedByPersonalCalendar" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="emailAddress" Type="Edm.String"/>
         <Property Name="isEmailNotificationEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastUpdatedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="membershipStatus" Type="graph.bookingStaffMembershipStatus" Nullable="false"/>
         <Property Name="role" Type="graph.bookingStaffRole" Nullable="false"/>
         <Property Name="timeZone" Type="Edm.String"/>
         <Property Name="useBusinessHours" Type="Edm.Boolean" Nullable="false"/>
@@ -22312,11 +24613,847 @@
       <EntityType Name="solutionsRoot">
         <NavigationProperty Name="bookingBusinesses" Type="Collection(graph.bookingBusiness)" ContainsTarget="true"/>
         <NavigationProperty Name="bookingCurrencies" Type="Collection(graph.bookingCurrency)" ContainsTarget="true"/>
+        <NavigationProperty Name="backupRestore" Type="graph.backupRestoreRoot" ContainsTarget="true"/>
         <NavigationProperty Name="virtualEvents" Type="graph.virtualEventsRoot" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="backupRestoreRoot" BaseType="graph.entity">
+        <Property Name="serviceStatus" Type="graph.serviceStatus"/>
+        <NavigationProperty Name="driveInclusionRules" Type="Collection(graph.driveProtectionRule)" ContainsTarget="true"/>
+        <NavigationProperty Name="driveProtectionUnits" Type="Collection(graph.driveProtectionUnit)" ContainsTarget="true"/>
+        <NavigationProperty Name="exchangeProtectionPolicies" Type="Collection(graph.exchangeProtectionPolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="exchangeRestoreSessions" Type="Collection(graph.exchangeRestoreSession)" ContainsTarget="true"/>
+        <NavigationProperty Name="mailboxInclusionRules" Type="Collection(graph.mailboxProtectionRule)" ContainsTarget="true"/>
+        <NavigationProperty Name="mailboxProtectionUnits" Type="Collection(graph.mailboxProtectionUnit)" ContainsTarget="true"/>
+        <NavigationProperty Name="oneDriveForBusinessProtectionPolicies" Type="Collection(graph.oneDriveForBusinessProtectionPolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="oneDriveForBusinessRestoreSessions" Type="Collection(graph.oneDriveForBusinessRestoreSession)" ContainsTarget="true"/>
+        <NavigationProperty Name="protectionPolicies" Type="Collection(graph.protectionPolicyBase)" ContainsTarget="true"/>
+        <NavigationProperty Name="protectionUnits" Type="Collection(graph.protectionUnitBase)"/>
+        <NavigationProperty Name="restorePoints" Type="Collection(graph.restorePoint)" ContainsTarget="true"/>
+        <NavigationProperty Name="restoreSessions" Type="Collection(graph.restoreSessionBase)" ContainsTarget="true"/>
+        <NavigationProperty Name="serviceApps" Type="Collection(graph.serviceApp)" ContainsTarget="true"/>
+        <NavigationProperty Name="sharePointProtectionPolicies" Type="Collection(graph.sharePointProtectionPolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="sharePointRestoreSessions" Type="Collection(graph.sharePointRestoreSession)" ContainsTarget="true"/>
+        <NavigationProperty Name="siteInclusionRules" Type="Collection(graph.siteProtectionRule)" ContainsTarget="true"/>
+        <NavigationProperty Name="siteProtectionUnits" Type="Collection(graph.siteProtectionUnit)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="virtualEventsRoot" BaseType="graph.entity">
         <NavigationProperty Name="events" Type="Collection(graph.virtualEvent)" ContainsTarget="true"/>
+        <NavigationProperty Name="townhalls" Type="Collection(graph.virtualEventTownhall)" ContainsTarget="true"/>
         <NavigationProperty Name="webinars" Type="Collection(graph.virtualEventWebinar)" ContainsTarget="true"/>
+      </EntityType>
+      <ComplexType Name="cloudPcAuditActor">
+        <Property Name="applicationDisplayName" Type="Edm.String"/>
+        <Property Name="applicationId" Type="Edm.String"/>
+        <Property Name="ipAddress" Type="Edm.String"/>
+        <Property Name="remoteTenantId" Type="Edm.String"/>
+        <Property Name="remoteUserId" Type="Edm.String"/>
+        <Property Name="servicePrincipalName" Type="Edm.String"/>
+        <Property Name="userId" Type="Edm.String"/>
+        <Property Name="userPermissions" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+        <Property Name="userRoleScopeTags" Type="Collection(graph.cloudPcUserRoleScopeTagInfo)"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcUserRoleScopeTagInfo">
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="roleScopeTagId" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcAuditProperty">
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="newValue" Type="Edm.String" Nullable="false"/>
+        <Property Name="oldValue" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcAuditResource">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="modifiedProperties" Type="Collection(graph.cloudPcAuditProperty)" Nullable="false"/>
+        <Property Name="resourceId" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcDomainJoinConfiguration">
+        <Property Name="domainJoinType" Type="graph.cloudPcDomainJoinType"/>
+        <Property Name="onPremisesConnectionId" Type="Edm.String"/>
+        <Property Name="regionGroup" Type="graph.cloudPcRegionGroup"/>
+        <Property Name="regionName" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcManagementAssignmentTarget" Abstract="true"/>
+      <ComplexType Name="cloudPcManagementGroupAssignmentTarget" BaseType="graph.cloudPcManagementAssignmentTarget">
+        <Property Name="groupId" Type="Edm.String"/>
+        <Property Name="servicePlanId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcOnPremisesConnectionHealthCheck">
+        <Property Name="additionalDetail" Type="Edm.String"/>
+        <Property Name="correlationId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="errorType" Type="graph.cloudPcOnPremisesConnectionHealthCheckErrorType"/>
+        <Property Name="recommendedAction" Type="Edm.String"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="status" Type="graph.cloudPcOnPremisesConnectionStatus" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcOnPremisesConnectionStatusDetail">
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="healthChecks" Type="Collection(graph.cloudPcOnPremisesConnectionHealthCheck)"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcProvisioningPolicyAutopatch">
+        <Property Name="autopatchGroupId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcRestorePointSetting">
+        <Property Name="frequencyType" Type="graph.cloudPcRestorePointFrequencyType"/>
+        <Property Name="userRestoreEnabled" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcSourceDeviceImage">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="resourceId" Type="Edm.String" Nullable="false"/>
+        <Property Name="subscriptionDisplayName" Type="Edm.String"/>
+        <Property Name="subscriptionId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudPcWindowsSetting">
+        <Property Name="locale" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="microsoftManagedDesktop">
+        <Property Name="managedType" Type="graph.microsoftManagedDesktopType"/>
+        <Property Name="profile" Type="Edm.String"/>
+      </ComplexType>
+      <EntityType Name="cloudPC" BaseType="graph.entity">
+        <Property Name="aadDeviceId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="gracePeriodEndDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="imageDisplayName" Type="Edm.String"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="managedDeviceId" Type="Edm.String"/>
+        <Property Name="managedDeviceName" Type="Edm.String"/>
+        <Property Name="onPremisesConnectionName" Type="Edm.String"/>
+        <Property Name="provisioningPolicyId" Type="Edm.String"/>
+        <Property Name="provisioningPolicyName" Type="Edm.String"/>
+        <Property Name="provisioningType" Type="graph.cloudPcProvisioningType"/>
+        <Property Name="servicePlanId" Type="Edm.String"/>
+        <Property Name="servicePlanName" Type="Edm.String"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="cloudPcAuditEvent" BaseType="graph.entity">
+        <Property Name="activity" Type="Edm.String"/>
+        <Property Name="activityDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="activityOperationType" Type="graph.cloudPcAuditActivityOperationType" Nullable="false"/>
+        <Property Name="activityResult" Type="graph.cloudPcAuditActivityResult" Nullable="false"/>
+        <Property Name="activityType" Type="Edm.String" Nullable="false"/>
+        <Property Name="actor" Type="graph.cloudPcAuditActor" Nullable="false"/>
+        <Property Name="category" Type="graph.cloudPcAuditCategory" Nullable="false"/>
+        <Property Name="componentName" Type="Edm.String" Nullable="false"/>
+        <Property Name="correlationId" Type="Edm.String" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="resources" Type="Collection(graph.cloudPcAuditResource)" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="cloudPcDeviceImage" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="errorCode" Type="graph.cloudPcDeviceImageErrorCode"/>
+        <Property Name="expirationDate" Type="Edm.Date"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="operatingSystem" Type="Edm.String"/>
+        <Property Name="osBuildNumber" Type="Edm.String"/>
+        <Property Name="osStatus" Type="graph.cloudPcDeviceImageOsStatus"/>
+        <Property Name="sourceImageResourceId" Type="Edm.String"/>
+        <Property Name="status" Type="graph.cloudPcDeviceImageStatus"/>
+        <Property Name="version" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="cloudPcGalleryImage" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="endDate" Type="Edm.Date"/>
+        <Property Name="expirationDate" Type="Edm.Date"/>
+        <Property Name="offerName" Type="Edm.String"/>
+        <Property Name="publisherName" Type="Edm.String"/>
+        <Property Name="sizeInGB" Type="Edm.Int32"/>
+        <Property Name="skuName" Type="Edm.String"/>
+        <Property Name="startDate" Type="Edm.Date"/>
+        <Property Name="status" Type="graph.cloudPcGalleryImageStatus"/>
+      </EntityType>
+      <EntityType Name="cloudPcOnPremisesConnection" BaseType="graph.entity">
+        <Property Name="adDomainName" Type="Edm.String"/>
+        <Property Name="adDomainPassword" Type="Edm.String"/>
+        <Property Name="adDomainUsername" Type="Edm.String"/>
+        <Property Name="alternateResourceUrl" Type="Edm.String"/>
+        <Property Name="connectionType" Type="graph.cloudPcOnPremisesConnectionType"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="healthCheckStatus" Type="graph.cloudPcOnPremisesConnectionStatus" Nullable="false"/>
+        <Property Name="healthCheckStatusDetail" Type="graph.cloudPcOnPremisesConnectionStatusDetail"/>
+        <Property Name="inUse" Type="Edm.Boolean"/>
+        <Property Name="organizationalUnit" Type="Edm.String"/>
+        <Property Name="resourceGroupId" Type="Edm.String" Nullable="false"/>
+        <Property Name="subnetId" Type="Edm.String" Nullable="false"/>
+        <Property Name="subscriptionId" Type="Edm.String" Nullable="false"/>
+        <Property Name="subscriptionName" Type="Edm.String"/>
+        <Property Name="virtualNetworkId" Type="Edm.String" Nullable="false"/>
+        <Property Name="virtualNetworkLocation" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="cloudPcProvisioningPolicy" BaseType="graph.entity">
+        <Property Name="alternateResourceUrl" Type="Edm.String"/>
+        <Property Name="autopatch" Type="graph.cloudPcProvisioningPolicyAutopatch"/>
+        <Property Name="cloudPcGroupDisplayName" Type="Edm.String"/>
+        <Property Name="cloudPcNamingTemplate" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="domainJoinConfigurations" Type="Collection(graph.cloudPcDomainJoinConfiguration)"/>
+        <Property Name="enableSingleSignOn" Type="Edm.Boolean"/>
+        <Property Name="gracePeriodInHours" Type="Edm.Int32"/>
+        <Property Name="imageDisplayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="imageId" Type="Edm.String" Nullable="false"/>
+        <Property Name="imageType" Type="graph.cloudPcProvisioningPolicyImageType" Nullable="false"/>
+        <Property Name="localAdminEnabled" Type="Edm.Boolean"/>
+        <Property Name="microsoftManagedDesktop" Type="graph.microsoftManagedDesktop"/>
+        <Property Name="provisioningType" Type="graph.cloudPcProvisioningType"/>
+        <Property Name="windowsSetting" Type="graph.cloudPcWindowsSetting"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="cloudPcProvisioningPolicyAssignment" BaseType="graph.entity">
+        <Property Name="target" Type="graph.cloudPcManagementAssignmentTarget"/>
+        <NavigationProperty Name="assignedUsers" Type="Collection(graph.user)"/>
+      </EntityType>
+      <EntityType Name="cloudPcUserSetting" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="localAdminEnabled" Type="Edm.Boolean"/>
+        <Property Name="resetEnabled" Type="Edm.Boolean"/>
+        <Property Name="restorePointSetting" Type="graph.cloudPcRestorePointSetting"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.cloudPcUserSettingAssignment)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="cloudPcUserSettingAssignment" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="target" Type="graph.cloudPcManagementAssignmentTarget"/>
+      </EntityType>
+      <EntityType Name="deviceManagement" BaseType="graph.entity">
+        <Property Name="intuneAccountId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="settings" Type="graph.deviceManagementSettings"/>
+        <Property Name="intuneBrand" Type="graph.intuneBrand"/>
+        <Property Name="deviceProtectionOverview" Type="graph.deviceProtectionOverview"/>
+        <Property Name="subscriptionState" Type="graph.deviceManagementSubscriptionState" Nullable="false"/>
+        <Property Name="userExperienceAnalyticsSettings" Type="graph.userExperienceAnalyticsSettings"/>
+        <Property Name="windowsMalwareOverview" Type="graph.windowsMalwareOverview"/>
+        <NavigationProperty Name="auditEvents" Type="Collection(graph.auditEvent)" ContainsTarget="true"/>
+        <NavigationProperty Name="virtualEndpoint" Type="graph.virtualEndpoint" ContainsTarget="true"/>
+        <NavigationProperty Name="termsAndConditions" Type="Collection(graph.termsAndConditions)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceCompliancePolicies" Type="Collection(graph.deviceCompliancePolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceCompliancePolicyDeviceStateSummary" Type="graph.deviceCompliancePolicyDeviceStateSummary" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceCompliancePolicySettingStateSummaries" Type="Collection(graph.deviceCompliancePolicySettingStateSummary)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceConfigurationDeviceStateSummaries" Type="graph.deviceConfigurationDeviceStateSummary" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceConfigurations" Type="Collection(graph.deviceConfiguration)" ContainsTarget="true"/>
+        <NavigationProperty Name="iosUpdateStatuses" Type="Collection(graph.iosUpdateDeviceStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="softwareUpdateStatusSummary" Type="graph.softwareUpdateStatusSummary"/>
+        <NavigationProperty Name="complianceManagementPartners" Type="Collection(graph.complianceManagementPartner)" ContainsTarget="true"/>
+        <NavigationProperty Name="conditionalAccessSettings" Type="graph.onPremisesConditionalAccessSettings" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceCategories" Type="Collection(graph.deviceCategory)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceEnrollmentConfigurations" Type="Collection(graph.deviceEnrollmentConfiguration)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceManagementPartners" Type="Collection(graph.deviceManagementPartner)" ContainsTarget="true"/>
+        <NavigationProperty Name="exchangeConnectors" Type="Collection(graph.deviceManagementExchangeConnector)" ContainsTarget="true"/>
+        <NavigationProperty Name="mobileThreatDefenseConnectors" Type="Collection(graph.mobileThreatDefenseConnector)" ContainsTarget="true"/>
+        <NavigationProperty Name="applePushNotificationCertificate" Type="graph.applePushNotificationCertificate" ContainsTarget="true"/>
+        <NavigationProperty Name="detectedApps" Type="Collection(graph.detectedApp)" ContainsTarget="true"/>
+        <NavigationProperty Name="managedDeviceOverview" Type="graph.managedDeviceOverview"/>
+        <NavigationProperty Name="managedDevices" Type="Collection(graph.managedDevice)" ContainsTarget="true"/>
+        <NavigationProperty Name="mobileAppTroubleshootingEvents" Type="Collection(graph.mobileAppTroubleshootingEvent)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthApplicationPerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByOSVersion)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthDeviceModelPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthDeviceModelPerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthDevicePerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthDevicePerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthDevicePerformanceDetails" Type="Collection(graph.userExperienceAnalyticsAppHealthDevicePerformanceDetails)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthOSVersionPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthOSVersionPerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsAppHealthOverview" Type="graph.userExperienceAnalyticsCategory" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsBaselines" Type="Collection(graph.userExperienceAnalyticsBaseline)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsCategories" Type="Collection(graph.userExperienceAnalyticsCategory)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsDevicePerformance" Type="Collection(graph.userExperienceAnalyticsDevicePerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsDeviceScores" Type="Collection(graph.userExperienceAnalyticsDeviceScores)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupHistory" Type="Collection(graph.userExperienceAnalyticsDeviceStartupHistory)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupProcesses" Type="Collection(graph.userExperienceAnalyticsDeviceStartupProcess)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupProcessPerformance" Type="Collection(graph.userExperienceAnalyticsDeviceStartupProcessPerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsMetricHistory" Type="Collection(graph.userExperienceAnalyticsMetricHistory)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsModelScores" Type="Collection(graph.userExperienceAnalyticsModelScores)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsOverview" Type="graph.userExperienceAnalyticsOverview" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsScoreHistory" Type="Collection(graph.userExperienceAnalyticsScoreHistory)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" Type="graph.userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereMetrics" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereMetric)" ContainsTarget="true"/>
+        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereModelPerformance" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereModelPerformance)" ContainsTarget="true"/>
+        <NavigationProperty Name="windowsMalwareInformation" Type="Collection(graph.windowsMalwareInformation)" ContainsTarget="true"/>
+        <NavigationProperty Name="importedWindowsAutopilotDeviceIdentities" Type="Collection(graph.importedWindowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
+        <NavigationProperty Name="windowsAutopilotDeviceIdentities" Type="Collection(graph.windowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
+        <NavigationProperty Name="notificationMessageTemplates" Type="Collection(graph.notificationMessageTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="resourceOperations" Type="Collection(graph.resourceOperation)" ContainsTarget="true"/>
+        <NavigationProperty Name="roleAssignments" Type="Collection(graph.deviceAndAppManagementRoleAssignment)" ContainsTarget="true"/>
+        <NavigationProperty Name="roleDefinitions" Type="Collection(graph.roleDefinition)" ContainsTarget="true"/>
+        <NavigationProperty Name="remoteAssistancePartners" Type="Collection(graph.remoteAssistancePartner)" ContainsTarget="true"/>
+        <NavigationProperty Name="reports" Type="graph.deviceManagementReports" ContainsTarget="true"/>
+        <NavigationProperty Name="telecomExpenseManagementPartners" Type="Collection(graph.telecomExpenseManagementPartner)" ContainsTarget="true"/>
+        <NavigationProperty Name="troubleshootingEvents" Type="Collection(graph.deviceManagementTroubleshootingEvent)" ContainsTarget="true"/>
+        <NavigationProperty Name="windowsInformationProtectionAppLearningSummaries" Type="Collection(graph.windowsInformationProtectionAppLearningSummary)" ContainsTarget="true"/>
+        <NavigationProperty Name="windowsInformationProtectionNetworkLearningSummaries" Type="Collection(graph.windowsInformationProtectionNetworkLearningSummary)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="auditEvent" BaseType="graph.entity">
+        <Property Name="activity" Type="Edm.String"/>
+        <Property Name="activityDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="activityOperationType" Type="Edm.String"/>
+        <Property Name="activityResult" Type="Edm.String"/>
+        <Property Name="activityType" Type="Edm.String"/>
+        <Property Name="actor" Type="graph.auditActor"/>
+        <Property Name="category" Type="Edm.String"/>
+        <Property Name="componentName" Type="Edm.String"/>
+        <Property Name="correlationId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="resources" Type="Collection(graph.auditResource)"/>
+      </EntityType>
+      <EntityType Name="virtualEndpoint" BaseType="graph.entity">
+        <NavigationProperty Name="auditEvents" Type="Collection(graph.cloudPcAuditEvent)" ContainsTarget="true"/>
+        <NavigationProperty Name="cloudPCs" Type="Collection(graph.cloudPC)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceImages" Type="Collection(graph.cloudPcDeviceImage)" ContainsTarget="true"/>
+        <NavigationProperty Name="galleryImages" Type="Collection(graph.cloudPcGalleryImage)" ContainsTarget="true"/>
+        <NavigationProperty Name="onPremisesConnections" Type="Collection(graph.cloudPcOnPremisesConnection)" ContainsTarget="true"/>
+        <NavigationProperty Name="provisioningPolicies" Type="Collection(graph.cloudPcProvisioningPolicy)" ContainsTarget="true"/>
+        <NavigationProperty Name="userSettings" Type="Collection(graph.cloudPcUserSetting)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="termsAndConditions" BaseType="graph.entity">
+        <Property Name="acceptanceStatement" Type="Edm.String"/>
+        <Property Name="bodyText" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="title" Type="Edm.String"/>
+        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="acceptanceStatuses" Type="Collection(graph.termsAndConditionsAcceptanceStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.termsAndConditionsAssignment)" ContainsTarget="true"/>
+      </EntityType>
+      <ComplexType Name="deviceManagementSettings">
+        <Property Name="deviceComplianceCheckinThresholdDays" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="isScheduledActionEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="secureByDefault" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
+      <EntityType Name="deviceCompliancePolicy" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.deviceCompliancePolicyAssignment)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceSettingStateSummaries" Type="Collection(graph.settingStateDeviceSummary)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceStatuses" Type="Collection(graph.deviceComplianceDeviceStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceStatusOverview" Type="graph.deviceComplianceDeviceOverview" ContainsTarget="true"/>
+        <NavigationProperty Name="scheduledActionsForRule" Type="Collection(graph.deviceComplianceScheduledActionForRule)" ContainsTarget="true"/>
+        <NavigationProperty Name="userStatuses" Type="Collection(graph.deviceComplianceUserStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="userStatusOverview" Type="graph.deviceComplianceUserOverview" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="deviceCompliancePolicyDeviceStateSummary" BaseType="graph.entity">
+        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="configManagerCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="inGracePeriodCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="deviceCompliancePolicySettingStateSummary" BaseType="graph.entity">
+        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="platformType" Type="graph.policyPlatformType" Nullable="false"/>
+        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="setting" Type="Edm.String"/>
+        <Property Name="settingName" Type="Edm.String"/>
+        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="deviceComplianceSettingStates" Type="Collection(graph.deviceComplianceSettingState)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="deviceConfigurationDeviceStateSummary" BaseType="graph.entity">
+        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="deviceConfiguration" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.deviceConfigurationAssignment)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceSettingStateSummaries" Type="Collection(graph.settingStateDeviceSummary)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceStatuses" Type="Collection(graph.deviceConfigurationDeviceStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="deviceStatusOverview" Type="graph.deviceConfigurationDeviceOverview" ContainsTarget="true"/>
+        <NavigationProperty Name="userStatuses" Type="Collection(graph.deviceConfigurationUserStatus)" ContainsTarget="true"/>
+        <NavigationProperty Name="userStatusOverview" Type="graph.deviceConfigurationUserOverview" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="iosUpdateDeviceStatus" BaseType="graph.entity">
+        <Property Name="complianceGracePeriodExpirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="deviceDisplayName" Type="Edm.String"/>
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="deviceModel" Type="Edm.String"/>
+        <Property Name="installStatus" Type="graph.iosUpdatesInstallStatus" Nullable="false"/>
+        <Property Name="lastReportedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="osVersion" Type="Edm.String"/>
+        <Property Name="status" Type="graph.complianceStatus" Nullable="false"/>
+        <Property Name="userId" Type="Edm.String"/>
+        <Property Name="userName" Type="Edm.String"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="softwareUpdateStatusSummary" BaseType="graph.entity">
+        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="compliantUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="conflictUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="errorUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="nonCompliantUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="notApplicableUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="remediatedUserCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="unknownUserCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="intuneBrand">
+        <Property Name="contactITEmailAddress" Type="Edm.String"/>
+        <Property Name="contactITName" Type="Edm.String"/>
+        <Property Name="contactITNotes" Type="Edm.String"/>
+        <Property Name="contactITPhoneNumber" Type="Edm.String"/>
+        <Property Name="darkBackgroundLogo" Type="graph.mimeContent"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lightBackgroundLogo" Type="graph.mimeContent"/>
+        <Property Name="onlineSupportSiteName" Type="Edm.String"/>
+        <Property Name="onlineSupportSiteUrl" Type="Edm.String"/>
+        <Property Name="privacyUrl" Type="Edm.String"/>
+        <Property Name="showDisplayNameNextToLogo" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="showLogo" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="showNameNextToLogo" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="themeColor" Type="graph.rgbColor"/>
+      </ComplexType>
+      <EntityType Name="complianceManagementPartner" BaseType="graph.entity">
+        <Property Name="androidEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
+        <Property Name="androidOnboarded" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="iosEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
+        <Property Name="iosOnboarded" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="macOsEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
+        <Property Name="macOsOnboarded" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="partnerState" Type="graph.deviceManagementPartnerTenantState" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="onPremisesConditionalAccessSettings" BaseType="graph.entity">
+        <Property Name="enabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="excludedGroups" Type="Collection(Edm.Guid)" Nullable="false"/>
+        <Property Name="includedGroups" Type="Collection(Edm.Guid)" Nullable="false"/>
+        <Property Name="overrideDefaultRule" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="deviceCategory" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="deviceEnrollmentConfiguration" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="priority" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="assignments" Type="Collection(graph.enrollmentConfigurationAssignment)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="deviceManagementPartner" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="groupsRequiringPartnerEnrollment" Type="Collection(graph.deviceManagementPartnerAssignment)"/>
+        <Property Name="isConfigured" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="partnerAppType" Type="graph.deviceManagementPartnerAppType" Nullable="false"/>
+        <Property Name="partnerState" Type="graph.deviceManagementPartnerTenantState" Nullable="false"/>
+        <Property Name="singleTenantAppId" Type="Edm.String"/>
+        <Property Name="whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="whenPartnerDevicesWillBeRemovedDateTime" Type="Edm.DateTimeOffset"/>
+      </EntityType>
+      <EntityType Name="deviceManagementExchangeConnector" BaseType="graph.entity">
+        <Property Name="connectorServerName" Type="Edm.String"/>
+        <Property Name="exchangeAlias" Type="Edm.String"/>
+        <Property Name="exchangeConnectorType" Type="graph.deviceManagementExchangeConnectorType" Nullable="false"/>
+        <Property Name="exchangeOrganization" Type="Edm.String"/>
+        <Property Name="lastSyncDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="primarySmtpAddress" Type="Edm.String"/>
+        <Property Name="serverName" Type="Edm.String"/>
+        <Property Name="status" Type="graph.deviceManagementExchangeConnectorStatus" Nullable="false"/>
+        <Property Name="version" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="mobileThreatDefenseConnector" BaseType="graph.entity">
+        <Property Name="allowPartnerToCollectIOSApplicationMetadata" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="allowPartnerToCollectIOSPersonalApplicationMetadata" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="androidDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="androidEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="androidMobileApplicationManagementEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="iosDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="iosEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="iosMobileApplicationManagementEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="microsoftDefenderForEndpointAttachEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="partnerState" Type="graph.mobileThreatPartnerTenantState" Nullable="false"/>
+        <Property Name="partnerUnresponsivenessThresholdInDays" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="partnerUnsupportedOsVersionBlocked" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="windowsDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="windowsEnabled" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="deviceProtectionOverview">
+        <Property Name="cleanDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="criticalFailuresDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="inactiveThreatAgentDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingFullScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingManualStepsDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingOfflineScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingQuickScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingRestartDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="pendingSignatureUpdateDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalReportedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="unknownStateThreatAgentDeviceCount" Type="Edm.Int32" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="userExperienceAnalyticsSettings">
+        <Property Name="configurationManagerDataConnectorConfigured" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="windowsMalwareOverview">
+        <Property Name="malwareCategorySummary" Type="Collection(graph.windowsMalwareCategoryCount)"/>
+        <Property Name="malwareDetectedDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="malwareExecutionStateSummary" Type="Collection(graph.windowsMalwareExecutionStateCount)"/>
+        <Property Name="malwareNameSummary" Type="Collection(graph.windowsMalwareNameCount)"/>
+        <Property Name="malwareSeveritySummary" Type="Collection(graph.windowsMalwareSeverityCount)"/>
+        <Property Name="malwareStateSummary" Type="Collection(graph.windowsMalwareStateCount)"/>
+        <Property Name="osVersionsSummary" Type="Collection(graph.osVersionCount)"/>
+        <Property Name="totalDistinctMalwareCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalMalwareCount" Type="Edm.Int32" Nullable="false"/>
+      </ComplexType>
+      <EntityType Name="applePushNotificationCertificate" BaseType="graph.entity">
+        <Property Name="appleIdentifier" Type="Edm.String"/>
+        <Property Name="certificate" Type="Edm.String"/>
+        <Property Name="certificateSerialNumber" Type="Edm.String"/>
+        <Property Name="certificateUploadFailureReason" Type="Edm.String"/>
+        <Property Name="certificateUploadStatus" Type="Edm.String"/>
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="topicIdentifier" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="detectedApp" BaseType="graph.entity">
+        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="platform" Type="graph.detectedAppPlatformType" Nullable="false"/>
+        <Property Name="publisher" Type="Edm.String"/>
+        <Property Name="sizeInByte" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="version" Type="Edm.String"/>
+        <NavigationProperty Name="managedDevices" Type="Collection(graph.managedDevice)"/>
+      </EntityType>
+      <EntityType Name="managedDeviceOverview" BaseType="graph.entity">
+        <Property Name="deviceExchangeAccessStateSummary" Type="graph.deviceExchangeAccessStateSummary"/>
+        <Property Name="deviceOperatingSystemSummary" Type="graph.deviceOperatingSystemSummary"/>
+        <Property Name="dualEnrolledDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="enrolledDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="mdmEnrolledCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="mobileAppTroubleshootingEvent" BaseType="graph.entity">
+        <NavigationProperty Name="appLogCollectionRequests" Type="Collection(graph.appLogCollectionRequest)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthApplicationPerformance" BaseType="graph.entity">
+        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appDisplayName" Type="Edm.String"/>
+        <Property Name="appHangCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appHealthScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="appName" Type="Edm.String"/>
+        <Property Name="appPublisher" Type="Edm.String"/>
+        <Property Name="appUsageDuration" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails" BaseType="graph.entity">
+        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appDisplayName" Type="Edm.String"/>
+        <Property Name="appName" Type="Edm.String"/>
+        <Property Name="appPublisher" Type="Edm.String"/>
+        <Property Name="appVersion" Type="Edm.String"/>
+        <Property Name="deviceCountWithCrashes" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="isLatestUsedVersion" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isMostUsedVersion" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId" BaseType="graph.entity">
+        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appDisplayName" Type="Edm.String"/>
+        <Property Name="appName" Type="Edm.String"/>
+        <Property Name="appPublisher" Type="Edm.String"/>
+        <Property Name="appVersion" Type="Edm.String"/>
+        <Property Name="deviceDisplayName" Type="Edm.String"/>
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="processedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByOSVersion" BaseType="graph.entity">
+        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appDisplayName" Type="Edm.String"/>
+        <Property Name="appName" Type="Edm.String"/>
+        <Property Name="appPublisher" Type="Edm.String"/>
+        <Property Name="appUsageDuration" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="osBuildNumber" Type="Edm.String"/>
+        <Property Name="osVersion" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthDeviceModelPerformance" BaseType="graph.entity">
+        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="deviceManufacturer" Type="Edm.String"/>
+        <Property Name="deviceModel" Type="Edm.String"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="modelAppHealthScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthDevicePerformance" BaseType="graph.entity">
+        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="appHangCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="crashedAppCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="deviceAppHealthScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="deviceDisplayName" Type="Edm.String"/>
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="deviceManufacturer" Type="Edm.String"/>
+        <Property Name="deviceModel" Type="Edm.String"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="processedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthDevicePerformanceDetails" BaseType="graph.entity">
+        <Property Name="appDisplayName" Type="Edm.String"/>
+        <Property Name="appPublisher" Type="Edm.String"/>
+        <Property Name="appVersion" Type="Edm.String"/>
+        <Property Name="deviceDisplayName" Type="Edm.String"/>
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="eventDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="eventType" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsAppHealthOSVersionPerformance" BaseType="graph.entity">
+        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="osBuildNumber" Type="Edm.String"/>
+        <Property Name="osVersion" Type="Edm.String"/>
+        <Property Name="osVersionAppHealthScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsCategory" BaseType="graph.entity">
+        <Property Name="insights" Type="Collection(graph.userExperienceAnalyticsInsight)"/>
+        <NavigationProperty Name="metricValues" Type="Collection(graph.userExperienceAnalyticsMetric)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsBaseline" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isBuiltIn" Type="Edm.Boolean" Nullable="false"/>
+        <NavigationProperty Name="appHealthMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="batteryHealthMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="bestPracticesMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="deviceBootPerformanceMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="rebootAnalyticsMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="resourcePerformanceMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+        <NavigationProperty Name="workFromAnywhereMetrics" Type="graph.userExperienceAnalyticsCategory"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsDevicePerformance" BaseType="graph.entity">
+        <Property Name="averageBlueScreens" Type="Edm.Double" Nullable="false"/>
+        <Property Name="averageRestarts" Type="Edm.Double" Nullable="false"/>
+        <Property Name="blueScreenCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="bootScore" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="coreBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="coreLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="deviceCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="deviceName" Type="Edm.String"/>
+        <Property Name="diskType" Type="graph.diskType" Nullable="false"/>
+        <Property Name="groupPolicyBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="groupPolicyLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="loginScore" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="modelStartupPerformanceScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="operatingSystemVersion" Type="Edm.String"/>
+        <Property Name="responsiveDesktopTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="restartCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsDeviceScores" BaseType="graph.entity">
+        <Property Name="appReliabilityScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="batteryHealthScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="deviceName" Type="Edm.String"/>
+        <Property Name="endpointAnalyticsScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsDeviceStartupHistory" BaseType="graph.entity">
+        <Property Name="coreBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="coreLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="featureUpdateBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="groupPolicyBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="groupPolicyLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="isFeatureUpdate" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isFirstLogin" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="operatingSystemVersion" Type="Edm.String"/>
+        <Property Name="responsiveDesktopTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="restartCategory" Type="graph.userExperienceAnalyticsOperatingSystemRestartCategory" Nullable="false"/>
+        <Property Name="restartFaultBucket" Type="Edm.String"/>
+        <Property Name="restartStopCode" Type="Edm.String"/>
+        <Property Name="startTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="totalBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="totalLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsDeviceStartupProcess" BaseType="graph.entity">
+        <Property Name="managedDeviceId" Type="Edm.String"/>
+        <Property Name="processName" Type="Edm.String"/>
+        <Property Name="productName" Type="Edm.String"/>
+        <Property Name="publisher" Type="Edm.String"/>
+        <Property Name="startupImpactInMs" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsDeviceStartupProcessPerformance" BaseType="graph.entity">
+        <Property Name="deviceCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="medianImpactInMs" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="processName" Type="Edm.String"/>
+        <Property Name="productName" Type="Edm.String"/>
+        <Property Name="publisher" Type="Edm.String"/>
+        <Property Name="totalImpactInMs" Type="Edm.Int64" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsMetricHistory" BaseType="graph.entity">
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="metricDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="metricType" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsModelScores" BaseType="graph.entity">
+        <Property Name="appReliabilityScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="batteryHealthScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="endpointAnalyticsScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="modelDeviceCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsOverview" BaseType="graph.entity">
+        <Property Name="insights" Type="Collection(graph.userExperienceAnalyticsInsight)"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsScoreHistory" BaseType="graph.entity">
+        <Property Name="startupDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" BaseType="graph.entity">
+        <Property Name="osCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="processor64BitCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="processorCoreCountCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="processorFamilyCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="processorSpeedCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="ramCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="secureBootCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="storageCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="totalDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="tpmCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
+        <Property Name="upgradeEligibleDeviceCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereMetric" BaseType="graph.entity">
+        <NavigationProperty Name="metricDevices" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereDevice)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereModelPerformance" BaseType="graph.entity">
+        <Property Name="cloudIdentityScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="cloudManagementScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="cloudProvisioningScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="modelDeviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="windowsScore" Type="Edm.Double" Nullable="false"/>
+        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="windowsMalwareInformation" BaseType="graph.entity">
+        <Property Name="additionalInformationUrl" Type="Edm.String"/>
+        <Property Name="category" Type="graph.windowsMalwareCategory"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lastDetectionDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="severity" Type="graph.windowsMalwareSeverity"/>
+        <NavigationProperty Name="deviceMalwareStates" Type="Collection(graph.malwareStateForWindowsDevice)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="importedWindowsAutopilotDeviceIdentity" BaseType="graph.entity">
+        <Property Name="assignedUserPrincipalName" Type="Edm.String"/>
+        <Property Name="groupTag" Type="Edm.String"/>
+        <Property Name="hardwareIdentifier" Type="Edm.Binary"/>
+        <Property Name="importId" Type="Edm.String"/>
+        <Property Name="productKey" Type="Edm.String"/>
+        <Property Name="serialNumber" Type="Edm.String"/>
+        <Property Name="state" Type="graph.importedWindowsAutopilotDeviceIdentityState"/>
+      </EntityType>
+      <EntityType Name="windowsAutopilotDeviceIdentity" BaseType="graph.entity">
+        <Property Name="addressableUserName" Type="Edm.String"/>
+        <Property Name="azureActiveDirectoryDeviceId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="enrollmentState" Type="graph.enrollmentState" Nullable="false"/>
+        <Property Name="groupTag" Type="Edm.String"/>
+        <Property Name="lastContactedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="managedDeviceId" Type="Edm.String"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="productKey" Type="Edm.String"/>
+        <Property Name="purchaseOrderIdentifier" Type="Edm.String"/>
+        <Property Name="resourceName" Type="Edm.String"/>
+        <Property Name="serialNumber" Type="Edm.String"/>
+        <Property Name="skuNumber" Type="Edm.String"/>
+        <Property Name="systemFamily" Type="Edm.String"/>
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="notificationMessageTemplate" BaseType="graph.entity">
+        <Property Name="brandingOptions" Type="graph.notificationTemplateBrandingOptions" Nullable="false"/>
+        <Property Name="defaultLocale" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="roleScopeTagIds" Type="Collection(Edm.String)"/>
+        <NavigationProperty Name="localizedNotificationMessages" Type="Collection(graph.localizedNotificationMessage)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="resourceOperation" BaseType="graph.entity">
+        <Property Name="actionName" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="resourceName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="roleAssignment" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="resourceScopes" Type="Collection(Edm.String)"/>
+        <NavigationProperty Name="roleDefinition" Type="graph.roleDefinition"/>
+      </EntityType>
+      <EntityType Name="deviceAndAppManagementRoleAssignment" BaseType="graph.roleAssignment">
+        <Property Name="members" Type="Collection(Edm.String)"/>
+      </EntityType>
+      <EntityType Name="roleDefinition" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isBuiltIn" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="rolePermissions" Type="Collection(graph.rolePermission)"/>
+        <NavigationProperty Name="roleAssignments" Type="Collection(graph.roleAssignment)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="remoteAssistancePartner" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lastConnectionDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="onboardingStatus" Type="graph.remoteAssistanceOnboardingStatus" Nullable="false"/>
+        <Property Name="onboardingUrl" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="deviceManagementReports" BaseType="graph.entity">
+        <NavigationProperty Name="exportJobs" Type="Collection(graph.deviceManagementExportJob)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="telecomExpenseManagementPartner" BaseType="graph.entity">
+        <Property Name="appAuthorized" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="enabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="lastConnectionDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="url" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="windowsInformationProtectionAppLearningSummary" BaseType="graph.entity">
+        <Property Name="applicationName" Type="Edm.String"/>
+        <Property Name="applicationType" Type="graph.applicationType" Nullable="false"/>
+        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="windowsInformationProtectionNetworkLearningSummary" BaseType="graph.entity">
+        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="url" Type="Edm.String"/>
       </EntityType>
       <ComplexType Name="dataSubject" OpenType="true">
         <Property Name="email" Type="Edm.String"/>
@@ -22420,12 +25557,14 @@
         <NavigationProperty Name="notes" Type="Collection(graph.authoredNote)" ContainsTarget="true"/>
         <NavigationProperty Name="team" Type="graph.team"/>
       </EntityType>
-      <EntityType Name="security" BaseType="graph.entity">
+      <EntityType Name="security">
         <NavigationProperty Name="subjectRightsRequests" Type="Collection(graph.subjectRightsRequest)" ContainsTarget="true"/>
         <NavigationProperty Name="cases" Type="microsoft.graph.security.casesRoot" ContainsTarget="true"/>
+        <NavigationProperty Name="identities" Type="microsoft.graph.security.identityContainer" ContainsTarget="true"/>
         <NavigationProperty Name="alerts_v2" Type="Collection(microsoft.graph.security.alert)" ContainsTarget="true"/>
         <NavigationProperty Name="incidents" Type="Collection(microsoft.graph.security.incident)" ContainsTarget="true"/>
         <NavigationProperty Name="attackSimulation" Type="graph.attackSimulationRoot" ContainsTarget="true"/>
+        <NavigationProperty Name="labels" Type="microsoft.graph.security.labelsRoot" ContainsTarget="true"/>
         <NavigationProperty Name="triggers" Type="microsoft.graph.security.triggersRoot" ContainsTarget="true"/>
         <NavigationProperty Name="triggerTypes" Type="microsoft.graph.security.triggerTypesRoot" ContainsTarget="true"/>
         <NavigationProperty Name="alerts" Type="Collection(graph.alert)" ContainsTarget="true"/>
@@ -22552,84 +25691,18 @@
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String" Nullable="false"/>
         <Property Name="email" Type="Edm.String"/>
+        <Property Name="isArchived" Type="Edm.Boolean"/>
         <Property Name="isFavoriteByDefault" Type="Edm.Boolean"/>
         <Property Name="membershipType" Type="graph.channelMembershipType"/>
         <Property Name="summary" Type="graph.channelSummary"/>
         <Property Name="tenantId" Type="Edm.String"/>
         <Property Name="webUrl" Type="Edm.String"/>
+        <NavigationProperty Name="allMembers" Type="Collection(graph.conversationMember)" ContainsTarget="true"/>
         <NavigationProperty Name="filesFolder" Type="graph.driveItem" ContainsTarget="true"/>
         <NavigationProperty Name="members" Type="Collection(graph.conversationMember)" ContainsTarget="true"/>
         <NavigationProperty Name="messages" Type="Collection(graph.chatMessage)" ContainsTarget="true"/>
         <NavigationProperty Name="sharedWithTeams" Type="Collection(graph.sharedWithChannelTeamInfo)" ContainsTarget="true"/>
         <NavigationProperty Name="tabs" Type="Collection(graph.teamsTab)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="group" BaseType="graph.directoryObject" OpenType="true">
-        <Property Name="assignedLabels" Type="Collection(graph.assignedLabel)"/>
-        <Property Name="assignedLicenses" Type="Collection(graph.assignedLicense)"/>
-        <Property Name="classification" Type="Edm.String"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="groupTypes" Type="Collection(Edm.String)" Nullable="false"/>
-        <Property Name="hasMembersWithLicenseErrors" Type="Edm.Boolean"/>
-        <Property Name="isAssignableToRole" Type="Edm.Boolean"/>
-        <Property Name="licenseProcessingState" Type="graph.licenseProcessingState"/>
-        <Property Name="mail" Type="Edm.String"/>
-        <Property Name="mailEnabled" Type="Edm.Boolean"/>
-        <Property Name="mailNickname" Type="Edm.String"/>
-        <Property Name="membershipRule" Type="Edm.String"/>
-        <Property Name="membershipRuleProcessingState" Type="Edm.String"/>
-        <Property Name="onPremisesDomainName" Type="Edm.String"/>
-        <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="onPremisesNetBiosName" Type="Edm.String"/>
-        <Property Name="onPremisesProvisioningErrors" Type="Collection(graph.onPremisesProvisioningError)"/>
-        <Property Name="onPremisesSamAccountName" Type="Edm.String"/>
-        <Property Name="onPremisesSecurityIdentifier" Type="Edm.String"/>
-        <Property Name="onPremisesSyncEnabled" Type="Edm.Boolean"/>
-        <Property Name="preferredDataLocation" Type="Edm.String"/>
-        <Property Name="preferredLanguage" Type="Edm.String"/>
-        <Property Name="proxyAddresses" Type="Collection(Edm.String)" Nullable="false"/>
-        <Property Name="renewedDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="securityEnabled" Type="Edm.Boolean"/>
-        <Property Name="securityIdentifier" Type="Edm.String"/>
-        <Property Name="serviceProvisioningErrors" Type="Collection(graph.serviceProvisioningError)"/>
-        <Property Name="theme" Type="Edm.String"/>
-        <Property Name="visibility" Type="Edm.String"/>
-        <Property Name="allowExternalSenders" Type="Edm.Boolean"/>
-        <Property Name="autoSubscribeNewMembers" Type="Edm.Boolean"/>
-        <Property Name="hideFromAddressLists" Type="Edm.Boolean"/>
-        <Property Name="hideFromOutlookClients" Type="Edm.Boolean"/>
-        <Property Name="isSubscribedByMail" Type="Edm.Boolean"/>
-        <Property Name="unseenCount" Type="Edm.Int32"/>
-        <Property Name="isArchived" Type="Edm.Boolean"/>
-        <NavigationProperty Name="appRoleAssignments" Type="Collection(graph.appRoleAssignment)" ContainsTarget="true"/>
-        <NavigationProperty Name="createdOnBehalfOf" Type="graph.directoryObject"/>
-        <NavigationProperty Name="memberOf" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="members" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="membersWithLicenseErrors" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="owners" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="permissionGrants" Type="Collection(graph.resourceSpecificPermissionGrant)" ContainsTarget="true"/>
-        <NavigationProperty Name="settings" Type="Collection(graph.groupSetting)" ContainsTarget="true"/>
-        <NavigationProperty Name="transitiveMemberOf" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="transitiveMembers" Type="Collection(graph.directoryObject)"/>
-        <NavigationProperty Name="acceptedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
-        <NavigationProperty Name="calendar" Type="graph.calendar" ContainsTarget="true"/>
-        <NavigationProperty Name="calendarView" Type="Collection(graph.event)" ContainsTarget="true"/>
-        <NavigationProperty Name="conversations" Type="Collection(graph.conversation)" ContainsTarget="true"/>
-        <NavigationProperty Name="events" Type="Collection(graph.event)" ContainsTarget="true"/>
-        <NavigationProperty Name="rejectedSenders" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
-        <NavigationProperty Name="threads" Type="Collection(graph.conversationThread)" ContainsTarget="true"/>
-        <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true"/>
-        <NavigationProperty Name="drives" Type="Collection(graph.drive)" ContainsTarget="true"/>
-        <NavigationProperty Name="sites" Type="Collection(graph.site)" ContainsTarget="true"/>
-        <NavigationProperty Name="extensions" Type="Collection(graph.extension)" ContainsTarget="true"/>
-        <NavigationProperty Name="groupLifecyclePolicies" Type="Collection(graph.groupLifecyclePolicy)" ContainsTarget="true"/>
-        <NavigationProperty Name="planner" Type="graph.plannerGroup" ContainsTarget="true"/>
-        <NavigationProperty Name="onenote" Type="graph.onenote" ContainsTarget="true"/>
-        <NavigationProperty Name="photo" Type="graph.profilePhoto" ContainsTarget="true"/>
-        <NavigationProperty Name="photos" Type="Collection(graph.profilePhoto)" ContainsTarget="true"/>
-        <NavigationProperty Name="team" Type="graph.team" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="teamsAppInstallation" BaseType="graph.entity">
         <Property Name="consentedPermissionSet" Type="graph.teamsAppPermissionSet"/>
@@ -22651,13 +25724,6 @@
         <Property Name="targetResourceId" Type="Edm.String"/>
         <Property Name="targetResourceLocation" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="resourceSpecificPermissionGrant" BaseType="graph.directoryObject">
-        <Property Name="clientAppId" Type="Edm.String"/>
-        <Property Name="clientId" Type="Edm.String"/>
-        <Property Name="permission" Type="Edm.String"/>
-        <Property Name="permissionType" Type="Edm.String"/>
-        <Property Name="resourceAppId" Type="Edm.String"/>
-      </EntityType>
       <EntityType Name="teamworkTag" BaseType="graph.entity">
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
@@ -22669,21 +25735,26 @@
       <EntityType Name="teamsTemplate" BaseType="graph.entity"/>
       <EntityType Name="schedule" BaseType="graph.entity">
         <Property Name="enabled" Type="Edm.Boolean"/>
+        <Property Name="isActivitiesIncludedWhenCopyingShiftsEnabled" Type="Edm.Boolean"/>
         <Property Name="offerShiftRequestsEnabled" Type="Edm.Boolean"/>
         <Property Name="openShiftsEnabled" Type="Edm.Boolean"/>
         <Property Name="provisionStatus" Type="graph.operationStatus"/>
         <Property Name="provisionStatusCode" Type="Edm.String"/>
+        <Property Name="startDayOfWeek" Type="graph.dayOfWeek"/>
         <Property Name="swapShiftsRequestsEnabled" Type="Edm.Boolean"/>
         <Property Name="timeClockEnabled" Type="Edm.Boolean"/>
+        <Property Name="timeClockSettings" Type="graph.timeClockSettings"/>
         <Property Name="timeOffRequestsEnabled" Type="Edm.Boolean"/>
         <Property Name="timeZone" Type="Edm.String"/>
         <Property Name="workforceIntegrationIds" Type="Collection(Edm.String)"/>
+        <NavigationProperty Name="dayNotes" Type="Collection(graph.dayNote)" ContainsTarget="true"/>
         <NavigationProperty Name="offerShiftRequests" Type="Collection(graph.offerShiftRequest)" ContainsTarget="true"/>
         <NavigationProperty Name="openShiftChangeRequests" Type="Collection(graph.openShiftChangeRequest)" ContainsTarget="true"/>
         <NavigationProperty Name="openShifts" Type="Collection(graph.openShift)" ContainsTarget="true"/>
         <NavigationProperty Name="schedulingGroups" Type="Collection(graph.schedulingGroup)" ContainsTarget="true"/>
         <NavigationProperty Name="shifts" Type="Collection(graph.shift)" ContainsTarget="true"/>
         <NavigationProperty Name="swapShiftsChangeRequests" Type="Collection(graph.swapShiftsChangeRequest)" ContainsTarget="true"/>
+        <NavigationProperty Name="timeCards" Type="Collection(graph.timeCard)" ContainsTarget="true"/>
         <NavigationProperty Name="timeOffReasons" Type="Collection(graph.timeOffReason)" ContainsTarget="true"/>
         <NavigationProperty Name="timeOffRequests" Type="Collection(graph.timeOffRequest)" ContainsTarget="true"/>
         <NavigationProperty Name="timesOff" Type="Collection(graph.timeOff)" ContainsTarget="true"/>
@@ -22694,45 +25765,6 @@
         <Property Name="subcode" Type="Edm.Int32" Nullable="false"/>
       </ComplexType>
       <EntityType Name="compliance"/>
-      <ComplexType Name="assignedLabel">
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="labelId" Type="Edm.String"/>
-      </ComplexType>
-      <ComplexType Name="licenseProcessingState">
-        <Property Name="state" Type="Edm.String"/>
-      </ComplexType>
-      <EntityType Name="groupSetting" BaseType="graph.entity" OpenType="true">
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="templateId" Type="Edm.String"/>
-        <Property Name="values" Type="Collection(graph.settingValue)" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="conversation" BaseType="graph.entity">
-        <Property Name="hasAttachments" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastDeliveredDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="preview" Type="Edm.String" Nullable="false"/>
-        <Property Name="topic" Type="Edm.String" Nullable="false"/>
-        <Property Name="uniqueSenders" Type="Collection(Edm.String)" Nullable="false"/>
-        <NavigationProperty Name="threads" Type="Collection(graph.conversationThread)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="conversationThread" BaseType="graph.entity">
-        <Property Name="ccRecipients" Type="Collection(graph.recipient)" Nullable="false"/>
-        <Property Name="hasAttachments" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="isLocked" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastDeliveredDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="preview" Type="Edm.String" Nullable="false"/>
-        <Property Name="topic" Type="Edm.String" Nullable="false"/>
-        <Property Name="toRecipients" Type="Collection(graph.recipient)" Nullable="false"/>
-        <Property Name="uniqueSenders" Type="Collection(Edm.String)" Nullable="false"/>
-        <NavigationProperty Name="posts" Type="Collection(graph.post)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="groupLifecyclePolicy" BaseType="graph.entity">
-        <Property Name="alternateNotificationEmails" Type="Edm.String"/>
-        <Property Name="groupLifetimeInDays" Type="Edm.Int32"/>
-        <Property Name="managedGroupTypes" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="plannerGroup" BaseType="graph.entity">
-        <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)"/>
-      </EntityType>
       <ComplexType Name="root"/>
       <ComplexType Name="sharepointIds">
         <Property Name="listId" Type="Edm.String"/>
@@ -22744,6 +25776,7 @@
         <Property Name="webId" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="siteCollection">
+        <Property Name="archivalDetails" Type="graph.siteArchivalDetails"/>
         <Property Name="dataLocationCode" Type="Edm.String"/>
         <Property Name="hostname" Type="Edm.String"/>
         <Property Name="root" Type="graph.root"/>
@@ -22833,6 +25866,11 @@
         <Property Name="resourceId" Type="Edm.String"/>
         <Property Name="type" Type="Edm.String"/>
       </EntityType>
+      <EntityType Name="baseSitePage" BaseType="graph.baseItem">
+        <Property Name="pageLayout" Type="graph.pageLayoutType"/>
+        <Property Name="publishingState" Type="graph.publicationFacet"/>
+        <Property Name="title" Type="Edm.String"/>
+      </EntityType>
       <EntityType Name="permission" BaseType="graph.entity">
         <Property Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="grantedTo" Type="graph.identitySet"/>
@@ -22850,6 +25888,53 @@
       <ComplexType Name="assignmentOrder">
         <Property Name="order" Type="Collection(Edm.String)"/>
       </ComplexType>
+      <ComplexType Name="authenticationAttributeCollectionInputConfiguration">
+        <Property Name="attribute" Type="Edm.String" Nullable="false"/>
+        <Property Name="defaultValue" Type="Edm.String"/>
+        <Property Name="editable" Type="Edm.Boolean"/>
+        <Property Name="hidden" Type="Edm.Boolean"/>
+        <Property Name="inputType" Type="graph.authenticationAttributeCollectionInputType" Nullable="false"/>
+        <Property Name="label" Type="Edm.String" Nullable="false"/>
+        <Property Name="options" Type="Collection(graph.authenticationAttributeCollectionOptionConfiguration)"/>
+        <Property Name="required" Type="Edm.Boolean"/>
+        <Property Name="validationRegEx" Type="Edm.String"/>
+        <Property Name="writeToDirectory" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="authenticationAttributeCollectionOptionConfiguration">
+        <Property Name="label" Type="Edm.String" Nullable="false"/>
+        <Property Name="value" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="authenticationAttributeCollectionPage">
+        <Property Name="views" Type="Collection(graph.authenticationAttributeCollectionPageViewConfiguration)"/>
+      </ComplexType>
+      <ComplexType Name="authenticationAttributeCollectionPageViewConfiguration">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="inputs" Type="Collection(graph.authenticationAttributeCollectionInputConfiguration)"/>
+        <Property Name="title" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="authenticationConditions">
+        <Property Name="applications" Type="graph.authenticationConditionsApplications"/>
+      </ComplexType>
+      <ComplexType Name="authenticationConditionsApplications">
+        <NavigationProperty Name="includeApplications" Type="Collection(graph.authenticationConditionApplication)" ContainsTarget="true"/>
+      </ComplexType>
+      <EntityType Name="authenticationConditionApplication">
+        <Key>
+          <PropertyRef Name="appId"/>
+        </Key>
+        <Property Name="appId" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="authenticationConfigurationValidation">
+        <Property Name="errors" Type="Collection(graph.genericError)"/>
+        <Property Name="warnings" Type="Collection(graph.genericError)"/>
+      </ComplexType>
+      <ComplexType Name="genericError">
+        <Property Name="code" Type="Edm.String"/>
+        <Property Name="message" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="azureAdTokenAuthentication" BaseType="graph.customExtensionAuthenticationConfiguration">
+        <Property Name="resourceId" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="basicAuthentication" BaseType="graph.apiAuthenticationConfigurationBase">
         <Property Name="password" Type="Edm.String"/>
         <Property Name="username" Type="Edm.String"/>
@@ -22862,6 +25947,50 @@
         <Property Name="notAfter" Type="Edm.Int64" Nullable="false"/>
         <Property Name="notBefore" Type="Edm.Int64" Nullable="false"/>
         <Property Name="thumbprint" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="customExtensionOverwriteConfiguration">
+        <Property Name="clientConfiguration" Type="graph.customExtensionClientConfiguration"/>
+      </ComplexType>
+      <ComplexType Name="httpRequestEndpoint" BaseType="graph.customExtensionEndpointConfiguration">
+        <Property Name="targetUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="onAttributeCollectionHandler" Abstract="true"/>
+      <ComplexType Name="onAttributeCollectionExternalUsersSelfServiceSignUp" BaseType="graph.onAttributeCollectionHandler">
+        <Property Name="attributeCollectionPage" Type="graph.authenticationAttributeCollectionPage"/>
+        <NavigationProperty Name="attributes" Type="Collection(graph.identityUserFlowAttribute)"/>
+      </ComplexType>
+      <EntityType Name="identityUserFlowAttribute" BaseType="graph.entity">
+        <Property Name="dataType" Type="graph.identityUserFlowAttributeDataType" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="userFlowAttributeType" Type="graph.identityUserFlowAttributeType" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="onAuthenticationMethodLoadStartHandler" Abstract="true"/>
+      <ComplexType Name="onAuthenticationMethodLoadStartExternalUsersSelfServiceSignUp" BaseType="graph.onAuthenticationMethodLoadStartHandler">
+        <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)"/>
+      </ComplexType>
+      <EntityType Name="identityProviderBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="displayName" Type="Edm.String"/>
+      </EntityType>
+      <ComplexType Name="onInteractiveAuthFlowStartHandler" Abstract="true"/>
+      <ComplexType Name="onInteractiveAuthFlowStartExternalUsersSelfServiceSignUp" BaseType="graph.onInteractiveAuthFlowStartHandler">
+        <Property Name="isSignUpAllowed" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="onTokenIssuanceStartHandler" Abstract="true"/>
+      <ComplexType Name="onTokenIssuanceStartCustomExtensionHandler" BaseType="graph.onTokenIssuanceStartHandler">
+        <Property Name="configuration" Type="graph.customExtensionOverwriteConfiguration"/>
+        <NavigationProperty Name="customExtension" Type="graph.onTokenIssuanceStartCustomExtension"/>
+      </ComplexType>
+      <EntityType Name="customAuthenticationExtension" BaseType="graph.customCalloutExtension" Abstract="true"/>
+      <EntityType Name="onTokenIssuanceStartCustomExtension" BaseType="graph.customAuthenticationExtension">
+        <Property Name="claimsForTokenConfiguration" Type="Collection(graph.onTokenIssuanceStartReturnClaim)"/>
+      </EntityType>
+      <ComplexType Name="onTokenIssuanceStartReturnClaim">
+        <Property Name="claimIdInApiResponse" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="onUserCreateStartHandler" Abstract="true"/>
+      <ComplexType Name="onUserCreateStartExternalUsersSelfServiceSignUp" BaseType="graph.onUserCreateStartHandler">
+        <Property Name="userTypeToCreate" Type="graph.userType"/>
       </ComplexType>
       <ComplexType Name="pkcs12Certificate" BaseType="graph.apiAuthenticationConfigurationBase">
         <Property Name="password" Type="Edm.String"/>
@@ -22884,14 +26013,20 @@
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="targetUrl" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="identityProviderBase" BaseType="graph.entity" Abstract="true">
-        <Property Name="displayName" Type="Edm.String"/>
-      </EntityType>
       <EntityType Name="appleManagedIdentityProvider" BaseType="graph.identityProviderBase">
         <Property Name="certificateData" Type="Edm.String"/>
         <Property Name="developerId" Type="Edm.String"/>
         <Property Name="keyId" Type="Edm.String"/>
         <Property Name="serviceId" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="authenticationEventListener" BaseType="graph.entity" Abstract="true" OpenType="true">
+        <Property Name="authenticationEventsFlowId" Type="Edm.String"/>
+        <Property Name="conditions" Type="graph.authenticationConditions"/>
+      </EntityType>
+      <EntityType Name="authenticationEventsFlow" BaseType="graph.entity" Abstract="true" OpenType="true">
+        <Property Name="conditions" Type="graph.authenticationConditions"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
       </EntityType>
       <EntityType Name="identityUserFlow" BaseType="graph.entity">
         <Property Name="userFlowType" Type="graph.userFlowType" Nullable="false"/>
@@ -22927,21 +26062,39 @@
       <EntityType Name="builtInIdentityProvider" BaseType="graph.identityProviderBase">
         <Property Name="identityProviderType" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="identityUserFlowAttribute" BaseType="graph.entity">
-        <Property Name="dataType" Type="graph.identityUserFlowAttributeDataType" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="userFlowAttributeType" Type="graph.identityUserFlowAttributeType" Nullable="false"/>
+      <EntityType Name="externalUsersSelfServiceSignUpEventsFlow" BaseType="graph.authenticationEventsFlow">
+        <Property Name="onAttributeCollection" Type="graph.onAttributeCollectionHandler"/>
+        <Property Name="onAuthenticationMethodLoadStart" Type="graph.onAuthenticationMethodLoadStartHandler"/>
+        <Property Name="onInteractiveAuthFlowStart" Type="graph.onInteractiveAuthFlowStartHandler"/>
+        <Property Name="onUserCreateStart" Type="graph.onUserCreateStartHandler"/>
       </EntityType>
       <EntityType Name="identityBuiltInUserFlowAttribute" BaseType="graph.identityUserFlowAttribute"/>
       <EntityType Name="identityContainer" BaseType="graph.entity">
         <NavigationProperty Name="apiConnectors" Type="Collection(graph.identityApiConnector)" ContainsTarget="true"/>
+        <NavigationProperty Name="authenticationEventListeners" Type="Collection(graph.authenticationEventListener)" ContainsTarget="true"/>
+        <NavigationProperty Name="authenticationEventsFlows" Type="Collection(graph.authenticationEventsFlow)" ContainsTarget="true"/>
         <NavigationProperty Name="b2xUserFlows" Type="Collection(graph.b2xIdentityUserFlow)" ContainsTarget="true"/>
+        <NavigationProperty Name="customAuthenticationExtensions" Type="Collection(graph.customAuthenticationExtension)" ContainsTarget="true"/>
         <NavigationProperty Name="identityProviders" Type="Collection(graph.identityProviderBase)" ContainsTarget="true"/>
         <NavigationProperty Name="userFlowAttributes" Type="Collection(graph.identityUserFlowAttribute)" ContainsTarget="true"/>
         <NavigationProperty Name="conditionalAccess" Type="graph.conditionalAccessRoot" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="identityCustomUserFlowAttribute" BaseType="graph.identityUserFlowAttribute"/>
+      <EntityType Name="onAttributeCollectionListener" BaseType="graph.authenticationEventListener">
+        <Property Name="handler" Type="graph.onAttributeCollectionHandler"/>
+      </EntityType>
+      <EntityType Name="onAuthenticationMethodLoadStartListener" BaseType="graph.authenticationEventListener">
+        <Property Name="handler" Type="graph.onAuthenticationMethodLoadStartHandler"/>
+      </EntityType>
+      <EntityType Name="onInteractiveAuthFlowStartListener" BaseType="graph.authenticationEventListener">
+        <Property Name="handler" Type="graph.onInteractiveAuthFlowStartHandler"/>
+      </EntityType>
+      <EntityType Name="onTokenIssuanceStartListener" BaseType="graph.authenticationEventListener">
+        <Property Name="handler" Type="graph.onTokenIssuanceStartHandler"/>
+      </EntityType>
+      <EntityType Name="onUserCreateStartListener" BaseType="graph.authenticationEventListener">
+        <Property Name="handler" Type="graph.onUserCreateStartHandler"/>
+      </EntityType>
       <EntityType Name="socialIdentityProvider" BaseType="graph.identityProviderBase">
         <Property Name="clientId" Type="Edm.String"/>
         <Property Name="clientSecret" Type="Edm.String"/>
@@ -22976,10 +26129,15 @@
         <NavigationProperty Name="deletedItems" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
         <NavigationProperty Name="federationConfigurations" Type="Collection(graph.identityProviderBase)" ContainsTarget="true"/>
         <NavigationProperty Name="onPremisesSynchronization" Type="Collection(graph.onPremisesDirectorySynchronization)" ContainsTarget="true"/>
+        <NavigationProperty Name="subscriptions" Type="Collection(graph.companySubscription)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="administrativeUnit" BaseType="graph.directoryObject" OpenType="true">
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isMemberManagementRestricted" Type="Edm.Boolean"/>
+        <Property Name="membershipRule" Type="Edm.String"/>
+        <Property Name="membershipRuleProcessingState" Type="Edm.String"/>
+        <Property Name="membershipType" Type="Edm.String"/>
         <Property Name="visibility" Type="Edm.String"/>
         <NavigationProperty Name="members" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="scopedRoleMembers" Type="Collection(graph.scopedRoleMembership)" ContainsTarget="true"/>
@@ -23004,6 +26162,52 @@
         <Property Name="configuration" Type="graph.onPremisesDirectorySynchronizationConfiguration"/>
         <Property Name="features" Type="graph.onPremisesDirectorySynchronizationFeature" Nullable="false"/>
       </EntityType>
+      <EntityType Name="companySubscription" BaseType="graph.entity">
+        <Property Name="commerceSubscriptionId" Type="Edm.String"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="isTrial" Type="Edm.Boolean"/>
+        <Property Name="nextLifecycleDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="ownerId" Type="Edm.String"/>
+        <Property Name="ownerTenantId" Type="Edm.String"/>
+        <Property Name="ownerType" Type="Edm.String"/>
+        <Property Name="serviceStatus" Type="Collection(graph.servicePlanInfo)" Nullable="false"/>
+        <Property Name="skuId" Type="Edm.String"/>
+        <Property Name="skuPartNumber" Type="Edm.String"/>
+        <Property Name="status" Type="Edm.String"/>
+        <Property Name="totalLicenses" Type="Edm.Int32"/>
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="commerceSubscriptionId"/>
+                    <PropertyValue Property="Name" PropertyPath="commerceSubscriptionId"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <ComplexType Name="deviceRegistrationMembership"/>
+      <ComplexType Name="allDeviceRegistrationMembership" BaseType="graph.deviceRegistrationMembership"/>
+      <ComplexType Name="azureADJoinPolicy">
+        <Property Name="allowedToJoin" Type="graph.deviceRegistrationMembership"/>
+        <Property Name="isAdminConfigurable" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="azureADRegistrationPolicy">
+        <Property Name="allowedToRegister" Type="graph.deviceRegistrationMembership"/>
+        <Property Name="isAdminConfigurable" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="enumeratedDeviceRegistrationMembership" BaseType="graph.deviceRegistrationMembership">
+        <Property Name="groups" Type="Collection(Edm.String)"/>
+        <Property Name="users" Type="Collection(Edm.String)"/>
+      </ComplexType>
+      <ComplexType Name="localAdminPasswordSettings">
+        <Property Name="isEnabled" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="noDeviceRegistrationMembership" BaseType="graph.deviceRegistrationMembership"/>
       <ComplexType Name="alternativeSecurityId">
         <Property Name="identityProvider" Type="Edm.String"/>
         <Property Name="key" Type="Edm.Binary"/>
@@ -23013,20 +26217,24 @@
         <Property Name="appId" Type="Edm.String"/>
         <Property Name="delegatedPermissionIds" Type="Collection(Edm.String)" Nullable="false"/>
       </ComplexType>
-      <ComplexType Name="appManagementConfiguration">
+      <ComplexType Name="appManagementConfiguration" Abstract="true">
         <Property Name="keyCredentials" Type="Collection(graph.keyCredentialConfiguration)"/>
         <Property Name="passwordCredentials" Type="Collection(graph.passwordCredentialConfiguration)"/>
       </ComplexType>
+      <ComplexType Name="appManagementApplicationConfiguration" BaseType="graph.appManagementConfiguration"/>
       <ComplexType Name="keyCredentialConfiguration">
         <Property Name="maxLifetime" Type="Edm.Duration"/>
         <Property Name="restrictForAppsCreatedAfterDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="restrictionType" Type="graph.appKeyCredentialRestrictionType"/>
+        <Property Name="state" Type="graph.appManagementRestrictionState" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="passwordCredentialConfiguration">
         <Property Name="maxLifetime" Type="Edm.Duration"/>
         <Property Name="restrictForAppsCreatedAfterDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="restrictionType" Type="graph.appCredentialRestrictionType"/>
+        <Property Name="state" Type="graph.appManagementRestrictionState" Nullable="false"/>
       </ComplexType>
+      <ComplexType Name="appManagementServicePrincipalConfiguration" BaseType="graph.appManagementConfiguration"/>
       <ComplexType Name="certificateAuthority">
         <Property Name="certificate" Type="Edm.Binary" Nullable="false"/>
         <Property Name="certificateRevocationListUrl" Type="Edm.String"/>
@@ -23036,6 +26244,12 @@
         <Property Name="issuerSki" Type="Edm.String" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="ComplexExtensionValue" OpenType="true"/>
+      <ComplexType Name="contentCustomization">
+        <Property Name="attributeCollection" Type="Collection(graph.keyValue)" Nullable="false"/>
+        <Property Name="attributeCollectionRelativeUrl" Type="Edm.String"/>
+        <Property Name="registrationCampaign" Type="Collection(graph.keyValue)" Nullable="false"/>
+        <Property Name="registrationCampaignRelativeUrl" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="crossTenantAccessPolicyB2BSetting">
         <Property Name="applications" Type="graph.crossTenantAccessPolicyTargetConfiguration"/>
         <Property Name="usersAndGroups" Type="graph.crossTenantAccessPolicyTargetConfiguration"/>
@@ -23053,9 +26267,22 @@
         <Property Name="target" Type="Edm.String"/>
         <Property Name="targetType" Type="graph.crossTenantAccessPolicyTargetType"/>
       </ComplexType>
+      <ComplexType Name="crossTenantAccessPolicyTenantRestrictions" BaseType="graph.crossTenantAccessPolicyB2BSetting">
+        <Property Name="devices" Type="graph.devicesFilter"/>
+      </ComplexType>
+      <ComplexType Name="devicesFilter">
+        <Property Name="mode" Type="graph.crossTenantAccessPolicyTargetConfigurationAccessType"/>
+        <Property Name="rule" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="crossTenantUserSyncInbound">
         <Property Name="isSyncAllowed" Type="Edm.Boolean"/>
       </ComplexType>
+      <ComplexType Name="customAppManagementConfiguration" BaseType="graph.appManagementConfiguration"/>
+      <ComplexType Name="invitationRedemptionIdentityProviderConfiguration">
+        <Property Name="fallbackIdentityProvider" Type="graph.b2bIdentityProvidersType"/>
+        <Property Name="primaryIdentityProviderPrecedenceOrder" Type="Collection(graph.b2bIdentityProvidersType)"/>
+      </ComplexType>
+      <ComplexType Name="defaultInvitationRedemptionIdentityProviderConfiguration" BaseType="graph.invitationRedemptionIdentityProviderConfiguration"/>
       <ComplexType Name="defaultUserRolePermissions">
         <Property Name="allowedToCreateApps" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="allowedToCreateSecurityGroups" Type="Edm.Boolean" Nullable="false"/>
@@ -23103,6 +26330,17 @@
         <Property Name="hidePrivacyAndCookies" Type="Edm.Boolean"/>
         <Property Name="hideResetItNow" Type="Edm.Boolean"/>
         <Property Name="hideTermsOfUse" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="multiTenantOrganizationJoinRequestTransitionDetails">
+        <Property Name="desiredMemberState" Type="graph.multiTenantOrganizationMemberState"/>
+        <Property Name="details" Type="Edm.String"/>
+        <Property Name="status" Type="graph.multiTenantOrganizationMemberProcessingStatus"/>
+      </ComplexType>
+      <ComplexType Name="multiTenantOrganizationMemberTransitionDetails">
+        <Property Name="desiredRole" Type="graph.multiTenantOrganizationMemberRole"/>
+        <Property Name="desiredState" Type="graph.multiTenantOrganizationMemberState"/>
+        <Property Name="details" Type="Edm.String"/>
+        <Property Name="status" Type="graph.multiTenantOrganizationMemberProcessingStatus"/>
       </ComplexType>
       <ComplexType Name="onPremisesAccidentalDeletionPrevention">
         <Property Name="alertThreshold" Type="Edm.Int32"/>
@@ -23233,7 +26471,9 @@
         <Property Name="b2bDirectConnectInbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
         <Property Name="b2bDirectConnectOutbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
         <Property Name="inboundTrust" Type="graph.crossTenantAccessPolicyInboundTrust"/>
+        <Property Name="invitationRedemptionIdentityProviderConfiguration" Type="graph.defaultInvitationRedemptionIdentityProviderConfiguration"/>
         <Property Name="isServiceDefault" Type="Edm.Boolean"/>
+        <Property Name="tenantRestrictions" Type="graph.crossTenantAccessPolicyTenantRestrictions"/>
       </EntityType>
       <EntityType Name="crossTenantAccessPolicyConfigurationPartner">
         <Key>
@@ -23245,9 +26485,15 @@
         <Property Name="b2bDirectConnectInbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
         <Property Name="b2bDirectConnectOutbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
         <Property Name="inboundTrust" Type="graph.crossTenantAccessPolicyInboundTrust"/>
+        <Property Name="isInMultiTenantOrganization" Type="Edm.Boolean"/>
         <Property Name="isServiceProvider" Type="Edm.Boolean"/>
         <Property Name="tenantId" Type="Edm.String" Nullable="false"/>
+        <Property Name="tenantRestrictions" Type="graph.crossTenantAccessPolicyTenantRestrictions"/>
         <NavigationProperty Name="identitySynchronization" Type="graph.crossTenantIdentitySyncPolicyPartner" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="policyTemplate" BaseType="graph.entity">
+        <NavigationProperty Name="multiTenantOrganizationIdentitySynchronization" Type="graph.multiTenantOrganizationIdentitySyncPolicyTemplate" ContainsTarget="true"/>
+        <NavigationProperty Name="multiTenantOrganizationPartnerConfiguration" Type="graph.multiTenantOrganizationPartnerConfigurationTemplate" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="crossTenantIdentitySyncPolicyPartner">
         <Key>
@@ -23269,10 +26515,17 @@
         <Property Name="deviceVersion" Type="Edm.Int32"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="enrollmentProfileName" Type="Edm.String"/>
+        <Property Name="enrollmentType" Type="Edm.String"/>
         <Property Name="isCompliant" Type="Edm.Boolean"/>
         <Property Name="isManaged" Type="Edm.Boolean"/>
+        <Property Name="isManagementRestricted" Type="Edm.Boolean"/>
+        <Property Name="isRooted" Type="Edm.Boolean"/>
+        <Property Name="managementType" Type="Edm.String"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
         <Property Name="mdmAppId" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
         <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="onPremisesSecurityIdentifier" Type="Edm.String"/>
         <Property Name="onPremisesSyncEnabled" Type="Edm.Boolean"/>
         <Property Name="operatingSystem" Type="Edm.String"/>
         <Property Name="operatingSystemVersion" Type="Edm.String"/>
@@ -23348,6 +26601,7 @@
         <Property Name="supportedServices" Type="Collection(Edm.String)" Nullable="false"/>
         <NavigationProperty Name="domainNameReferences" Type="Collection(graph.directoryObject)"/>
         <NavigationProperty Name="federationConfiguration" Type="Collection(graph.internalDomainFederation)" ContainsTarget="true"/>
+        <NavigationProperty Name="rootDomain" Type="graph.domain"/>
         <NavigationProperty Name="serviceConfigurationRecords" Type="Collection(graph.domainDnsRecord)" ContainsTarget="true"/>
         <NavigationProperty Name="verificationDnsRecords" Type="Collection(graph.domainDnsRecord)" ContainsTarget="true"/>
       </EntityType>
@@ -23363,6 +26617,7 @@
         <Property Name="federatedIdpMfaBehavior" Type="graph.federatedIdpMfaBehavior"/>
         <Property Name="isSignedAuthenticationRequestRequired" Type="Edm.Boolean"/>
         <Property Name="nextSigningCertificate" Type="Edm.String"/>
+        <Property Name="passwordResetUri" Type="Edm.String"/>
         <Property Name="promptLoginBehavior" Type="graph.promptLoginBehavior"/>
         <Property Name="signingCertificateUpdateStatus" Type="graph.signingCertificateUpdateStatus"/>
         <Property Name="signOutUri" Type="Edm.String"/>
@@ -23401,6 +26656,43 @@
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="values" Type="Collection(graph.settingTemplateValue)" Nullable="false"/>
       </EntityType>
+      <EntityType Name="multiTenantOrganization" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="state" Type="graph.multiTenantOrganizationState"/>
+        <NavigationProperty Name="joinRequest" Type="graph.multiTenantOrganizationJoinRequestRecord" ContainsTarget="true"/>
+        <NavigationProperty Name="tenants" Type="Collection(graph.multiTenantOrganizationMember)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="multiTenantOrganizationJoinRequestRecord" BaseType="graph.entity">
+        <Property Name="addedByTenantId" Type="Edm.String"/>
+        <Property Name="memberState" Type="graph.multiTenantOrganizationMemberState"/>
+        <Property Name="role" Type="graph.multiTenantOrganizationMemberRole"/>
+        <Property Name="transitionDetails" Type="graph.multiTenantOrganizationJoinRequestTransitionDetails"/>
+      </EntityType>
+      <EntityType Name="multiTenantOrganizationMember" BaseType="graph.directoryObject">
+        <Property Name="addedByTenantId" Type="Edm.Guid"/>
+        <Property Name="addedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="joinedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="role" Type="graph.multiTenantOrganizationMemberRole"/>
+        <Property Name="state" Type="graph.multiTenantOrganizationMemberState"/>
+        <Property Name="tenantId" Type="Edm.String" Nullable="false"/>
+        <Property Name="transitionDetails" Type="graph.multiTenantOrganizationMemberTransitionDetails"/>
+      </EntityType>
+      <EntityType Name="multiTenantOrganizationIdentitySyncPolicyTemplate" BaseType="graph.entity">
+        <Property Name="templateApplicationLevel" Type="graph.templateApplicationLevel" Nullable="false"/>
+        <Property Name="userSyncInbound" Type="graph.crossTenantUserSyncInbound"/>
+      </EntityType>
+      <EntityType Name="multiTenantOrganizationPartnerConfigurationTemplate" BaseType="graph.entity">
+        <Property Name="automaticUserConsentSettings" Type="graph.inboundOutboundPolicyConfiguration"/>
+        <Property Name="b2bCollaborationInbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
+        <Property Name="b2bCollaborationOutbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
+        <Property Name="b2bDirectConnectInbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
+        <Property Name="b2bDirectConnectOutbound" Type="graph.crossTenantAccessPolicyB2BSetting"/>
+        <Property Name="inboundTrust" Type="graph.crossTenantAccessPolicyInboundTrust"/>
+        <Property Name="templateApplicationLevel" Type="graph.templateApplicationLevel" Nullable="false"/>
+      </EntityType>
       <EntityType Name="organization" BaseType="graph.directoryObject" OpenType="true">
         <Property Name="assignedPlans" Type="Collection(graph.assignedPlan)" Nullable="false"/>
         <Property Name="businessPhones" Type="Collection(Edm.String)" Nullable="false"/>
@@ -23437,6 +26729,7 @@
         <Property Name="bannerLogo" Type="Edm.Stream"/>
         <Property Name="bannerLogoRelativeUrl" Type="Edm.String"/>
         <Property Name="cdnList" Type="Collection(Edm.String)"/>
+        <Property Name="contentCustomization" Type="graph.contentCustomization"/>
         <Property Name="customAccountResetCredentialsUrl" Type="Edm.String"/>
         <Property Name="customCannotAccessYourAccountText" Type="Edm.String"/>
         <Property Name="customCannotAccessYourAccountUrl" Type="Edm.String"/>
@@ -23649,6 +26942,7 @@
         <Property Name="subscriptionIds" Type="Collection(Edm.String)"/>
       </EntityType>
       <EntityType Name="tenantRelationship">
+        <NavigationProperty Name="multiTenantOrganization" Type="graph.multiTenantOrganization" ContainsTarget="true"/>
         <NavigationProperty Name="delegatedAdminCustomers" Type="Collection(graph.delegatedAdminCustomer)" ContainsTarget="true"/>
         <NavigationProperty Name="delegatedAdminRelationships" Type="Collection(graph.delegatedAdminRelationship)" ContainsTarget="true"/>
       </EntityType>
@@ -23702,7 +26996,9 @@
       <EntityType Name="admin">
         <NavigationProperty Name="edge" Type="graph.edge" ContainsTarget="true"/>
         <NavigationProperty Name="sharepoint" Type="graph.sharepoint" ContainsTarget="true"/>
+        <NavigationProperty Name="microsoft365Apps" Type="graph.adminMicrosoft365Apps" ContainsTarget="true"/>
         <NavigationProperty Name="serviceAnnouncement" Type="graph.serviceAnnouncement" ContainsTarget="true"/>
+        <NavigationProperty Name="reportSettings" Type="graph.adminReportSettings" ContainsTarget="true"/>
         <NavigationProperty Name="people" Type="graph.peopleAdminSettings" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="edge" BaseType="graph.entity">
@@ -23711,13 +27007,21 @@
       <EntityType Name="sharepoint" BaseType="graph.entity">
         <NavigationProperty Name="settings" Type="graph.sharepointSettings" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="adminMicrosoft365Apps" BaseType="graph.entity">
+        <NavigationProperty Name="installationOptions" Type="graph.m365AppsInstallationOptions" ContainsTarget="true"/>
+      </EntityType>
       <EntityType Name="serviceAnnouncement" BaseType="graph.entity">
         <NavigationProperty Name="healthOverviews" Type="Collection(graph.serviceHealth)" ContainsTarget="true"/>
         <NavigationProperty Name="issues" Type="Collection(graph.serviceHealthIssue)" ContainsTarget="true"/>
         <NavigationProperty Name="messages" Type="Collection(graph.serviceUpdateMessage)" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="adminReportSettings" BaseType="graph.entity">
+        <Property Name="displayConcealedNames" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
       <EntityType Name="peopleAdminSettings" BaseType="graph.entity">
         <NavigationProperty Name="profileCardProperties" Type="Collection(graph.profileCardProperty)" ContainsTarget="true"/>
+        <NavigationProperty Name="pronouns" Type="graph.pronounsSettings" ContainsTarget="true"/>
+        <NavigationProperty Name="itemInsights" Type="graph.insightsSettings" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="browserSharedCookie" BaseType="graph.entity">
         <Property Name="comment" Type="Edm.String" Nullable="false"/>
@@ -23786,6 +27090,9 @@
         <Property Name="lastModifiedBy" Type="graph.identitySet"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
       </ComplexType>
+      <ComplexType Name="educationChannelResource" BaseType="graph.educationResource">
+        <Property Name="url" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="educationExcelResource" BaseType="graph.educationResource">
         <Property Name="fileUrl" Type="Edm.String"/>
       </ComplexType>
@@ -23803,6 +27110,9 @@
       </ComplexType>
       <ComplexType Name="educationFileResource" BaseType="graph.educationResource">
         <Property Name="fileUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="educationLinkedAssignmentResource" BaseType="graph.educationResource">
+        <Property Name="url" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="educationLinkResource" BaseType="graph.educationResource">
         <Property Name="link" Type="Edm.String"/>
@@ -23869,17 +27179,23 @@
         <Property Name="instructions" Type="graph.educationItemBody"/>
         <Property Name="lastModifiedBy" Type="graph.identitySet"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="moduleUrl" Type="Edm.String"/>
         <Property Name="notificationChannelUrl" Type="Edm.String"/>
         <Property Name="resourcesFolderUrl" Type="Edm.String"/>
         <Property Name="status" Type="graph.educationAssignmentStatus"/>
         <Property Name="webUrl" Type="Edm.String"/>
         <NavigationProperty Name="categories" Type="Collection(graph.educationCategory)" ContainsTarget="true"/>
+        <NavigationProperty Name="gradingCategory" Type="graph.educationGradingCategory"/>
         <NavigationProperty Name="resources" Type="Collection(graph.educationAssignmentResource)" ContainsTarget="true"/>
         <NavigationProperty Name="rubric" Type="graph.educationRubric" ContainsTarget="true"/>
         <NavigationProperty Name="submissions" Type="Collection(graph.educationSubmission)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="educationCategory" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="educationGradingCategory" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="percentageWeight" Type="Edm.Int32" Nullable="false"/>
       </EntityType>
       <EntityType Name="educationAssignmentResource" BaseType="graph.entity">
         <Property Name="distributeForStudentWork" Type="Edm.Boolean"/>
@@ -23897,6 +27213,8 @@
         <Property Name="qualities" Type="Collection(graph.rubricQuality)"/>
       </EntityType>
       <EntityType Name="educationSubmission" BaseType="graph.entity">
+        <Property Name="excusedBy" Type="graph.identitySet"/>
+        <Property Name="excusedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="reassignedBy" Type="graph.identitySet"/>
         <Property Name="reassignedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="recipient" Type="graph.educationSubmissionRecipient"/>
@@ -23908,6 +27226,7 @@
         <Property Name="submittedDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="unsubmittedBy" Type="graph.identitySet"/>
         <Property Name="unsubmittedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="webUrl" Type="Edm.String"/>
         <NavigationProperty Name="outcomes" Type="Collection(graph.educationOutcome)" ContainsTarget="true"/>
         <NavigationProperty Name="resources" Type="Collection(graph.educationSubmissionResource)" ContainsTarget="true"/>
         <NavigationProperty Name="submittedResources" Type="Collection(graph.educationSubmissionResource)" ContainsTarget="true"/>
@@ -23920,6 +27239,7 @@
       </EntityType>
       <EntityType Name="educationAssignmentSettings" BaseType="graph.entity">
         <Property Name="submissionAnimationDisabled" Type="Edm.Boolean"/>
+        <NavigationProperty Name="gradingCategories" Type="Collection(graph.educationGradingCategory)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="educationClass" BaseType="graph.entity">
         <Property Name="classCode" Type="Edm.String"/>
@@ -23938,10 +27258,23 @@
         <NavigationProperty Name="assignmentDefaults" Type="graph.educationAssignmentDefaults" ContainsTarget="true"/>
         <NavigationProperty Name="assignments" Type="Collection(graph.educationAssignment)" ContainsTarget="true"/>
         <NavigationProperty Name="assignmentSettings" Type="graph.educationAssignmentSettings" ContainsTarget="true"/>
+        <NavigationProperty Name="modules" Type="Collection(graph.educationModule)" ContainsTarget="true"/>
         <NavigationProperty Name="group" Type="graph.group"/>
         <NavigationProperty Name="members" Type="Collection(graph.educationUser)"/>
         <NavigationProperty Name="schools" Type="Collection(graph.educationSchool)"/>
         <NavigationProperty Name="teachers" Type="Collection(graph.educationUser)"/>
+      </EntityType>
+      <EntityType Name="educationModule" BaseType="graph.entity">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isPinned" Type="Edm.Boolean"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="resourcesFolderUrl" Type="Edm.String"/>
+        <Property Name="status" Type="graph.educationModuleStatus"/>
+        <NavigationProperty Name="resources" Type="Collection(graph.educationModuleResource)" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="educationCourse">
         <Property Name="courseNumber" Type="Edm.String"/>
@@ -24030,6 +27363,9 @@
         <Property Name="feedbackResource" Type="graph.educationResource"/>
         <Property Name="resourceStatus" Type="graph.educationFeedbackResourceOutcomeStatus"/>
       </EntityType>
+      <EntityType Name="educationModuleResource" BaseType="graph.entity">
+        <Property Name="resource" Type="graph.educationResource"/>
+      </EntityType>
       <EntityType Name="educationPointsOutcome" BaseType="graph.educationOutcome">
         <Property Name="points" Type="graph.educationAssignmentPointsGrade"/>
         <Property Name="publishedPoints" Type="graph.educationAssignmentPointsGrade"/>
@@ -24072,6 +27408,158 @@
         <Property Name="externalId" Type="Edm.String"/>
         <Property Name="teacherNumber" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="artifactQuery">
+        <Property Name="artifactType" Type="graph.restorableArtifact"/>
+        <Property Name="queryExpression" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="restorePointSearchResponse">
+        <Property Name="noResultProtectionUnitIds" Type="Collection(Edm.String)"/>
+        <Property Name="searchResponseId" Type="Edm.String"/>
+        <Property Name="searchResults" Type="Collection(graph.restorePointSearchResult)"/>
+      </ComplexType>
+      <ComplexType Name="restorePointSearchResult">
+        <Property Name="artifactHitCount" Type="Edm.Int32"/>
+        <NavigationProperty Name="restorePoint" Type="graph.restorePoint"/>
+      </ComplexType>
+      <EntityType Name="restorePoint" BaseType="graph.entity">
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="protectionDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="tags" Type="graph.restorePointTags"/>
+        <NavigationProperty Name="protectionUnit" Type="graph.protectionUnitBase"/>
+      </EntityType>
+      <ComplexType Name="retentionSetting">
+        <Property Name="interval" Type="Edm.String"/>
+        <Property Name="period" Type="Edm.Duration"/>
+      </ComplexType>
+      <ComplexType Name="serviceStatus">
+        <Property Name="backupServiceConsumer" Type="graph.backupServiceConsumer"/>
+        <Property Name="disableReason" Type="graph.disableReason"/>
+        <Property Name="gracePeriodDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="restoreAllowedTillDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="status" Type="graph.backupServiceStatus"/>
+      </ComplexType>
+      <ComplexType Name="timePeriod">
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
+      </ComplexType>
+      <EntityType Name="protectionRuleBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="error" Type="graph.publicError"/>
+        <Property Name="isAutoApplyEnabled" Type="Edm.Boolean"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="status" Type="graph.protectionRuleStatus"/>
+      </EntityType>
+      <EntityType Name="driveProtectionRule" BaseType="graph.protectionRuleBase">
+        <Property Name="driveExpression" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="protectionUnitBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="error" Type="graph.publicError"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="policyId" Type="Edm.String"/>
+        <Property Name="status" Type="graph.protectionUnitStatus"/>
+      </EntityType>
+      <EntityType Name="driveProtectionUnit" BaseType="graph.protectionUnitBase">
+        <Property Name="directoryObjectId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="email" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="protectionPolicyBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="retentionSettings" Type="Collection(graph.retentionSetting)"/>
+        <Property Name="status" Type="graph.protectionPolicyStatus"/>
+      </EntityType>
+      <EntityType Name="exchangeProtectionPolicy" BaseType="graph.protectionPolicyBase">
+        <NavigationProperty Name="mailboxInclusionRules" Type="Collection(graph.mailboxProtectionRule)"/>
+        <NavigationProperty Name="mailboxProtectionUnits" Type="Collection(graph.mailboxProtectionUnit)"/>
+      </EntityType>
+      <EntityType Name="restoreSessionBase" BaseType="graph.entity">
+        <Property Name="completedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="error" Type="graph.publicError"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="status" Type="graph.restoreSessionStatus"/>
+      </EntityType>
+      <EntityType Name="exchangeRestoreSession" BaseType="graph.restoreSessionBase">
+        <NavigationProperty Name="granularMailboxRestoreArtifacts" Type="Collection(graph.granularMailboxRestoreArtifact)" ContainsTarget="true"/>
+        <NavigationProperty Name="mailboxRestoreArtifacts" Type="Collection(graph.mailboxRestoreArtifact)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="mailboxProtectionRule" BaseType="graph.protectionRuleBase">
+        <Property Name="mailboxExpression" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="mailboxProtectionUnit" BaseType="graph.protectionUnitBase">
+        <Property Name="directoryObjectId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="email" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="oneDriveForBusinessProtectionPolicy" BaseType="graph.protectionPolicyBase">
+        <NavigationProperty Name="driveInclusionRules" Type="Collection(graph.driveProtectionRule)"/>
+        <NavigationProperty Name="driveProtectionUnits" Type="Collection(graph.driveProtectionUnit)"/>
+      </EntityType>
+      <EntityType Name="oneDriveForBusinessRestoreSession" BaseType="graph.restoreSessionBase">
+        <NavigationProperty Name="driveRestoreArtifacts" Type="Collection(graph.driveRestoreArtifact)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="serviceApp" BaseType="graph.entity">
+        <Property Name="application" Type="graph.identity"/>
+        <Property Name="effectiveDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="registrationDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="status" Type="graph.serviceAppStatus"/>
+      </EntityType>
+      <EntityType Name="sharePointProtectionPolicy" BaseType="graph.protectionPolicyBase">
+        <NavigationProperty Name="siteInclusionRules" Type="Collection(graph.siteProtectionRule)"/>
+        <NavigationProperty Name="siteProtectionUnits" Type="Collection(graph.siteProtectionUnit)"/>
+      </EntityType>
+      <EntityType Name="sharePointRestoreSession" BaseType="graph.restoreSessionBase">
+        <NavigationProperty Name="siteRestoreArtifacts" Type="Collection(graph.siteRestoreArtifact)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="siteProtectionRule" BaseType="graph.protectionRuleBase">
+        <Property Name="siteExpression" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="siteProtectionUnit" BaseType="graph.protectionUnitBase">
+        <Property Name="siteId" Type="Edm.String"/>
+        <Property Name="siteName" Type="Edm.String"/>
+        <Property Name="siteWebUrl" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="restoreArtifactBase" BaseType="graph.entity">
+        <Property Name="completionDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="destinationType" Type="graph.destinationType"/>
+        <Property Name="error" Type="graph.publicError"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="status" Type="graph.artifactRestoreStatus"/>
+        <NavigationProperty Name="restorePoint" Type="graph.restorePoint"/>
+      </EntityType>
+      <EntityType Name="driveRestoreArtifact" BaseType="graph.restoreArtifactBase">
+        <Property Name="restoredSiteId" Type="Edm.String"/>
+        <Property Name="restoredSiteName" Type="Edm.String"/>
+        <Property Name="restoredSiteWebUrl" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="mailboxRestoreArtifact" BaseType="graph.restoreArtifactBase">
+        <Property Name="restoredFolderId" Type="Edm.String"/>
+        <Property Name="restoredFolderName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="granularMailboxRestoreArtifact" BaseType="graph.mailboxRestoreArtifact">
+        <Property Name="artifactCount" Type="Edm.Int32"/>
+        <Property Name="searchResponseId" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="siteRestoreArtifact" BaseType="graph.restoreArtifactBase">
+        <Property Name="restoredSiteId" Type="Edm.String"/>
+        <Property Name="restoredSiteName" Type="Edm.String"/>
+        <Property Name="restoredSiteWebUrl" Type="Edm.String"/>
+      </EntityType>
       <ComplexType Name="Json"/>
       <ComplexType Name="workbookFilterCriteria">
         <Property Name="color" Type="Edm.String"/>
@@ -24710,10 +28198,6 @@
         <Property Name="sourceId" Type="Edm.String"/>
         <Property Name="targetId" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="genericError">
-        <Property Name="code" Type="Edm.String"/>
-        <Property Name="message" Type="Edm.String"/>
-      </ComplexType>
       <ComplexType Name="timeZoneBase">
         <Property Name="name" Type="Edm.String"/>
       </ComplexType>
@@ -24997,11 +28481,47 @@
         <Property Name="displayName" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="referenceAttachment" BaseType="graph.attachment"/>
+      <ComplexType Name="Dictionary" OpenType="true"/>
+      <ComplexType Name="fileStorageContainerCustomPropertyDictionary" BaseType="graph.Dictionary" OpenType="true"/>
+      <ComplexType Name="fileStorageContainerCustomPropertyValue">
+        <Property Name="isSearchable" Type="Edm.Boolean"/>
+        <Property Name="value" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="fileStorageContainerSettings">
+        <Property Name="isItemVersioningEnabled" Type="Edm.Boolean"/>
+        <Property Name="isOcrEnabled" Type="Edm.Boolean"/>
+        <Property Name="itemMajorVersionLimit" Type="Edm.Int32"/>
+      </ComplexType>
+      <ComplexType Name="fileStorageContainerViewpoint">
+        <Property Name="effectiveRole" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
       <ComplexType Name="idleSessionSignOut">
         <Property Name="isEnabled" Type="Edm.Boolean"/>
         <Property Name="signOutAfterInSeconds" Type="Edm.Int64"/>
         <Property Name="warnAfterInSeconds" Type="Edm.Int64"/>
       </ComplexType>
+      <EntityType Name="fileStorage" BaseType="graph.entity">
+        <NavigationProperty Name="containers" Type="Collection(graph.fileStorageContainer)" ContainsTarget="true"/>
+        <NavigationProperty Name="deletedContainers" Type="Collection(graph.fileStorageContainer)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="fileStorageContainer" BaseType="graph.entity">
+        <Property Name="containerTypeId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="customProperties" Type="graph.fileStorageContainerCustomPropertyDictionary"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lockState" Type="graph.siteLockState"/>
+        <Property Name="settings" Type="graph.fileStorageContainerSettings" Nullable="false"/>
+        <Property Name="status" Type="graph.fileStorageContainerStatus"/>
+        <Property Name="viewpoint" Type="graph.fileStorageContainerViewpoint"/>
+        <NavigationProperty Name="drive" Type="graph.drive" ContainsTarget="true"/>
+        <NavigationProperty Name="permissions" Type="Collection(graph.permission)" ContainsTarget="true"/>
+        <NavigationProperty Name="recycleBin" Type="graph.recycleBin" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="recycleBin" BaseType="graph.baseItem" OpenType="true">
+        <Property Name="settings" Type="graph.recycleBinSettings"/>
+        <NavigationProperty Name="items" Type="Collection(graph.recycleBinItem)" ContainsTarget="true"/>
+      </EntityType>
       <EntityType Name="sharepointSettings" BaseType="graph.entity">
         <Property Name="allowedDomainGuidsForSyncApp" Type="Collection(Edm.Guid)"/>
         <Property Name="availableManagedPathsForSiteCreation" Type="Collection(Edm.String)" Nullable="false"/>
@@ -25032,6 +28552,13 @@
         <Property Name="siteCreationDefaultManagedPath" Type="Edm.String" Nullable="false"/>
         <Property Name="siteCreationDefaultStorageLimitInMB" Type="Edm.Int32"/>
         <Property Name="tenantDefaultTimezone" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="storage">
+        <NavigationProperty Name="fileStorage" Type="graph.fileStorage" ContainsTarget="true"/>
+        <NavigationProperty Name="settings" Type="graph.storageSettings" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="storageSettings" BaseType="graph.entity">
+        <NavigationProperty Name="quota" Type="graph.unifiedStorageQuota" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="accessAction" OpenType="true"/>
       <ComplexType Name="album">
@@ -25106,11 +28633,20 @@
         <Property Name="title" Type="Edm.String"/>
         <Property Name="versionId" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="driveItemSource">
+        <Property Name="application" Type="graph.driveItemSourceApplication"/>
+        <Property Name="externalId" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="driveItemUploadableProperties">
         <Property Name="description" Type="Edm.String"/>
+        <Property Name="driveItemSource" Type="graph.driveItemSource"/>
         <Property Name="fileSize" Type="Edm.Int64"/>
         <Property Name="fileSystemInfo" Type="graph.fileSystemInfo"/>
+        <Property Name="mediaSource" Type="graph.mediaSource"/>
         <Property Name="name" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="mediaSource">
+        <Property Name="contentCategory" Type="graph.mediaSourceContentCategory"/>
       </ComplexType>
       <ComplexType Name="driveRecipient">
         <Property Name="alias" Type="Edm.String"/>
@@ -25174,6 +28710,14 @@
       <ComplexType Name="mentionAction">
         <Property Name="mentionees" Type="Collection(graph.identitySet)"/>
       </ComplexType>
+      <ComplexType Name="metaDataKeyStringPair">
+        <Property Name="key" Type="Edm.String"/>
+        <Property Name="value" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="metaDataKeyValuePair">
+        <Property Name="key" Type="Edm.String"/>
+        <Property Name="value" Type="graph.Json"/>
+      </ComplexType>
       <ComplexType Name="moveAction">
         <Property Name="from" Type="Edm.String"/>
         <Property Name="to" Type="Edm.String"/>
@@ -25195,6 +28739,14 @@
       <ComplexType Name="storagePlanInformation">
         <Property Name="upgradeAvailable" Type="Edm.Boolean"/>
       </ComplexType>
+      <ComplexType Name="reactionsFacet">
+        <Property Name="commentCount" Type="Edm.Int32"/>
+        <Property Name="likeCount" Type="Edm.Int32"/>
+        <Property Name="shareCount" Type="Edm.Int32"/>
+      </ComplexType>
+      <ComplexType Name="recycleBinSettings">
+        <Property Name="retentionPeriodOverrideDays" Type="Edm.Int32"/>
+      </ComplexType>
       <ComplexType Name="renameAction">
         <Property Name="newName" Type="Edm.String"/>
         <Property Name="oldName" Type="Edm.String"/>
@@ -25207,6 +28759,12 @@
         <Property Name="isLabelUpdateAllowed" Type="Edm.Boolean"/>
         <Property Name="isMetadataUpdateAllowed" Type="Edm.Boolean"/>
         <Property Name="isRecordLocked" Type="Edm.Boolean"/>
+      </ComplexType>
+      <ComplexType Name="serverProcessedContent">
+        <Property Name="htmlStrings" Type="Collection(graph.metaDataKeyStringPair)"/>
+        <Property Name="imageSources" Type="Collection(graph.metaDataKeyStringPair)"/>
+        <Property Name="links" Type="Collection(graph.metaDataKeyStringPair)"/>
+        <Property Name="searchablePlainTexts" Type="Collection(graph.metaDataKeyStringPair)"/>
       </ComplexType>
       <ComplexType Name="shareAction">
         <Property Name="recipients" Type="Collection(graph.identitySet)"/>
@@ -25233,6 +28791,9 @@
         <Property Name="webHtml" Type="Edm.String"/>
         <Property Name="webUrl" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="siteArchivalDetails">
+        <Property Name="archiveStatus" Type="graph.siteArchiveStatus"/>
+      </ComplexType>
       <ComplexType Name="termColumn">
         <Property Name="allowMultipleValues" Type="Edm.Boolean"/>
         <Property Name="showFullyQualifiedName" Type="Edm.Boolean"/>
@@ -25254,9 +28815,47 @@
         <Property Name="width" Type="Edm.Int32"/>
       </ComplexType>
       <ComplexType Name="thumbnailColumn"/>
+      <ComplexType Name="titleArea" OpenType="true">
+        <Property Name="alternativeText" Type="Edm.String"/>
+        <Property Name="enableGradientEffect" Type="Edm.Boolean"/>
+        <Property Name="imageWebUrl" Type="Edm.String"/>
+        <Property Name="layout" Type="graph.titleAreaLayoutType"/>
+        <Property Name="serverProcessedContent" Type="graph.serverProcessedContent"/>
+        <Property Name="showAuthor" Type="Edm.Boolean"/>
+        <Property Name="showPublishedDate" Type="Edm.Boolean"/>
+        <Property Name="showTextBlockAboveTitle" Type="Edm.Boolean"/>
+        <Property Name="textAboveTitle" Type="Edm.String"/>
+        <Property Name="textAlignment" Type="graph.titleAreaTextAlignmentType"/>
+      </ComplexType>
       <ComplexType Name="versionAction">
         <Property Name="newVersion" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="webPartData">
+        <Property Name="dataVersion" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="properties" Type="graph.Json"/>
+        <Property Name="serverProcessedContent" Type="graph.serverProcessedContent"/>
+        <Property Name="title" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="webPartPosition">
+        <Property Name="columnId" Type="Edm.Double"/>
+        <Property Name="horizontalSectionId" Type="Edm.Double"/>
+        <Property Name="isInVerticalSection" Type="Edm.Boolean"/>
+        <Property Name="webPartIndex" Type="Edm.Double"/>
+      </ComplexType>
+      <EntityType Name="canvasLayout" BaseType="graph.entity">
+        <NavigationProperty Name="horizontalSections" Type="Collection(graph.horizontalSection)" ContainsTarget="true"/>
+        <NavigationProperty Name="verticalSection" Type="graph.verticalSection" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="horizontalSection" BaseType="graph.entity">
+        <Property Name="emphasis" Type="graph.sectionEmphasisType"/>
+        <Property Name="layout" Type="graph.horizontalSectionLayoutType"/>
+        <NavigationProperty Name="columns" Type="Collection(graph.horizontalSectionColumn)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="verticalSection" BaseType="graph.entity">
+        <Property Name="emphasis" Type="graph.sectionEmphasisType"/>
+        <NavigationProperty Name="webparts" Type="Collection(graph.webPart)" ContainsTarget="true"/>
+      </EntityType>
       <EntityType Name="columnLink" BaseType="graph.entity">
         <Property Name="name" Type="Edm.String"/>
       </EntityType>
@@ -25271,6 +28870,11 @@
         <Property Name="shouldCaptureMinorVersion" Type="Edm.Boolean"/>
       </EntityType>
       <EntityType Name="fieldValueSet" BaseType="graph.entity" OpenType="true"/>
+      <EntityType Name="horizontalSectionColumn" BaseType="graph.entity">
+        <Property Name="width" Type="Edm.Int32"/>
+        <NavigationProperty Name="webparts" Type="Collection(graph.webPart)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="webPart" BaseType="graph.entity" Abstract="true"/>
       <EntityType Name="itemActivity" BaseType="graph.entity" OpenType="true">
         <Property Name="access" Type="graph.accessAction"/>
         <Property Name="activityDateTime" Type="Edm.DateTimeOffset"/>
@@ -25289,6 +28893,11 @@
         <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
         <NavigationProperty Name="activities" Type="Collection(graph.itemActivity)"/>
       </EntityType>
+      <EntityType Name="recycleBinItem" BaseType="graph.baseItem" OpenType="true">
+        <Property Name="deletedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="deletedFromLocation" Type="Edm.String"/>
+        <Property Name="size" Type="Edm.Int64"/>
+      </EntityType>
       <EntityType Name="sharedDriveItem" BaseType="graph.baseItem">
         <Property Name="owner" Type="graph.identitySet"/>
         <NavigationProperty Name="driveItem" Type="graph.driveItem" ContainsTarget="true"/>
@@ -25299,6 +28908,28 @@
         <NavigationProperty Name="root" Type="graph.driveItem" ContainsTarget="true"/>
         <NavigationProperty Name="site" Type="graph.site" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="sitePage" BaseType="graph.baseSitePage" OpenType="true">
+        <Property Name="promotionKind" Type="graph.pagePromotionType"/>
+        <Property Name="reactions" Type="graph.reactionsFacet"/>
+        <Property Name="showComments" Type="Edm.Boolean"/>
+        <Property Name="showRecommendedPages" Type="Edm.Boolean"/>
+        <Property Name="thumbnailWebUrl" Type="Edm.String"/>
+        <Property Name="titleArea" Type="graph.titleArea"/>
+        <NavigationProperty Name="canvasLayout" Type="graph.canvasLayout" ContainsTarget="true"/>
+        <NavigationProperty Name="webParts" Type="Collection(graph.webPart)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="standardWebPart" BaseType="graph.webPart">
+        <Property Name="containerTextWebPartId" Type="Edm.String"/>
+        <Property Name="data" Type="graph.webPartData"/>
+        <Property Name="webPartType" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="textWebPart" BaseType="graph.webPart">
+        <Property Name="innerHtml" Type="Edm.String"/>
+      </EntityType>
+      <ComplexType Name="attendeeNotificationInfo">
+        <Property Name="phoneNumber" Type="Edm.String"/>
+        <Property Name="timeZone" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="broadcastMeetingSettings">
         <Property Name="allowedAudience" Type="graph.broadcastMeetingAudience"/>
         <Property Name="captions" Type="graph.broadcastMeetingCaptionSettings"/>
@@ -25312,15 +28943,21 @@
         <Property Name="organizer" Type="graph.meetingParticipantInfo"/>
       </ComplexType>
       <EntityType Name="callRecording" BaseType="graph.entity">
+        <Property Name="callId" Type="Edm.String"/>
         <Property Name="content" Type="Edm.Stream"/>
+        <Property Name="contentCorrelationId" Type="Edm.String"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="meetingId" Type="Edm.String"/>
         <Property Name="meetingOrganizer" Type="graph.identitySet"/>
         <Property Name="recordingContentUrl" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="callTranscript" BaseType="graph.entity">
+        <Property Name="callId" Type="Edm.String"/>
         <Property Name="content" Type="Edm.Stream"/>
+        <Property Name="contentCorrelationId" Type="Edm.String"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="endDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="meetingId" Type="Edm.String"/>
         <Property Name="meetingOrganizer" Type="graph.identitySet"/>
         <Property Name="metadataContent" Type="Edm.Stream"/>
@@ -25550,6 +29187,7 @@
       <EntityType Name="attributeMappingFunctionSchema" BaseType="graph.entity">
         <Property Name="parameters" Type="Collection(graph.attributeMappingParameterSchema)"/>
       </EntityType>
+      <EntityType Name="bulkUpload" BaseType="graph.entity" HasStream="true"/>
       <EntityType Name="directoryDefinition" BaseType="graph.entity">
         <Property Name="discoverabilities" Type="graph.directoryDefinitionDiscoverabilities" Nullable="false"/>
         <Property Name="discoveryDateTime" Type="Edm.DateTimeOffset"/>
@@ -25568,6 +29206,7 @@
         <Property Name="status" Type="graph.synchronizationStatus"/>
         <Property Name="synchronizationJobSettings" Type="Collection(graph.keyValuePair)"/>
         <Property Name="templateId" Type="Edm.String"/>
+        <NavigationProperty Name="bulkUpload" Type="graph.bulkUpload" ContainsTarget="true"/>
         <NavigationProperty Name="schema" Type="graph.synchronizationSchema" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="synchronizationTemplate" BaseType="graph.entity">
@@ -25584,6 +29223,16 @@
         <Property Name="version" Type="Edm.String"/>
         <NavigationProperty Name="directories" Type="Collection(graph.directoryDefinition)" ContainsTarget="true"/>
       </EntityType>
+      <ComplexType Name="communicationsIdentitySet" BaseType="graph.identitySet" OpenType="true">
+        <Property Name="applicationInstance" Type="graph.identity"/>
+        <Property Name="assertedIdentity" Type="graph.identity"/>
+        <Property Name="azureCommunicationServicesUser" Type="graph.identity"/>
+        <Property Name="encrypted" Type="graph.identity"/>
+        <Property Name="endpointType" Type="graph.endpointType"/>
+        <Property Name="guest" Type="graph.identity"/>
+        <Property Name="onPremises" Type="graph.identity"/>
+        <Property Name="phone" Type="graph.identity"/>
+      </ComplexType>
       <EntityType Name="cloudCommunications">
         <NavigationProperty Name="callRecords" Type="Collection(microsoft.graph.callRecords.callRecord)" ContainsTarget="true"/>
         <NavigationProperty Name="calls" Type="Collection(graph.call)" ContainsTarget="true"/>
@@ -25881,6 +29530,7 @@
         <NavigationProperty Name="internalSponsors" Type="Collection(graph.directoryObject)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="accessPackageResourceEnvironment" BaseType="graph.entity">
+        <Property Name="connectionInfo" Type="graph.connectionInfo"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
@@ -25903,6 +29553,7 @@
         <NavigationProperty Name="scope" Type="graph.accessPackageResourceScope" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="accessPackageResource" BaseType="graph.entity">
+        <Property Name="attributes" Type="Collection(graph.accessPackageResourceAttribute)"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
@@ -26063,6 +29714,9 @@
         <Property Name="mode" Type="graph.filterMode" Nullable="false"/>
         <Property Name="rule" Type="Edm.String" Nullable="false"/>
       </ComplexType>
+      <ComplexType Name="conditionalAccessAuthenticationFlows">
+        <Property Name="transferMethods" Type="graph.conditionalAccessTransferMethods" Nullable="false"/>
+      </ComplexType>
       <ComplexType Name="conditionalAccessClientApplications">
         <Property Name="excludeServicePrincipals" Type="Collection(Edm.String)" Nullable="false"/>
         <Property Name="includeServicePrincipals" Type="Collection(Edm.String)" Nullable="false"/>
@@ -26070,9 +29724,11 @@
       </ComplexType>
       <ComplexType Name="conditionalAccessConditionSet">
         <Property Name="applications" Type="graph.conditionalAccessApplications"/>
+        <Property Name="authenticationFlows" Type="graph.conditionalAccessAuthenticationFlows"/>
         <Property Name="clientApplications" Type="graph.conditionalAccessClientApplications"/>
         <Property Name="clientAppTypes" Type="Collection(graph.conditionalAccessClientApp)" Nullable="false"/>
         <Property Name="devices" Type="graph.conditionalAccessDevices"/>
+        <Property Name="insiderRiskLevels" Type="graph.conditionalAccessInsiderRiskLevels"/>
         <Property Name="locations" Type="graph.conditionalAccessLocations"/>
         <Property Name="platforms" Type="graph.conditionalAccessPlatforms"/>
         <Property Name="servicePrincipalRiskLevels" Type="Collection(graph.riskLevel)" Nullable="false"/>
@@ -26325,6 +29981,19 @@
         <Property Name="removeAccessWhenTargetLeavesAllowedTargets" Type="Edm.Boolean"/>
         <Property Name="requestAccessForAllowedTargets" Type="Edm.Boolean"/>
       </ComplexType>
+      <ComplexType Name="accessPackageResourceAttribute">
+        <Property Name="destination" Type="graph.accessPackageResourceAttributeDestination"/>
+        <Property Name="isEditable" Type="Edm.Boolean"/>
+        <Property Name="isPersistedOnAssignmentRemoval" Type="Edm.Boolean"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="source" Type="graph.accessPackageResourceAttributeSource"/>
+      </ComplexType>
+      <ComplexType Name="accessPackageResourceAttributeDestination" Abstract="true"/>
+      <ComplexType Name="accessPackageResourceAttributeSource" Abstract="true"/>
+      <ComplexType Name="accessPackageResourceAttributeQuestion" BaseType="graph.accessPackageResourceAttributeSource">
+        <NavigationProperty Name="question" Type="graph.accessPackageQuestion"/>
+      </ComplexType>
+      <ComplexType Name="accessPackageUserDirectoryAttributeStore" BaseType="graph.accessPackageResourceAttributeDestination"/>
       <ComplexType Name="attributeRuleMembers" BaseType="graph.subjectSet">
         <Property Name="description" Type="Edm.String"/>
         <Property Name="membershipRule" Type="Edm.String"/>
@@ -26369,6 +30038,7 @@
       <ComplexType Name="targetManager" BaseType="graph.subjectSet">
         <Property Name="managerLevel" Type="Edm.Int32"/>
       </ComplexType>
+      <ComplexType Name="targetUserSponsors" BaseType="graph.subjectSet"/>
       <EntityType Name="accessPackageSubject" BaseType="graph.entity">
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="email" Type="Edm.String"/>
@@ -26437,6 +30107,10 @@
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="domainName" Type="Edm.String"/>
         <Property Name="issuerUri" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="socialIdentitySource" BaseType="graph.identitySource">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="socialIdentitySourceType" Type="graph.socialIdentitySourceType" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="deviceAndAppManagementAssignmentTarget" Abstract="true"/>
       <ComplexType Name="allDevicesAssignmentTarget" BaseType="graph.deviceAndAppManagementAssignmentTarget"/>
@@ -26552,10 +30226,14 @@
         <Property Name="supportsUserLicensing" Type="Edm.Boolean" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="win32LobAppAssignmentSettings" BaseType="graph.mobileAppAssignmentSettings">
+        <Property Name="autoUpdateSettings" Type="graph.win32LobAppAutoUpdateSettings"/>
         <Property Name="deliveryOptimizationPriority" Type="graph.win32LobAppDeliveryOptimizationPriority" Nullable="false"/>
         <Property Name="installTimeSettings" Type="graph.mobileAppInstallTimeSettings"/>
         <Property Name="notifications" Type="graph.win32LobAppNotification" Nullable="false"/>
         <Property Name="restartSettings" Type="graph.win32LobAppRestartSettings"/>
+      </ComplexType>
+      <ComplexType Name="win32LobAppAutoUpdateSettings">
+        <Property Name="autoUpdateSupersededAppsState" Type="graph.win32LobAutoUpdateSupersededAppsState" Nullable="false"/>
       </ComplexType>
       <ComplexType Name="win32LobAppRestartSettings">
         <Property Name="countdownDisplayBeforeRestartInMinutes" Type="Edm.Int32" Nullable="false"/>
@@ -26854,6 +30532,18 @@
         <Property Name="revokeOnMdmHandoffDisabled" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="windowsHelloForBusinessBlocked" Type="Edm.Boolean" Nullable="false"/>
       </EntityType>
+      <EntityType Name="deviceManagementExportJob" BaseType="graph.entity">
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="filter" Type="Edm.String"/>
+        <Property Name="format" Type="graph.deviceManagementReportFileFormat" Nullable="false"/>
+        <Property Name="localizationType" Type="graph.deviceManagementExportJobLocalizationType" Nullable="false"/>
+        <Property Name="reportName" Type="Edm.String" Nullable="false"/>
+        <Property Name="requestDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="select" Type="Collection(Edm.String)"/>
+        <Property Name="snapshotId" Type="Edm.String"/>
+        <Property Name="status" Type="graph.deviceManagementReportStatus" Nullable="false"/>
+        <Property Name="url" Type="Edm.String"/>
+      </EntityType>
       <EntityType Name="enterpriseCodeSigningCertificate" BaseType="graph.entity">
         <Property Name="content" Type="Edm.Binary"/>
         <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
@@ -27018,6 +30708,7 @@
         <Property Name="azureStorageUriExpirationDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="isCommitted" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isDependency" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="manifest" Type="Edm.Binary"/>
         <Property Name="name" Type="Edm.String"/>
         <Property Name="size" Type="Edm.Int64" Nullable="false"/>
@@ -27100,632 +30791,6 @@
         <Property Name="modifiedProperties" Type="Collection(graph.auditProperty)"/>
         <Property Name="resourceId" Type="Edm.String"/>
       </ComplexType>
-      <EntityType Name="auditEvent" BaseType="graph.entity">
-        <Property Name="activity" Type="Edm.String"/>
-        <Property Name="activityDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="activityOperationType" Type="Edm.String"/>
-        <Property Name="activityResult" Type="Edm.String"/>
-        <Property Name="activityType" Type="Edm.String"/>
-        <Property Name="actor" Type="graph.auditActor"/>
-        <Property Name="category" Type="Edm.String"/>
-        <Property Name="componentName" Type="Edm.String"/>
-        <Property Name="correlationId" Type="Edm.Guid" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="resources" Type="Collection(graph.auditResource)"/>
-      </EntityType>
-      <EntityType Name="deviceManagement" BaseType="graph.entity">
-        <Property Name="intuneAccountId" Type="Edm.Guid" Nullable="false"/>
-        <Property Name="settings" Type="graph.deviceManagementSettings"/>
-        <Property Name="intuneBrand" Type="graph.intuneBrand"/>
-        <Property Name="deviceProtectionOverview" Type="graph.deviceProtectionOverview"/>
-        <Property Name="subscriptionState" Type="graph.deviceManagementSubscriptionState" Nullable="false"/>
-        <Property Name="userExperienceAnalyticsSettings" Type="graph.userExperienceAnalyticsSettings"/>
-        <Property Name="windowsMalwareOverview" Type="graph.windowsMalwareOverview"/>
-        <NavigationProperty Name="termsAndConditions" Type="Collection(graph.termsAndConditions)" ContainsTarget="true"/>
-        <NavigationProperty Name="auditEvents" Type="Collection(graph.auditEvent)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceCompliancePolicies" Type="Collection(graph.deviceCompliancePolicy)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceCompliancePolicyDeviceStateSummary" Type="graph.deviceCompliancePolicyDeviceStateSummary" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceCompliancePolicySettingStateSummaries" Type="Collection(graph.deviceCompliancePolicySettingStateSummary)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceConfigurationDeviceStateSummaries" Type="graph.deviceConfigurationDeviceStateSummary" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceConfigurations" Type="Collection(graph.deviceConfiguration)" ContainsTarget="true"/>
-        <NavigationProperty Name="iosUpdateStatuses" Type="Collection(graph.iosUpdateDeviceStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="softwareUpdateStatusSummary" Type="graph.softwareUpdateStatusSummary"/>
-        <NavigationProperty Name="complianceManagementPartners" Type="Collection(graph.complianceManagementPartner)" ContainsTarget="true"/>
-        <NavigationProperty Name="conditionalAccessSettings" Type="graph.onPremisesConditionalAccessSettings" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceCategories" Type="Collection(graph.deviceCategory)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceEnrollmentConfigurations" Type="Collection(graph.deviceEnrollmentConfiguration)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceManagementPartners" Type="Collection(graph.deviceManagementPartner)" ContainsTarget="true"/>
-        <NavigationProperty Name="exchangeConnectors" Type="Collection(graph.deviceManagementExchangeConnector)" ContainsTarget="true"/>
-        <NavigationProperty Name="mobileThreatDefenseConnectors" Type="Collection(graph.mobileThreatDefenseConnector)" ContainsTarget="true"/>
-        <NavigationProperty Name="applePushNotificationCertificate" Type="graph.applePushNotificationCertificate" ContainsTarget="true"/>
-        <NavigationProperty Name="detectedApps" Type="Collection(graph.detectedApp)" ContainsTarget="true"/>
-        <NavigationProperty Name="managedDeviceOverview" Type="graph.managedDeviceOverview"/>
-        <NavigationProperty Name="managedDevices" Type="Collection(graph.managedDevice)" ContainsTarget="true"/>
-        <NavigationProperty Name="mobileAppTroubleshootingEvents" Type="Collection(graph.mobileAppTroubleshootingEvent)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthApplicationPerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion" Type="Collection(graph.userExperienceAnalyticsAppHealthAppPerformanceByOSVersion)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthDeviceModelPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthDeviceModelPerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthDevicePerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthDevicePerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthDevicePerformanceDetails" Type="Collection(graph.userExperienceAnalyticsAppHealthDevicePerformanceDetails)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthOSVersionPerformance" Type="Collection(graph.userExperienceAnalyticsAppHealthOSVersionPerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsAppHealthOverview" Type="graph.userExperienceAnalyticsCategory" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsBaselines" Type="Collection(graph.userExperienceAnalyticsBaseline)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsCategories" Type="Collection(graph.userExperienceAnalyticsCategory)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsDevicePerformance" Type="Collection(graph.userExperienceAnalyticsDevicePerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsDeviceScores" Type="Collection(graph.userExperienceAnalyticsDeviceScores)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupHistory" Type="Collection(graph.userExperienceAnalyticsDeviceStartupHistory)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupProcesses" Type="Collection(graph.userExperienceAnalyticsDeviceStartupProcess)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsDeviceStartupProcessPerformance" Type="Collection(graph.userExperienceAnalyticsDeviceStartupProcessPerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsMetricHistory" Type="Collection(graph.userExperienceAnalyticsMetricHistory)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsModelScores" Type="Collection(graph.userExperienceAnalyticsModelScores)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsOverview" Type="graph.userExperienceAnalyticsOverview" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsScoreHistory" Type="Collection(graph.userExperienceAnalyticsScoreHistory)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" Type="graph.userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereMetrics" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereMetric)" ContainsTarget="true"/>
-        <NavigationProperty Name="userExperienceAnalyticsWorkFromAnywhereModelPerformance" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereModelPerformance)" ContainsTarget="true"/>
-        <NavigationProperty Name="windowsMalwareInformation" Type="Collection(graph.windowsMalwareInformation)" ContainsTarget="true"/>
-        <NavigationProperty Name="importedWindowsAutopilotDeviceIdentities" Type="Collection(graph.importedWindowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
-        <NavigationProperty Name="windowsAutopilotDeviceIdentities" Type="Collection(graph.windowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
-        <NavigationProperty Name="notificationMessageTemplates" Type="Collection(graph.notificationMessageTemplate)" ContainsTarget="true"/>
-        <NavigationProperty Name="resourceOperations" Type="Collection(graph.resourceOperation)" ContainsTarget="true"/>
-        <NavigationProperty Name="roleAssignments" Type="Collection(graph.deviceAndAppManagementRoleAssignment)" ContainsTarget="true"/>
-        <NavigationProperty Name="roleDefinitions" Type="Collection(graph.roleDefinition)" ContainsTarget="true"/>
-        <NavigationProperty Name="remoteAssistancePartners" Type="Collection(graph.remoteAssistancePartner)" ContainsTarget="true"/>
-        <NavigationProperty Name="reports" Type="graph.deviceManagementReports" ContainsTarget="true"/>
-        <NavigationProperty Name="telecomExpenseManagementPartners" Type="Collection(graph.telecomExpenseManagementPartner)" ContainsTarget="true"/>
-        <NavigationProperty Name="troubleshootingEvents" Type="Collection(graph.deviceManagementTroubleshootingEvent)" ContainsTarget="true"/>
-        <NavigationProperty Name="windowsInformationProtectionAppLearningSummaries" Type="Collection(graph.windowsInformationProtectionAppLearningSummary)" ContainsTarget="true"/>
-        <NavigationProperty Name="windowsInformationProtectionNetworkLearningSummaries" Type="Collection(graph.windowsInformationProtectionNetworkLearningSummary)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="termsAndConditions" BaseType="graph.entity">
-        <Property Name="acceptanceStatement" Type="Edm.String"/>
-        <Property Name="bodyText" Type="Edm.String"/>
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="title" Type="Edm.String"/>
-        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
-        <NavigationProperty Name="acceptanceStatuses" Type="Collection(graph.termsAndConditionsAcceptanceStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="assignments" Type="Collection(graph.termsAndConditionsAssignment)" ContainsTarget="true"/>
-      </EntityType>
-      <ComplexType Name="deviceManagementSettings">
-        <Property Name="deviceComplianceCheckinThresholdDays" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="isScheduledActionEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="secureByDefault" Type="Edm.Boolean" Nullable="false"/>
-      </ComplexType>
-      <EntityType Name="deviceCompliancePolicy" BaseType="graph.entity" Abstract="true">
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
-        <NavigationProperty Name="assignments" Type="Collection(graph.deviceCompliancePolicyAssignment)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceSettingStateSummaries" Type="Collection(graph.settingStateDeviceSummary)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceStatuses" Type="Collection(graph.deviceComplianceDeviceStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceStatusOverview" Type="graph.deviceComplianceDeviceOverview" ContainsTarget="true"/>
-        <NavigationProperty Name="scheduledActionsForRule" Type="Collection(graph.deviceComplianceScheduledActionForRule)" ContainsTarget="true"/>
-        <NavigationProperty Name="userStatuses" Type="Collection(graph.deviceComplianceUserStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="userStatusOverview" Type="graph.deviceComplianceUserOverview" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="deviceCompliancePolicyDeviceStateSummary" BaseType="graph.entity">
-        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="configManagerCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="inGracePeriodCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="deviceCompliancePolicySettingStateSummary" BaseType="graph.entity">
-        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="platformType" Type="graph.policyPlatformType" Nullable="false"/>
-        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="setting" Type="Edm.String"/>
-        <Property Name="settingName" Type="Edm.String"/>
-        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <NavigationProperty Name="deviceComplianceSettingStates" Type="Collection(graph.deviceComplianceSettingState)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="deviceConfigurationDeviceStateSummary" BaseType="graph.entity">
-        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="deviceConfiguration" BaseType="graph.entity" Abstract="true">
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
-        <NavigationProperty Name="assignments" Type="Collection(graph.deviceConfigurationAssignment)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceSettingStateSummaries" Type="Collection(graph.settingStateDeviceSummary)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceStatuses" Type="Collection(graph.deviceConfigurationDeviceStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="deviceStatusOverview" Type="graph.deviceConfigurationDeviceOverview" ContainsTarget="true"/>
-        <NavigationProperty Name="userStatuses" Type="Collection(graph.deviceConfigurationUserStatus)" ContainsTarget="true"/>
-        <NavigationProperty Name="userStatusOverview" Type="graph.deviceConfigurationUserOverview" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="iosUpdateDeviceStatus" BaseType="graph.entity">
-        <Property Name="complianceGracePeriodExpirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="deviceDisplayName" Type="Edm.String"/>
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="deviceModel" Type="Edm.String"/>
-        <Property Name="installStatus" Type="graph.iosUpdatesInstallStatus" Nullable="false"/>
-        <Property Name="lastReportedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="osVersion" Type="Edm.String"/>
-        <Property Name="status" Type="graph.complianceStatus" Nullable="false"/>
-        <Property Name="userId" Type="Edm.String"/>
-        <Property Name="userName" Type="Edm.String"/>
-        <Property Name="userPrincipalName" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="softwareUpdateStatusSummary" BaseType="graph.entity">
-        <Property Name="compliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="compliantUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="conflictDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="conflictUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="errorDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="errorUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="nonCompliantDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="nonCompliantUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="notApplicableDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="notApplicableUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="remediatedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="remediatedUserCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="unknownDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="unknownUserCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <ComplexType Name="intuneBrand">
-        <Property Name="contactITEmailAddress" Type="Edm.String"/>
-        <Property Name="contactITName" Type="Edm.String"/>
-        <Property Name="contactITNotes" Type="Edm.String"/>
-        <Property Name="contactITPhoneNumber" Type="Edm.String"/>
-        <Property Name="darkBackgroundLogo" Type="graph.mimeContent"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="lightBackgroundLogo" Type="graph.mimeContent"/>
-        <Property Name="onlineSupportSiteName" Type="Edm.String"/>
-        <Property Name="onlineSupportSiteUrl" Type="Edm.String"/>
-        <Property Name="privacyUrl" Type="Edm.String"/>
-        <Property Name="showDisplayNameNextToLogo" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="showLogo" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="showNameNextToLogo" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="themeColor" Type="graph.rgbColor"/>
-      </ComplexType>
-      <EntityType Name="complianceManagementPartner" BaseType="graph.entity">
-        <Property Name="androidEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
-        <Property Name="androidOnboarded" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="iosEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
-        <Property Name="iosOnboarded" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="macOsEnrollmentAssignments" Type="Collection(graph.complianceManagementPartnerAssignment)"/>
-        <Property Name="macOsOnboarded" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="partnerState" Type="graph.deviceManagementPartnerTenantState" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="onPremisesConditionalAccessSettings" BaseType="graph.entity">
-        <Property Name="enabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="excludedGroups" Type="Collection(Edm.Guid)" Nullable="false"/>
-        <Property Name="includedGroups" Type="Collection(Edm.Guid)" Nullable="false"/>
-        <Property Name="overrideDefaultRule" Type="Edm.Boolean" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="deviceCategory" BaseType="graph.entity">
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="deviceEnrollmentConfiguration" BaseType="graph.entity" Abstract="true">
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="priority" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="version" Type="Edm.Int32" Nullable="false"/>
-        <NavigationProperty Name="assignments" Type="Collection(graph.enrollmentConfigurationAssignment)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="deviceManagementPartner" BaseType="graph.entity">
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="groupsRequiringPartnerEnrollment" Type="Collection(graph.deviceManagementPartnerAssignment)"/>
-        <Property Name="isConfigured" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="partnerAppType" Type="graph.deviceManagementPartnerAppType" Nullable="false"/>
-        <Property Name="partnerState" Type="graph.deviceManagementPartnerTenantState" Nullable="false"/>
-        <Property Name="singleTenantAppId" Type="Edm.String"/>
-        <Property Name="whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="whenPartnerDevicesWillBeRemovedDateTime" Type="Edm.DateTimeOffset"/>
-      </EntityType>
-      <EntityType Name="deviceManagementExchangeConnector" BaseType="graph.entity">
-        <Property Name="connectorServerName" Type="Edm.String"/>
-        <Property Name="exchangeAlias" Type="Edm.String"/>
-        <Property Name="exchangeConnectorType" Type="graph.deviceManagementExchangeConnectorType" Nullable="false"/>
-        <Property Name="exchangeOrganization" Type="Edm.String"/>
-        <Property Name="lastSyncDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="primarySmtpAddress" Type="Edm.String"/>
-        <Property Name="serverName" Type="Edm.String"/>
-        <Property Name="status" Type="graph.deviceManagementExchangeConnectorStatus" Nullable="false"/>
-        <Property Name="version" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="mobileThreatDefenseConnector" BaseType="graph.entity">
-        <Property Name="allowPartnerToCollectIOSApplicationMetadata" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="allowPartnerToCollectIOSPersonalApplicationMetadata" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="androidDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="androidEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="androidMobileApplicationManagementEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="iosDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="iosEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="iosMobileApplicationManagementEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastHeartbeatDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="microsoftDefenderForEndpointAttachEnabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="partnerState" Type="graph.mobileThreatPartnerTenantState" Nullable="false"/>
-        <Property Name="partnerUnresponsivenessThresholdInDays" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="partnerUnsupportedOsVersionBlocked" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="windowsDeviceBlockedOnMissingPartnerData" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="windowsEnabled" Type="Edm.Boolean" Nullable="false"/>
-      </EntityType>
-      <ComplexType Name="deviceProtectionOverview">
-        <Property Name="cleanDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="criticalFailuresDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="inactiveThreatAgentDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingFullScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingManualStepsDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingOfflineScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingQuickScanDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingRestartDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="pendingSignatureUpdateDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="totalReportedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="unknownStateThreatAgentDeviceCount" Type="Edm.Int32" Nullable="false"/>
-      </ComplexType>
-      <ComplexType Name="userExperienceAnalyticsSettings">
-        <Property Name="configurationManagerDataConnectorConfigured" Type="Edm.Boolean" Nullable="false"/>
-      </ComplexType>
-      <ComplexType Name="windowsMalwareOverview">
-        <Property Name="malwareCategorySummary" Type="Collection(graph.windowsMalwareCategoryCount)"/>
-        <Property Name="malwareDetectedDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="malwareExecutionStateSummary" Type="Collection(graph.windowsMalwareExecutionStateCount)"/>
-        <Property Name="malwareNameSummary" Type="Collection(graph.windowsMalwareNameCount)"/>
-        <Property Name="malwareSeveritySummary" Type="Collection(graph.windowsMalwareSeverityCount)"/>
-        <Property Name="malwareStateSummary" Type="Collection(graph.windowsMalwareStateCount)"/>
-        <Property Name="osVersionsSummary" Type="Collection(graph.osVersionCount)"/>
-        <Property Name="totalDistinctMalwareCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="totalMalwareCount" Type="Edm.Int32" Nullable="false"/>
-      </ComplexType>
-      <EntityType Name="applePushNotificationCertificate" BaseType="graph.entity">
-        <Property Name="appleIdentifier" Type="Edm.String"/>
-        <Property Name="certificate" Type="Edm.String"/>
-        <Property Name="certificateSerialNumber" Type="Edm.String"/>
-        <Property Name="certificateUploadFailureReason" Type="Edm.String"/>
-        <Property Name="certificateUploadStatus" Type="Edm.String"/>
-        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="topicIdentifier" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="detectedApp" BaseType="graph.entity">
-        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="platform" Type="graph.detectedAppPlatformType" Nullable="false"/>
-        <Property Name="publisher" Type="Edm.String"/>
-        <Property Name="sizeInByte" Type="Edm.Int64" Nullable="false"/>
-        <Property Name="version" Type="Edm.String"/>
-        <NavigationProperty Name="managedDevices" Type="Collection(graph.managedDevice)"/>
-      </EntityType>
-      <EntityType Name="managedDeviceOverview" BaseType="graph.entity">
-        <Property Name="deviceExchangeAccessStateSummary" Type="graph.deviceExchangeAccessStateSummary"/>
-        <Property Name="deviceOperatingSystemSummary" Type="graph.deviceOperatingSystemSummary"/>
-        <Property Name="dualEnrolledDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="enrolledDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="mdmEnrolledCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="mobileAppTroubleshootingEvent" BaseType="graph.entity">
-        <NavigationProperty Name="appLogCollectionRequests" Type="Collection(graph.appLogCollectionRequest)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthApplicationPerformance" BaseType="graph.entity">
-        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appDisplayName" Type="Edm.String"/>
-        <Property Name="appHangCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appHealthScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="appName" Type="Edm.String"/>
-        <Property Name="appPublisher" Type="Edm.String"/>
-        <Property Name="appUsageDuration" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails" BaseType="graph.entity">
-        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appDisplayName" Type="Edm.String"/>
-        <Property Name="appName" Type="Edm.String"/>
-        <Property Name="appPublisher" Type="Edm.String"/>
-        <Property Name="appVersion" Type="Edm.String"/>
-        <Property Name="deviceCountWithCrashes" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="isLatestUsedVersion" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="isMostUsedVersion" Type="Edm.Boolean" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId" BaseType="graph.entity">
-        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appDisplayName" Type="Edm.String"/>
-        <Property Name="appName" Type="Edm.String"/>
-        <Property Name="appPublisher" Type="Edm.String"/>
-        <Property Name="appVersion" Type="Edm.String"/>
-        <Property Name="deviceDisplayName" Type="Edm.String"/>
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="processedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthAppPerformanceByOSVersion" BaseType="graph.entity">
-        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appDisplayName" Type="Edm.String"/>
-        <Property Name="appName" Type="Edm.String"/>
-        <Property Name="appPublisher" Type="Edm.String"/>
-        <Property Name="appUsageDuration" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="osBuildNumber" Type="Edm.String"/>
-        <Property Name="osVersion" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthDeviceModelPerformance" BaseType="graph.entity">
-        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="deviceManufacturer" Type="Edm.String"/>
-        <Property Name="deviceModel" Type="Edm.String"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="modelAppHealthScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthDevicePerformance" BaseType="graph.entity">
-        <Property Name="appCrashCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="appHangCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="crashedAppCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="deviceAppHealthScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="deviceDisplayName" Type="Edm.String"/>
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="deviceManufacturer" Type="Edm.String"/>
-        <Property Name="deviceModel" Type="Edm.String"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="processedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthDevicePerformanceDetails" BaseType="graph.entity">
-        <Property Name="appDisplayName" Type="Edm.String"/>
-        <Property Name="appPublisher" Type="Edm.String"/>
-        <Property Name="appVersion" Type="Edm.String"/>
-        <Property Name="deviceDisplayName" Type="Edm.String"/>
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="eventDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="eventType" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsAppHealthOSVersionPerformance" BaseType="graph.entity">
-        <Property Name="activeDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="meanTimeToFailureInMinutes" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="osBuildNumber" Type="Edm.String"/>
-        <Property Name="osVersion" Type="Edm.String"/>
-        <Property Name="osVersionAppHealthScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsCategory" BaseType="graph.entity">
-        <Property Name="insights" Type="Collection(graph.userExperienceAnalyticsInsight)"/>
-        <NavigationProperty Name="metricValues" Type="Collection(graph.userExperienceAnalyticsMetric)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsBaseline" BaseType="graph.entity">
-        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="isBuiltIn" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="appHealthMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="batteryHealthMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="bestPracticesMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="deviceBootPerformanceMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="rebootAnalyticsMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="resourcePerformanceMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-        <NavigationProperty Name="workFromAnywhereMetrics" Type="graph.userExperienceAnalyticsCategory"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsDevicePerformance" BaseType="graph.entity">
-        <Property Name="averageBlueScreens" Type="Edm.Double" Nullable="false"/>
-        <Property Name="averageRestarts" Type="Edm.Double" Nullable="false"/>
-        <Property Name="blueScreenCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="bootScore" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="coreBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="coreLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="deviceCount" Type="Edm.Int64" Nullable="false"/>
-        <Property Name="deviceName" Type="Edm.String"/>
-        <Property Name="diskType" Type="graph.diskType" Nullable="false"/>
-        <Property Name="groupPolicyBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="groupPolicyLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="loginScore" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="manufacturer" Type="Edm.String"/>
-        <Property Name="model" Type="Edm.String"/>
-        <Property Name="modelStartupPerformanceScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="operatingSystemVersion" Type="Edm.String"/>
-        <Property Name="responsiveDesktopTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="restartCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsDeviceScores" BaseType="graph.entity">
-        <Property Name="appReliabilityScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="batteryHealthScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="deviceName" Type="Edm.String"/>
-        <Property Name="endpointAnalyticsScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="manufacturer" Type="Edm.String"/>
-        <Property Name="model" Type="Edm.String"/>
-        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsDeviceStartupHistory" BaseType="graph.entity">
-        <Property Name="coreBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="coreLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="featureUpdateBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="groupPolicyBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="groupPolicyLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="isFeatureUpdate" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="isFirstLogin" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="operatingSystemVersion" Type="Edm.String"/>
-        <Property Name="responsiveDesktopTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="restartCategory" Type="graph.userExperienceAnalyticsOperatingSystemRestartCategory" Nullable="false"/>
-        <Property Name="restartFaultBucket" Type="Edm.String"/>
-        <Property Name="restartStopCode" Type="Edm.String"/>
-        <Property Name="startTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="totalBootTimeInMs" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="totalLoginTimeInMs" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsDeviceStartupProcess" BaseType="graph.entity">
-        <Property Name="managedDeviceId" Type="Edm.String"/>
-        <Property Name="processName" Type="Edm.String"/>
-        <Property Name="productName" Type="Edm.String"/>
-        <Property Name="publisher" Type="Edm.String"/>
-        <Property Name="startupImpactInMs" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsDeviceStartupProcessPerformance" BaseType="graph.entity">
-        <Property Name="deviceCount" Type="Edm.Int64" Nullable="false"/>
-        <Property Name="medianImpactInMs" Type="Edm.Int64" Nullable="false"/>
-        <Property Name="processName" Type="Edm.String"/>
-        <Property Name="productName" Type="Edm.String"/>
-        <Property Name="publisher" Type="Edm.String"/>
-        <Property Name="totalImpactInMs" Type="Edm.Int64" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsMetricHistory" BaseType="graph.entity">
-        <Property Name="deviceId" Type="Edm.String"/>
-        <Property Name="metricDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="metricType" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsModelScores" BaseType="graph.entity">
-        <Property Name="appReliabilityScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="batteryHealthScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="endpointAnalyticsScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="manufacturer" Type="Edm.String"/>
-        <Property Name="model" Type="Edm.String"/>
-        <Property Name="modelDeviceCount" Type="Edm.Int64" Nullable="false"/>
-        <Property Name="startupPerformanceScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsOverview" BaseType="graph.entity">
-        <Property Name="insights" Type="Collection(graph.userExperienceAnalyticsInsight)"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsScoreHistory" BaseType="graph.entity">
-        <Property Name="startupDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric" BaseType="graph.entity">
-        <Property Name="osCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="processor64BitCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="processorCoreCountCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="processorFamilyCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="processorSpeedCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="ramCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="secureBootCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="storageCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="totalDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="tpmCheckFailedPercentage" Type="Edm.Double" Nullable="false"/>
-        <Property Name="upgradeEligibleDeviceCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereMetric" BaseType="graph.entity">
-        <NavigationProperty Name="metricDevices" Type="Collection(graph.userExperienceAnalyticsWorkFromAnywhereDevice)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="userExperienceAnalyticsWorkFromAnywhereModelPerformance" BaseType="graph.entity">
-        <Property Name="cloudIdentityScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="cloudManagementScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="cloudProvisioningScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="healthStatus" Type="graph.userExperienceAnalyticsHealthState" Nullable="false"/>
-        <Property Name="manufacturer" Type="Edm.String"/>
-        <Property Name="model" Type="Edm.String"/>
-        <Property Name="modelDeviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="windowsScore" Type="Edm.Double" Nullable="false"/>
-        <Property Name="workFromAnywhereScore" Type="Edm.Double" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="windowsMalwareInformation" BaseType="graph.entity">
-        <Property Name="additionalInformationUrl" Type="Edm.String"/>
-        <Property Name="category" Type="graph.windowsMalwareCategory"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="lastDetectionDateTime" Type="Edm.DateTimeOffset"/>
-        <Property Name="severity" Type="graph.windowsMalwareSeverity"/>
-        <NavigationProperty Name="deviceMalwareStates" Type="Collection(graph.malwareStateForWindowsDevice)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="importedWindowsAutopilotDeviceIdentity" BaseType="graph.entity">
-        <Property Name="assignedUserPrincipalName" Type="Edm.String"/>
-        <Property Name="groupTag" Type="Edm.String"/>
-        <Property Name="hardwareIdentifier" Type="Edm.Binary"/>
-        <Property Name="importId" Type="Edm.String"/>
-        <Property Name="productKey" Type="Edm.String"/>
-        <Property Name="serialNumber" Type="Edm.String"/>
-        <Property Name="state" Type="graph.importedWindowsAutopilotDeviceIdentityState"/>
-      </EntityType>
-      <EntityType Name="windowsAutopilotDeviceIdentity" BaseType="graph.entity">
-        <Property Name="addressableUserName" Type="Edm.String"/>
-        <Property Name="azureActiveDirectoryDeviceId" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="enrollmentState" Type="graph.enrollmentState" Nullable="false"/>
-        <Property Name="groupTag" Type="Edm.String"/>
-        <Property Name="lastContactedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="managedDeviceId" Type="Edm.String"/>
-        <Property Name="manufacturer" Type="Edm.String"/>
-        <Property Name="model" Type="Edm.String"/>
-        <Property Name="productKey" Type="Edm.String"/>
-        <Property Name="purchaseOrderIdentifier" Type="Edm.String"/>
-        <Property Name="resourceName" Type="Edm.String"/>
-        <Property Name="serialNumber" Type="Edm.String"/>
-        <Property Name="skuNumber" Type="Edm.String"/>
-        <Property Name="systemFamily" Type="Edm.String"/>
-        <Property Name="userPrincipalName" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="notificationMessageTemplate" BaseType="graph.entity">
-        <Property Name="brandingOptions" Type="graph.notificationTemplateBrandingOptions" Nullable="false"/>
-        <Property Name="defaultLocale" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
-        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="roleScopeTagIds" Type="Collection(Edm.String)"/>
-        <NavigationProperty Name="localizedNotificationMessages" Type="Collection(graph.localizedNotificationMessage)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="resourceOperation" BaseType="graph.entity">
-        <Property Name="actionName" Type="Edm.String"/>
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="resourceName" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="roleAssignment" BaseType="graph.entity">
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="resourceScopes" Type="Collection(Edm.String)"/>
-        <NavigationProperty Name="roleDefinition" Type="graph.roleDefinition"/>
-      </EntityType>
-      <EntityType Name="deviceAndAppManagementRoleAssignment" BaseType="graph.roleAssignment">
-        <Property Name="members" Type="Collection(Edm.String)"/>
-      </EntityType>
-      <EntityType Name="roleDefinition" BaseType="graph.entity">
-        <Property Name="description" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="isBuiltIn" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="rolePermissions" Type="Collection(graph.rolePermission)"/>
-        <NavigationProperty Name="roleAssignments" Type="Collection(graph.roleAssignment)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="remoteAssistancePartner" BaseType="graph.entity">
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="lastConnectionDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="onboardingStatus" Type="graph.remoteAssistanceOnboardingStatus" Nullable="false"/>
-        <Property Name="onboardingUrl" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="deviceManagementReports" BaseType="graph.entity">
-        <NavigationProperty Name="exportJobs" Type="Collection(graph.deviceManagementExportJob)" ContainsTarget="true"/>
-      </EntityType>
-      <EntityType Name="telecomExpenseManagementPartner" BaseType="graph.entity">
-        <Property Name="appAuthorized" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="enabled" Type="Edm.Boolean" Nullable="false"/>
-        <Property Name="lastConnectionDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="url" Type="Edm.String"/>
-      </EntityType>
-      <EntityType Name="windowsInformationProtectionAppLearningSummary" BaseType="graph.entity">
-        <Property Name="applicationName" Type="Edm.String"/>
-        <Property Name="applicationType" Type="graph.applicationType" Nullable="false"/>
-        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
-      </EntityType>
-      <EntityType Name="windowsInformationProtectionNetworkLearningSummary" BaseType="graph.entity">
-        <Property Name="deviceCount" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="url" Type="Edm.String"/>
-      </EntityType>
       <EntityType Name="deviceInstallState" BaseType="graph.entity">
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="deviceName" Type="Edm.String"/>
@@ -29037,6 +32102,9 @@
         <Property Name="state" Type="graph.enablement" Nullable="false"/>
         <Property Name="unlockWithBiometricsEnabled" Type="Edm.Boolean" Nullable="false"/>
       </EntityType>
+      <EntityType Name="windows10EnrollmentCompletionPageConfiguration" BaseType="graph.deviceEnrollmentConfiguration">
+        <Property Name="allowNonBlockingAppInstallation" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
       <ComplexType Name="appLogCollectionDownloadDetails">
         <Property Name="appLogDecryptionAlgorithm" Type="graph.appLogDecryptionAlgorithm" Nullable="false"/>
         <Property Name="decryptionKey" Type="Edm.String"/>
@@ -29095,6 +32163,7 @@
         <Property Name="unlockPin" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="resetPasscodeActionResult" BaseType="graph.deviceActionResult">
+        <Property Name="errorCode" Type="Edm.Int32" Nullable="false"/>
         <Property Name="passcode" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="rotateBitLockerKeysDeviceActionResult" BaseType="graph.deviceActionResult">
@@ -29262,11 +32331,35 @@
         <Property Name="deviceImportStatus" Type="graph.importedWindowsAutopilotDeviceIdentityImportStatus" Nullable="false"/>
         <Property Name="deviceRegistrationId" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="outOfBoxExperienceSetting">
+        <Property Name="deviceUsageType" Type="graph.windowsDeviceUsageType" Nullable="false"/>
+        <Property Name="escapeLinkHidden" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="eulaHidden" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="keyboardSelectionPageSkipped" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="privacySettingsHidden" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="userType" Type="graph.windowsUserType" Nullable="false"/>
+      </ComplexType>
       <EntityType Name="importedWindowsAutopilotDeviceIdentityUpload" BaseType="graph.entity">
         <Property Name="createdDateTimeUtc" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="status" Type="graph.importedWindowsAutopilotDeviceIdentityUploadStatus" Nullable="false"/>
         <NavigationProperty Name="deviceIdentities" Type="Collection(graph.importedWindowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="windowsAutopilotDeploymentProfile" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="deviceNameTemplate" Type="Edm.String"/>
+        <Property Name="deviceType" Type="graph.windowsAutopilotDeviceType" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="hardwareHashExtractionEnabled" Type="Edm.Boolean"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="locale" Type="Edm.String"/>
+        <Property Name="managementServiceAppId" Type="Edm.String"/>
+        <Property Name="outOfBoxExperienceSetting" Type="graph.outOfBoxExperienceSetting"/>
+        <Property Name="preprovisioningAllowed" Type="Edm.Boolean"/>
+        <Property Name="roleScopeTagIds" Type="Collection(Edm.String)"/>
+        <NavigationProperty Name="assignedDevices" Type="Collection(graph.windowsAutopilotDeviceIdentity)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="windowsAutopilotDeploymentProfileAssignment" BaseType="graph.entity"/>
       <ComplexType Name="mobileAppIdentifier" Abstract="true"/>
       <ComplexType Name="androidMobileAppIdentifier" BaseType="graph.mobileAppIdentifier">
         <Property Name="packageId" Type="Edm.String" Nullable="false"/>
@@ -29372,18 +32465,7 @@
         <Property Name="resourceActions" Type="Collection(graph.resourceAction)"/>
       </ComplexType>
       <EntityType Name="deviceAndAppManagementRoleDefinition" BaseType="graph.roleDefinition"/>
-      <EntityType Name="deviceManagementExportJob" BaseType="graph.entity">
-        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="filter" Type="Edm.String"/>
-        <Property Name="format" Type="graph.deviceManagementReportFileFormat" Nullable="false"/>
-        <Property Name="localizationType" Type="graph.deviceManagementExportJobLocalizationType" Nullable="false"/>
-        <Property Name="reportName" Type="Edm.String" Nullable="false"/>
-        <Property Name="requestDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="select" Type="Collection(Edm.String)"/>
-        <Property Name="snapshotId" Type="Edm.String"/>
-        <Property Name="status" Type="graph.deviceManagementReportStatus" Nullable="false"/>
-        <Property Name="url" Type="Edm.String"/>
-      </EntityType>
+      <EntityType Name="deviceManagementCachedReportConfiguration" BaseType="graph.entity"/>
       <EntityType Name="enrollmentTroubleshootingEvent" BaseType="graph.deviceManagementTroubleshootingEvent">
         <Property Name="deviceId" Type="Edm.String"/>
         <Property Name="enrollmentType" Type="graph.deviceEnrollmentType" Nullable="false"/>
@@ -29393,6 +32475,21 @@
         <Property Name="operatingSystem" Type="Edm.String"/>
         <Property Name="osVersion" Type="Edm.String"/>
         <Property Name="userId" Type="Edm.String"/>
+      </EntityType>
+      <ComplexType Name="appsInstallationOptionsForMac">
+        <Property Name="isMicrosoft365AppsEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isSkypeForBusinessEnabled" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="appsInstallationOptionsForWindows">
+        <Property Name="isMicrosoft365AppsEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isProjectEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isSkypeForBusinessEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="isVisioEnabled" Type="Edm.Boolean" Nullable="false"/>
+      </ComplexType>
+      <EntityType Name="m365AppsInstallationOptions" BaseType="graph.entity">
+        <Property Name="appsForMac" Type="graph.appsInstallationOptionsForMac" Nullable="false"/>
+        <Property Name="appsForWindows" Type="graph.appsInstallationOptionsForWindows" Nullable="false"/>
+        <Property Name="updateChannel" Type="graph.appsUpdateChannelType" Nullable="false"/>
       </EntityType>
       <ComplexType Name="serviceHealthIssuePost">
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
@@ -29486,7 +32583,6 @@
         <Property Name="body" Type="graph.Json"/>
         <Property Name="displayName" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="Dictionary" OpenType="true"/>
       <ComplexType Name="resultTemplateDictionary" BaseType="graph.Dictionary" OpenType="true"/>
       <ComplexType Name="resultTemplateOption">
         <Property Name="enableResultTemplate" Type="Edm.Boolean"/>
@@ -29553,7 +32649,11 @@
         <Property Name="resultTemplates" Type="graph.resultTemplateDictionary"/>
         <Property Name="searchTerms" Type="Collection(Edm.String)"/>
       </ComplexType>
-      <EntityType Name="searchEntity" BaseType="graph.entity"/>
+      <EntityType Name="searchEntity" BaseType="graph.entity">
+        <NavigationProperty Name="acronyms" Type="Collection(microsoft.graph.search.acronym)" ContainsTarget="true"/>
+        <NavigationProperty Name="bookmarks" Type="Collection(microsoft.graph.search.bookmark)" ContainsTarget="true"/>
+        <NavigationProperty Name="qnas" Type="Collection(microsoft.graph.search.qna)" ContainsTarget="true"/>
+      </EntityType>
       <ComplexType Name="plannerAppliedCategories" OpenType="true"/>
       <ComplexType Name="plannerAssignment">
         <Property Name="assignedBy" Type="graph.identitySet"/>
@@ -29731,13 +32831,26 @@
         <Property Name="resourceVisualization" Type="graph.resourceVisualization"/>
         <NavigationProperty Name="resource" Type="graph.entity"/>
       </EntityType>
+      <EntityType Name="userInsightsSettings" BaseType="graph.entity">
+        <Property Name="isEnabled" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="windowsSetting" BaseType="graph.entity">
+        <Property Name="payloadType" Type="Edm.String"/>
+        <Property Name="settingType" Type="graph.windowsSettingType" Nullable="false"/>
+        <Property Name="windowsDeviceId" Type="Edm.String"/>
+        <NavigationProperty Name="instances" Type="Collection(graph.windowsSettingInstance)" ContainsTarget="true"/>
+      </EntityType>
       <EntityType Name="changeTrackedEntity" BaseType="graph.entity" Abstract="true">
+        <Property Name="createdBy" Type="graph.identitySet"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="lastModifiedBy" Type="graph.identitySet"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
       </EntityType>
       <EntityType Name="shiftPreferences" BaseType="graph.changeTrackedEntity">
         <Property Name="availability" Type="Collection(graph.shiftAvailability)"/>
+      </EntityType>
+      <EntityType Name="userStorage" BaseType="graph.entity">
+        <NavigationProperty Name="quota" Type="graph.unifiedStorageQuota" ContainsTarget="true"/>
       </EntityType>
       <ComplexType Name="CopyNotebookModel">
         <Property Name="createdBy" Type="Edm.String"/>
@@ -29910,6 +33023,22 @@
         <Property Name="indirectProviderTenantId" Type="Edm.String" Nullable="false"/>
         <Property Name="isPartnerConsentPending" Type="Edm.Boolean" Nullable="false"/>
       </EntityType>
+      <ComplexType Name="cloudClipboardItemPayload">
+        <Property Name="content" Type="Edm.String" Nullable="false"/>
+        <Property Name="formatName" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <EntityType Name="cloudClipboardItem" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="payloads" Type="Collection(graph.cloudClipboardItemPayload)" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="windowsSettingInstance" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="expirationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="payload" Type="Edm.String" Nullable="false"/>
+      </EntityType>
       <ComplexType Name="profileCardAnnotation">
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="localizations" Type="Collection(graph.displayNameLocalization)"/>
@@ -29917,6 +33046,13 @@
       <EntityType Name="profileCardProperty" BaseType="graph.entity">
         <Property Name="annotations" Type="Collection(graph.profileCardAnnotation)"/>
         <Property Name="directoryPropertyName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="pronounsSettings" BaseType="graph.entity">
+        <Property Name="isEnabledInOrganization" Type="Edm.Boolean" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="insightsSettings" BaseType="graph.entity">
+        <Property Name="disabledForGroup" Type="Edm.String"/>
+        <Property Name="isEnabledInOrganization" Type="Edm.Boolean"/>
       </EntityType>
       <ComplexType Name="approvalSettings">
         <Property Name="approvalMode" Type="Edm.String"/>
@@ -30427,6 +33563,7 @@
       </ComplexType>
       <ComplexType Name="userSimulationEventInfo">
         <Property Name="browser" Type="Edm.String"/>
+        <Property Name="clickSource" Type="graph.clickSource"/>
         <Property Name="eventDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="eventName" Type="Edm.String"/>
         <Property Name="ipAddress" Type="Edm.String"/>
@@ -30780,6 +33917,7 @@
       <ComplexType Name="callOptions" Abstract="true">
         <Property Name="hideBotAfterEscalation" Type="Edm.Boolean"/>
         <Property Name="isContentSharingNotificationEnabled" Type="Edm.Boolean"/>
+        <Property Name="isDeltaRosterEnabled" Type="Edm.Boolean"/>
       </ComplexType>
       <ComplexType Name="callRoute">
         <Property Name="final" Type="graph.identitySet" Nullable="false"/>
@@ -30794,6 +33932,9 @@
         <Property Name="messageId" Type="Edm.String"/>
         <Property Name="replyChainMessageId" Type="Edm.String"/>
         <Property Name="threadId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="chatRestrictions">
+        <Property Name="allowTextOnly" Type="Edm.Boolean"/>
       </ComplexType>
       <ComplexType Name="commsNotification" OpenType="true">
         <Property Name="changeType" Type="graph.changeType" Nullable="false"/>
@@ -30812,16 +33953,6 @@
       </ComplexType>
       <ComplexType Name="communicationsEncryptedIdentity" BaseType="graph.identity" OpenType="true"/>
       <ComplexType Name="communicationsGuestIdentity" BaseType="graph.identity" OpenType="true"/>
-      <ComplexType Name="communicationsIdentitySet" BaseType="graph.identitySet" OpenType="true">
-        <Property Name="applicationInstance" Type="graph.identity"/>
-        <Property Name="assertedIdentity" Type="graph.identity"/>
-        <Property Name="azureCommunicationServicesUser" Type="graph.identity"/>
-        <Property Name="encrypted" Type="graph.identity"/>
-        <Property Name="endpointType" Type="graph.endpointType"/>
-        <Property Name="guest" Type="graph.identity"/>
-        <Property Name="onPremises" Type="graph.identity"/>
-        <Property Name="phone" Type="graph.identity"/>
-      </ComplexType>
       <ComplexType Name="communicationsPhoneIdentity" BaseType="graph.identity" OpenType="true"/>
       <ComplexType Name="communicationsUserIdentity" BaseType="graph.identity" OpenType="true">
         <Property Name="tenantId" Type="Edm.String"/>
@@ -30957,12 +34088,35 @@
         <Property Name="sequenceId" Type="Edm.Int64" Nullable="false"/>
         <Property Name="tone" Type="graph.tone" Nullable="false"/>
       </ComplexType>
+      <ComplexType Name="virtualEventExternalInformation">
+        <Property Name="applicationId" Type="Edm.String"/>
+        <Property Name="externalEventId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="virtualEventExternalRegistrationInformation">
+        <Property Name="referrer" Type="Edm.String"/>
+        <Property Name="registrationId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="virtualEventPresenterDetails">
+        <Property Name="bio" Type="graph.itemBody"/>
+        <Property Name="company" Type="Edm.String"/>
+        <Property Name="jobTitle" Type="Edm.String"/>
+        <Property Name="linkedInProfileWebUrl" Type="Edm.String"/>
+        <Property Name="personalSiteWebUrl" Type="Edm.String"/>
+        <Property Name="photo" Type="Edm.Stream"/>
+        <Property Name="twitterProfileWebUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="virtualEventPresenterInfo" BaseType="graph.meetingParticipantInfo">
+        <Property Name="presenterDetails" Type="graph.virtualEventPresenterDetails"/>
+      </ComplexType>
       <ComplexType Name="virtualEventRegistrationQuestionAnswer">
         <Property Name="booleanValue" Type="Edm.Boolean"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="multiChoiceValues" Type="Collection(Edm.String)"/>
         <Property Name="questionId" Type="Edm.String"/>
         <Property Name="value" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="virtualEventSettings">
+        <Property Name="isAttendeeEmailNotificationEnabled" Type="Edm.Boolean"/>
       </ComplexType>
       <EntityType Name="commsOperation" BaseType="graph.entity" OpenType="true">
         <Property Name="clientContext" Type="Edm.String"/>
@@ -31021,6 +34175,9 @@
         <Property Name="recordingAccessToken" Type="Edm.String"/>
         <Property Name="recordingLocation" Type="Edm.String"/>
       </EntityType>
+      <EntityType Name="sendDtmfTonesOperation" BaseType="graph.commsOperation" OpenType="true">
+        <Property Name="completionReason" Type="graph.sendDtmfCompletionReason"/>
+      </EntityType>
       <EntityType Name="startHoldMusicOperation" BaseType="graph.commsOperation" OpenType="true"/>
       <EntityType Name="stopHoldMusicOperation" BaseType="graph.commsOperation" OpenType="true"/>
       <EntityType Name="subscribeToToneOperation" BaseType="graph.commsOperation" OpenType="true"/>
@@ -31031,9 +34188,17 @@
         <Property Name="description" Type="graph.itemBody"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="endDateTime" Type="graph.dateTimeTimeZone"/>
+        <Property Name="externalEventInformation" Type="Collection(graph.virtualEventExternalInformation)"/>
+        <Property Name="settings" Type="graph.virtualEventSettings"/>
         <Property Name="startDateTime" Type="graph.dateTimeTimeZone"/>
         <Property Name="status" Type="graph.virtualEventStatus"/>
+        <NavigationProperty Name="presenters" Type="Collection(graph.virtualEventPresenter)" ContainsTarget="true"/>
         <NavigationProperty Name="sessions" Type="Collection(graph.virtualEventSession)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="virtualEventPresenter" BaseType="graph.entity">
+        <Property Name="email" Type="Edm.String"/>
+        <Property Name="identity" Type="graph.identity"/>
+        <Property Name="presenterDetails" Type="graph.virtualEventPresenterDetails"/>
       </EntityType>
       <EntityType Name="virtualEventSession" BaseType="graph.onlineMeetingBase">
         <Property Name="endDateTime" Type="graph.dateTimeTimeZone"/>
@@ -31042,17 +34207,72 @@
       <EntityType Name="virtualEventRegistration" BaseType="graph.entity">
         <Property Name="cancelationDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="email" Type="Edm.String"/>
+        <Property Name="externalRegistrationInformation" Type="graph.virtualEventExternalRegistrationInformation"/>
         <Property Name="firstName" Type="Edm.String"/>
         <Property Name="lastName" Type="Edm.String"/>
+        <Property Name="preferredLanguage" Type="Edm.String"/>
+        <Property Name="preferredTimezone" Type="Edm.String"/>
         <Property Name="registrationDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="registrationQuestionAnswers" Type="Collection(graph.virtualEventRegistrationQuestionAnswer)"/>
         <Property Name="status" Type="graph.virtualEventAttendeeRegistrationStatus"/>
         <Property Name="userId" Type="Edm.String"/>
+        <NavigationProperty Name="sessions" Type="Collection(graph.virtualEventSession)"/>
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="userId"/>
+                    <PropertyValue Property="Name" PropertyPath="userId"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+            <Record Type="Org.OData.Core.V1.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Org.OData.Core.V1.PropertyRef">
+                    <PropertyValue Property="Alias" String="email"/>
+                    <PropertyValue Property="Name" PropertyPath="email"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="virtualEventRegistrationConfiguration" BaseType="graph.entity">
+        <Property Name="capacity" Type="Edm.Int32"/>
+        <Property Name="registrationWebUrl" Type="Edm.String"/>
+        <NavigationProperty Name="questions" Type="Collection(graph.virtualEventRegistrationQuestionBase)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="virtualEventRegistrationQuestionBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isRequired" Type="Edm.Boolean"/>
+      </EntityType>
+      <EntityType Name="virtualEventRegistrationCustomQuestion" BaseType="graph.virtualEventRegistrationQuestionBase">
+        <Property Name="answerChoices" Type="Collection(Edm.String)"/>
+        <Property Name="answerInputType" Type="graph.virtualEventRegistrationQuestionAnswerInputType"/>
+      </EntityType>
+      <EntityType Name="virtualEventRegistrationPredefinedQuestion" BaseType="graph.virtualEventRegistrationQuestionBase">
+        <Property Name="label" Type="graph.virtualEventRegistrationPredefinedQuestionLabel"/>
+      </EntityType>
+      <EntityType Name="virtualEventTownhall" BaseType="graph.virtualEvent">
+        <Property Name="audience" Type="graph.meetingAudience"/>
+        <Property Name="coOrganizers" Type="Collection(graph.communicationsUserIdentity)"/>
+        <Property Name="invitedAttendees" Type="Collection(graph.identity)"/>
+        <Property Name="isInviteOnly" Type="Edm.Boolean"/>
       </EntityType>
       <EntityType Name="virtualEventWebinar" BaseType="graph.virtualEvent">
         <Property Name="audience" Type="graph.meetingAudience"/>
         <Property Name="coOrganizers" Type="Collection(graph.communicationsUserIdentity)"/>
+        <NavigationProperty Name="registrationConfiguration" Type="graph.virtualEventWebinarRegistrationConfiguration" ContainsTarget="true"/>
         <NavigationProperty Name="registrations" Type="Collection(graph.virtualEventRegistration)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="virtualEventWebinarRegistrationConfiguration" BaseType="graph.virtualEventRegistrationConfiguration">
+        <Property Name="isManualApprovalEnabled" Type="Edm.Boolean"/>
+        <Property Name="isWaitlistEnabled" Type="Edm.Boolean"/>
       </EntityType>
       <ComplexType Name="passwordResetResponse">
         <Property Name="newPassword" Type="Edm.String"/>
@@ -31229,6 +34449,8 @@
       </ComplexType>
       <ComplexType Name="chatMessageReaction">
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="reactionContentUrl" Type="Edm.String"/>
         <Property Name="reactionType" Type="Edm.String" Nullable="false"/>
         <Property Name="user" Type="graph.chatMessageReactionIdentitySet" Nullable="false"/>
       </ComplexType>
@@ -31349,6 +34571,7 @@
         <Property Name="teamId" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="teamsAppAuthorization">
+        <Property Name="clientAppId" Type="Edm.String"/>
         <Property Name="requiredPermissionSet" Type="graph.teamsAppPermissionSet"/>
       </ComplexType>
       <ComplexType Name="teamsAppPermissionSet">
@@ -31372,6 +34595,9 @@
         <Property Name="initiator" Type="graph.identitySet"/>
         <Property Name="teamsAppDisplayName" Type="Edm.String"/>
         <Property Name="teamsAppId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="teamsLicensingDetails">
+        <Property Name="hasTeamsLicense" Type="Edm.Boolean"/>
       </ComplexType>
       <ComplexType Name="teamsTabConfiguration" OpenType="true">
         <Property Name="contentUrl" Type="Edm.String"/>
@@ -31476,6 +34702,7 @@
         <Property Name="contentType" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="chatMessageHostedContent" BaseType="graph.teamworkHostedContent"/>
+      <EntityType Name="deletedChat" BaseType="graph.entity"/>
       <EntityType Name="deletedTeam" BaseType="graph.entity">
         <NavigationProperty Name="channels" Type="Collection(graph.channel)" ContainsTarget="true"/>
       </EntityType>
@@ -31504,15 +34731,20 @@
       <EntityType Name="teamworkBot" BaseType="graph.entity"/>
       <EntityType Name="teamsAppSettings" BaseType="graph.entity">
         <Property Name="allowUserRequestsForAppAccess" Type="Edm.Boolean"/>
+        <Property Name="isUserPersonalScopeResourceSpecificConsentEnabled" Type="Edm.Boolean"/>
       </EntityType>
       <EntityType Name="teamwork" BaseType="graph.entity">
+        <Property Name="isTeamsEnabled" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="region" Type="Edm.String"/>
         <NavigationProperty Name="workforceIntegrations" Type="Collection(graph.workforceIntegration)" ContainsTarget="true"/>
+        <NavigationProperty Name="deletedChats" Type="Collection(graph.deletedChat)" ContainsTarget="true"/>
         <NavigationProperty Name="deletedTeams" Type="Collection(graph.deletedTeam)" ContainsTarget="true"/>
         <NavigationProperty Name="teamsAppSettings" Type="graph.teamsAppSettings" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="workforceIntegration" BaseType="graph.changeTrackedEntity">
         <Property Name="apiVersion" Type="Edm.Int32"/>
         <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="eligibilityFilteringEnabledEntities" Type="graph.eligibilityFilteringEnabledEntities"/>
         <Property Name="encryption" Type="graph.workforceIntegrationEncryption"/>
         <Property Name="isActive" Type="Edm.Boolean"/>
         <Property Name="supportedEntities" Type="graph.workforceIntegrationSupportedEntities"/>
@@ -31556,6 +34788,25 @@
         <Property Name="endTime" Type="Edm.TimeOfDay"/>
         <Property Name="startTime" Type="Edm.TimeOfDay"/>
       </ComplexType>
+      <ComplexType Name="timeCardBreak">
+        <Property Name="breakId" Type="Edm.String"/>
+        <Property Name="end" Type="graph.timeCardEvent"/>
+        <Property Name="notes" Type="graph.itemBody"/>
+        <Property Name="start" Type="graph.timeCardEvent" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="timeCardEvent">
+        <Property Name="dateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="isAtApprovedLocation" Type="Edm.Boolean"/>
+        <Property Name="notes" Type="graph.itemBody"/>
+      </ComplexType>
+      <ComplexType Name="timeCardEntry">
+        <Property Name="breaks" Type="Collection(graph.timeCardBreak)"/>
+        <Property Name="clockInEvent" Type="graph.timeCardEvent"/>
+        <Property Name="clockOutEvent" Type="graph.timeCardEvent"/>
+      </ComplexType>
+      <ComplexType Name="timeClockSettings">
+        <Property Name="approvedLocation" Type="graph.geoCoordinates"/>
+      </ComplexType>
       <ComplexType Name="timeOffItem" BaseType="graph.scheduleEntity">
         <Property Name="timeOffReasonId" Type="Edm.String"/>
       </ComplexType>
@@ -31563,6 +34814,11 @@
         <Property Name="protocol" Type="graph.workforceIntegrationEncryptionProtocol"/>
         <Property Name="secret" Type="Edm.String"/>
       </ComplexType>
+      <EntityType Name="dayNote" BaseType="graph.changeTrackedEntity">
+        <Property Name="dayNoteDate" Type="Edm.Date"/>
+        <Property Name="draftDayNote" Type="graph.itemBody"/>
+        <Property Name="sharedDayNote" Type="graph.itemBody"/>
+      </EntityType>
       <EntityType Name="scheduleChangeRequest" BaseType="graph.changeTrackedEntity" Abstract="true">
         <Property Name="assignedTo" Type="graph.scheduleChangeRequestActor"/>
         <Property Name="managerActionDateTime" Type="Edm.DateTimeOffset"/>
@@ -31581,6 +34837,7 @@
       </EntityType>
       <EntityType Name="openShift" BaseType="graph.changeTrackedEntity">
         <Property Name="draftOpenShift" Type="graph.openShiftItem"/>
+        <Property Name="isStagedForDeletion" Type="Edm.Boolean"/>
         <Property Name="schedulingGroupId" Type="Edm.String"/>
         <Property Name="sharedOpenShift" Type="graph.openShiftItem"/>
       </EntityType>
@@ -31588,12 +34845,14 @@
         <Property Name="openShiftId" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="schedulingGroup" BaseType="graph.changeTrackedEntity">
+        <Property Name="code" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="isActive" Type="Edm.Boolean"/>
         <Property Name="userIds" Type="Collection(Edm.String)"/>
       </EntityType>
       <EntityType Name="shift" BaseType="graph.changeTrackedEntity">
         <Property Name="draftShift" Type="graph.shiftItem"/>
+        <Property Name="isStagedForDeletion" Type="Edm.Boolean"/>
         <Property Name="schedulingGroupId" Type="Edm.String"/>
         <Property Name="sharedShift" Type="graph.shiftItem"/>
         <Property Name="userId" Type="Edm.String"/>
@@ -31601,7 +34860,18 @@
       <EntityType Name="swapShiftsChangeRequest" BaseType="graph.offerShiftRequest">
         <Property Name="recipientShiftId" Type="Edm.String"/>
       </EntityType>
+      <EntityType Name="timeCard" BaseType="graph.changeTrackedEntity">
+        <Property Name="breaks" Type="Collection(graph.timeCardBreak)"/>
+        <Property Name="clockInEvent" Type="graph.timeCardEvent"/>
+        <Property Name="clockOutEvent" Type="graph.timeCardEvent"/>
+        <Property Name="confirmedBy" Type="graph.confirmedBy"/>
+        <Property Name="notes" Type="graph.itemBody"/>
+        <Property Name="originalEntry" Type="graph.timeCardEntry"/>
+        <Property Name="state" Type="graph.timeCardState"/>
+        <Property Name="userId" Type="Edm.String"/>
+      </EntityType>
       <EntityType Name="timeOffReason" BaseType="graph.changeTrackedEntity">
+        <Property Name="code" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="iconType" Type="graph.timeOffReasonIconType"/>
         <Property Name="isActive" Type="Edm.Boolean"/>
@@ -31613,9 +34883,11 @@
       </EntityType>
       <EntityType Name="timeOff" BaseType="graph.changeTrackedEntity">
         <Property Name="draftTimeOff" Type="graph.timeOffItem"/>
+        <Property Name="isStagedForDeletion" Type="Edm.Boolean"/>
         <Property Name="sharedTimeOff" Type="graph.timeOffItem"/>
         <Property Name="userId" Type="Edm.String"/>
       </EntityType>
+      <EntityType Name="workingTimeSchedule" BaseType="graph.entity"/>
       <EntityType Name="emailFileAssessmentRequest" BaseType="graph.threatAssessmentRequest">
         <Property Name="contentData" Type="Edm.String" Nullable="false"/>
         <Property Name="destinationRoutingReason" Type="graph.mailDestinationRoutingReason"/>
@@ -31700,9 +34972,38 @@
         <NavigationProperty Name="extensions" Type="Collection(graph.extension)" ContainsTarget="true"/>
         <NavigationProperty Name="linkedResources" Type="Collection(graph.linkedResource)" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="storageQuotaBreakdown" BaseType="graph.entity">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="manageWebUrl" Type="Edm.String"/>
+        <Property Name="used" Type="Edm.Int64"/>
+      </EntityType>
+      <EntityType Name="serviceStorageQuotaBreakdown" BaseType="graph.storageQuotaBreakdown"/>
+      <EntityType Name="unifiedStorageQuota" BaseType="graph.entity">
+        <Property Name="deleted" Type="Edm.Int64"/>
+        <Property Name="manageWebUrl" Type="Edm.String"/>
+        <Property Name="remaining" Type="Edm.Int64"/>
+        <Property Name="state" Type="Edm.String"/>
+        <Property Name="total" Type="Edm.Int64"/>
+        <Property Name="used" Type="Edm.Int64"/>
+        <NavigationProperty Name="services" Type="Collection(graph.serviceStorageQuotaBreakdown)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="community" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="groupId" Type="Edm.String"/>
+        <Property Name="privacy" Type="graph.communityPrivacy" Nullable="false"/>
+        <NavigationProperty Name="group" Type="graph.group"/>
+        <NavigationProperty Name="owners" Type="Collection(graph.user)"/>
+      </EntityType>
       <EntityType Name="employeeExperience">
+        <NavigationProperty Name="communities" Type="Collection(graph.community)" ContainsTarget="true"/>
+        <NavigationProperty Name="engagementAsyncOperations" Type="Collection(graph.engagementAsyncOperation)" ContainsTarget="true"/>
         <NavigationProperty Name="learningCourseActivities" Type="Collection(graph.learningCourseActivity)" ContainsTarget="true"/>
         <NavigationProperty Name="learningProviders" Type="Collection(graph.learningProvider)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="engagementAsyncOperation" BaseType="graph.longRunningOperation">
+        <Property Name="operationType" Type="graph.engagementAsyncOperationType"/>
+        <Property Name="resourceId" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="learningCourseActivity" BaseType="graph.entity">
         <Property Name="completedDateTime" Type="Edm.DateTimeOffset"/>
@@ -31759,6 +35060,7 @@
         <Property Name="isSearchable" Type="Edm.Boolean"/>
         <Property Name="languageTag" Type="Edm.String" Nullable="false"/>
         <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="level" Type="graph.level"/>
         <Property Name="numberOfPages" Type="Edm.Int32"/>
         <Property Name="skillTags" Type="Collection(Edm.String)"/>
         <Property Name="sourceName" Type="Edm.String"/>
@@ -31791,6 +35093,518 @@
       <Term Name="channelCreationMode" Type="Edm.String" AppliesTo="microsoft.graph.channel"/>
       <Term Name="teamCreationMode" Type="Edm.String" AppliesTo="microsoft.graph.team"/>
       <Term Name="temporaryId" Type="Edm.String" AppliesTo="microsoft.graph.chatMessageHostedContent"/>
+      <Function Name="getRelyingPartyDetailedSummary" IsBound="true" IsComposable="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Collection(graph.relyingPartyDetailedSummary)" Nullable="false"/>
+      </Function>
+      <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="skip" Type="Edm.Int32"/>
+        <Parameter Name="top" Type="Edm.Int32"/>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="skipToken" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Function>
+      <Function Name="getEmailActivityCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailActivityUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailActivityUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailActivityUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailAppUsageAppsUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailAppUsageUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailAppUsageUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailAppUsageUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getEmailAppUsageVersionsUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getM365AppPlatformUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getM365AppUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getM365AppUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getM365AppUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getMailboxUsageDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getMailboxUsageMailboxCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getMailboxUsageQuotaStatusMailboxCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getMailboxUsageStorage" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActivationCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActivationsUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActiveUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityFileCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityGroupCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365GroupsActivityStorage" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOffice365ServicesUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveActivityFileCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveUsageAccountCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveUsageFileCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getOneDriveUsageStorage" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointActivityFileCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointActivityPages" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsageFileCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsagePages" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsageSiteCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSharePointSiteUsageStorage" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessDeviceUsageUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessOrganizerActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessOrganizerActivityMinuteCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessOrganizerActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessParticipantActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessParticipantActivityMinuteCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessParticipantActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessPeerToPeerActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessPeerToPeerActivityMinuteCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getSkypeForBusinessPeerToPeerActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsDeviceUsageDistributionUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsDeviceUsageUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsTeamActivityCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsTeamActivityDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsTeamActivityDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsTeamActivityDistributionCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsTeamCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsUserActivityCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsUserActivityUserCounts" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsUserActivityUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getTeamsUserActivityUserDetail" IsBound="true">
+        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerActivityUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerDeviceUsageUserCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerGroupsActivityCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getYammerGroupsActivityGroupCounts" IsBound="true" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Edm.Stream" Nullable="false"/>
+      </Function>
+      <Function Name="getGroupArchivedPrintJobs" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="groupId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
+      </Function>
+      <Function Name="getPrinterArchivedPrintJobs" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="printerId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
+      </Function>
+      <Function Name="getUserArchivedPrintJobs" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
+        <Parameter Name="userId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
+        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
+      </Function>
       <Function Name="usersRegisteredByFeature" IsBound="true" IsComposable="true">
         <Parameter Name="bindingParameter" Type="graph.authenticationMethodsRoot"/>
         <ReturnType Type="graph.userRegistrationFeatureSummary" Nullable="false"/>
@@ -31814,6 +35628,9 @@
       <Action Name="instantiate" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.applicationTemplate"/>
         <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="serviceManagementReference" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
         <ReturnType Type="graph.applicationServicePrincipal"/>
       </Action>
       <Action Name="setVerifiedPublisher" IsBound="true">
@@ -31900,6 +35717,12 @@
       <Action Name="cancel" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.printJob"/>
       </Action>
+      <Action Name="cancel" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.virtualEvent"/>
+      </Action>
+      <Action Name="cancel" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.virtualEventRegistration"/>
+      </Action>
       <Action Name="getStaffAvailability" IsBound="true">
         <Parameter Name="bookingBusiness" Type="graph.bookingBusiness" Nullable="false"/>
         <Parameter Name="staffIds" Type="Collection(Edm.String)" Nullable="false" Unicode="false"/>
@@ -31921,8 +35744,18 @@
         <Parameter Name="bindingParameter" Type="graph.educationAssignment"/>
         <ReturnType Type="graph.educationAssignment"/>
       </Action>
+      <Action Name="publish" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationModule"/>
+        <ReturnType Type="graph.educationModule"/>
+      </Action>
       <Action Name="publish" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="graph.contentType"/>
+      </Action>
+      <Action Name="publish" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.sitePage"/>
+      </Action>
+      <Action Name="publish" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.virtualEvent"/>
       </Action>
       <Action Name="unpublish" IsBound="true">
         <Parameter Name="bookingBusiness" Type="graph.bookingBusiness" Nullable="false"/>
@@ -31930,6 +35763,105 @@
       <Action Name="unpublish" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="graph.contentType"/>
       </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPcProvisioningPolicy"/>
+        <Parameter Name="assignments" Type="Collection(graph.cloudPcProvisioningPolicyAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPcUserSetting"/>
+        <Parameter Name="assignments" Type="Collection(graph.cloudPcUserSettingAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.managedDeviceMobileAppConfiguration"/>
+        <Parameter Name="assignments" Type="Collection(graph.managedDeviceMobileAppConfigurationAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.mobileApp"/>
+        <Parameter Name="mobileAppAssignments" Type="Collection(graph.mobileAppAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.managedEBook"/>
+        <Parameter Name="managedEBookAssignments" Type="Collection(graph.managedEBookAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceCompliancePolicy"/>
+        <Parameter Name="assignments" Type="Collection(graph.deviceCompliancePolicyAssignment)"/>
+        <ReturnType Type="Collection(graph.deviceCompliancePolicyAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceConfiguration"/>
+        <Parameter Name="assignments" Type="Collection(graph.deviceConfigurationAssignment)"/>
+        <ReturnType Type="Collection(graph.deviceConfigurationAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceEnrollmentConfiguration"/>
+        <Parameter Name="enrollmentConfigurationAssignments" Type="Collection(graph.enrollmentConfigurationAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.targetedManagedAppConfiguration"/>
+        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.targetedManagedAppProtection"/>
+        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
+      </Action>
+      <Action Name="assign" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.windowsInformationProtection"/>
+        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
+      </Action>
+      <Action Name="endGracePeriod" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPC"/>
+      </Action>
+      <Action Name="reboot" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPC"/>
+      </Action>
+      <Action Name="rename" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPC"/>
+        <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPC"/>
+        <Parameter Name="cloudPcSnapshotId" Type="Edm.String" Unicode="false"/>
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false"/>
+        <Parameter Name="autoReconcileProxyConflict" Type="Edm.Boolean">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="graph.directoryObject"/>
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.fileStorageContainer"/>
+        <ReturnType Type="graph.fileStorageContainer"/>
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
+        <Parameter Name="parentReference" Type="graph.itemReference"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="graph.driveItem"/>
+      </Action>
+      <Action Name="restore" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.documentSetVersion"/>
+      </Action>
+      <Action Name="troubleshoot" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPC"/>
+      </Action>
+      <Action Name="runHealthChecks" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.cloudPcOnPremisesConnection"/>
+      </Action>
+      <Function Name="getAuditActivityTypes" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.cloudPcAuditEvent)"/>
+        <ReturnType Type="Collection(Edm.String)" Unicode="false"/>
+      </Function>
+      <Function Name="getAuditActivityTypes" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.auditEvent)"/>
+        <Parameter Name="category" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Collection(Edm.String)" Unicode="false"/>
+      </Function>
+      <Function Name="getSourceImages" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.cloudPcDeviceImage)"/>
+        <ReturnType Type="Collection(graph.cloudPcSourceDeviceImage)"/>
+      </Function>
       <Function Name="getFinalAttachment" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.subjectRightsRequest"/>
         <ReturnType Type="Edm.Stream"/>
@@ -31951,6 +35883,16 @@
         <Parameter Name="pkcs12Value" Type="Edm.String" Unicode="false"/>
         <Parameter Name="password" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.identityApiConnector"/>
+      </Action>
+      <Action Name="validateAuthenticationConfiguration" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.customAuthenticationExtension)"/>
+        <Parameter Name="endpointConfiguration" Type="graph.customExtensionEndpointConfiguration"/>
+        <Parameter Name="authenticationConfiguration" Type="graph.customExtensionAuthenticationConfiguration"/>
+        <ReturnType Type="graph.authenticationConfigurationValidation"/>
+      </Action>
+      <Action Name="validateAuthenticationConfiguration" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.customAuthenticationExtension"/>
+        <ReturnType Type="graph.authenticationConfigurationValidation"/>
       </Action>
       <Function Name="availableProviderTypes" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.identityProvider)"/>
@@ -32128,19 +36070,6 @@
         <Parameter Name="securityEnabledOnly" Type="Edm.Boolean"/>
         <ReturnType Type="Collection(Edm.String)" Nullable="false" Unicode="false"/>
       </Action>
-      <Action Name="restore" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.directoryObject" Nullable="false"/>
-        <ReturnType Type="graph.directoryObject"/>
-      </Action>
-      <Action Name="restore" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
-        <Parameter Name="parentReference" Type="graph.itemReference"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="graph.driveItem"/>
-      </Action>
-      <Action Name="restore" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.documentSetVersion"/>
-      </Action>
       <Action Name="forceDelete" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.domain" Nullable="false"/>
         <Parameter Name="disableUserAccounts" Type="Edm.Boolean"/>
@@ -32151,6 +36080,9 @@
       </Action>
       <Action Name="verify" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="graph.domain" Nullable="false"/>
+        <Parameter Name="forceTakeover" Type="Edm.Boolean">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
         <ReturnType Type="graph.domain"/>
       </Action>
       <Action Name="getAvailableExtensionProperties" IsBound="true" EntitySetPath="bindingParameter">
@@ -32268,6 +36200,23 @@
         <Parameter Name="token" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="Collection(graph.driveItem)"/>
       </Function>
+      <Function Name="delta" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.listItem)"/>
+        <ReturnType Type="Collection(graph.listItem)"/>
+      </Function>
+      <Function Name="delta" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.listItem)"/>
+        <Parameter Name="token" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Collection(graph.listItem)"/>
+      </Function>
+      <Function Name="delta" IsBound="true" EntitySetPath="bindingParameter">
+        <Parameter Name="bindingParameter" Type="Collection(graph.callRecording)"/>
+        <ReturnType Type="Collection(graph.callRecording)"/>
+      </Function>
+      <Function Name="delta" IsBound="true" EntitySetPath="bindingParameter">
+        <Parameter Name="bindingParameter" Type="Collection(graph.callTranscript)"/>
+        <ReturnType Type="Collection(graph.callTranscript)"/>
+      </Function>
       <Function Name="delta" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="Collection(graph.chatMessage)"/>
         <ReturnType Type="Collection(graph.chatMessage)"/>
@@ -32280,9 +36229,6 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.todoTaskList)"/>
         <ReturnType Type="Collection(graph.todoTaskList)"/>
       </Function>
-      <Action Name="resetToSystemDefault" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.crossTenantAccessPolicyConfigurationDefault" Nullable="false"/>
-      </Action>
       <Function Name="findTenantInformationByDomainName" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.tenantRelationship" Nullable="false"/>
         <Parameter Name="domainName" Type="Edm.String" Unicode="false"/>
@@ -32293,6 +36239,41 @@
         <Parameter Name="tenantId" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.tenantInformation"/>
       </Function>
+      <Action Name="resetToSystemDefault" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.crossTenantAccessPolicyConfigurationDefault" Nullable="false"/>
+      </Action>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationAssignment"/>
+        <ReturnType Type="graph.educationAssignment"/>
+      </Action>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.protectionPolicyBase"/>
+        <ReturnType Type="graph.protectionPolicyBase"/>
+      </Action>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.restoreSessionBase"/>
+        <ReturnType Type="graph.restoreSessionBase"/>
+      </Action>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.serviceApp"/>
+        <Parameter Name="effectiveDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <ReturnType Type="graph.serviceApp"/>
+      </Action>
+      <Action Name="activate" IsBound="true">
+        <Parameter Name="this" Type="graph.fileStorageContainer"/>
+      </Action>
+      <Action Name="deactivate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationAssignment"/>
+        <ReturnType Type="graph.educationAssignment"/>
+      </Action>
+      <Action Name="deactivate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.protectionPolicyBase"/>
+        <ReturnType Type="graph.protectionPolicyBase"/>
+      </Action>
+      <Action Name="deactivate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.serviceApp"/>
+        <ReturnType Type="graph.serviceApp"/>
+      </Action>
       <Action Name="setUpFeedbackResourcesFolder" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.educationAssignment"/>
         <ReturnType Type="graph.educationAssignment"/>
@@ -32302,6 +36283,14 @@
         <ReturnType Type="graph.educationAssignment"/>
       </Action>
       <Action Name="setUpResourcesFolder" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationSubmission"/>
+        <ReturnType Type="graph.educationSubmission"/>
+      </Action>
+      <Action Name="setUpResourcesFolder" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationModule"/>
+        <ReturnType Type="graph.educationModule"/>
+      </Action>
+      <Action Name="excuse" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.educationSubmission"/>
         <ReturnType Type="graph.educationSubmission"/>
       </Action>
@@ -32321,6 +36310,44 @@
         <Parameter Name="bindingParameter" Type="graph.educationSubmission"/>
         <ReturnType Type="graph.educationSubmission"/>
       </Action>
+      <Action Name="pin" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationModule"/>
+        <ReturnType Type="graph.educationModule"/>
+      </Action>
+      <Action Name="unpin" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.educationModule"/>
+        <ReturnType Type="graph.educationModule"/>
+      </Action>
+      <Action Name="enable" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.backupRestoreRoot"/>
+        <Parameter Name="appOwnerTenantId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="graph.serviceStatus"/>
+      </Action>
+      <Action Name="run" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.protectionRuleBase"/>
+        <ReturnType Type="graph.protectionRuleBase"/>
+      </Action>
+      <Action Name="search" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.restorePoint)"/>
+        <Parameter Name="protectionUnitIds" Type="Collection(Edm.String)" Unicode="false"/>
+        <Parameter Name="protectionTimePeriod" Type="graph.timePeriod"/>
+        <Parameter Name="restorePointPreference" Type="graph.restorePointPreference"/>
+        <Parameter Name="tags" Type="graph.restorePointTags"/>
+        <Parameter Name="artifactQuery" Type="graph.artifactQuery">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="graph.restorePointSearchResponse"/>
+      </Action>
+      <Function Name="search" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
+        <Parameter Name="q" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Collection(graph.driveItem)"/>
+      </Function>
+      <Function Name="search" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.drive"/>
+        <Parameter Name="q" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Collection(graph.driveItem)"/>
+      </Function>
       <Action Name="abs" IsBound="true">
         <Parameter Name="bindparameter" Type="graph.workbookFunctions"/>
         <Parameter Name="number" Type="graph.Json"/>
@@ -35123,6 +39150,30 @@
         <Parameter Name="Comment" Type="Edm.String" Unicode="false"/>
         <Parameter Name="ToRecipients" Type="Collection(graph.recipient)" Nullable="false"/>
       </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.event"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.mailFolder"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.message"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.calendar"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.contact"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.contactFolder"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.fileStorageContainer"/>
+      </Action>
+      <Action Name="permanentDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
+      </Action>
       <Action Name="snoozeReminder" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.event"/>
         <Parameter Name="NewReminderTime" Type="graph.dateTimeTimeZone" Nullable="false"/>
@@ -35246,10 +39297,24 @@
         <Parameter Name="TimeZoneStandard" Type="graph.timeZoneStandard" Nullable="false"/>
         <ReturnType Type="Collection(graph.timeZoneInformation)" Nullable="false"/>
       </Function>
+      <Action Name="lock" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.fileStorageContainer"/>
+        <Parameter Name="lockState" Type="graph.siteLockState">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+      </Action>
+      <Action Name="unlock" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.fileStorageContainer"/>
+      </Action>
       <Action Name="remove" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.site)"/>
         <Parameter Name="value" Type="Collection(graph.site)"/>
         <ReturnType Type="Collection(graph.site)"/>
+      </Action>
+      <Action Name="remove" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.conversationMember)"/>
+        <Parameter Name="values" Type="Collection(graph.conversationMember)"/>
+        <ReturnType Type="Collection(graph.actionResultPart)"/>
       </Action>
       <Function Name="getAllSites" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.site)"/>
@@ -35285,13 +39350,34 @@
       </Action>
       <Action Name="createLink" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.driveItem"/>
-        <Parameter Name="type" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="type" Type="Edm.String" Unicode="false"/>
         <Parameter Name="scope" Type="Edm.String" Unicode="false"/>
         <Parameter Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
         <Parameter Name="password" Type="Edm.String" Unicode="false"/>
         <Parameter Name="message" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="recipients" Type="Collection(graph.driveRecipient)"/>
         <Parameter Name="retainInheritedPermissions" Type="Edm.Boolean"/>
+        <Parameter Name="sendNotification" Type="Edm.Boolean">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
         <ReturnType Type="graph.permission"/>
+      </Action>
+      <Action Name="createLink" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.listItem"/>
+        <Parameter Name="type" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="scope" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="expirationDateTime" Type="Edm.DateTimeOffset"/>
+        <Parameter Name="password" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="message" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="recipients" Type="Collection(graph.driveRecipient)"/>
+        <Parameter Name="retainInheritedPermissions" Type="Edm.Boolean"/>
+        <Parameter Name="sendNotification" Type="Edm.Boolean">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="graph.permission"/>
+      </Action>
+      <Action Name="discardCheckout" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
       </Action>
       <Action Name="extractSensitivityLabels" IsBound="true">
         <Parameter Name="bindparameter" Type="graph.driveItem"/>
@@ -35318,9 +39404,6 @@
         <Parameter Name="participants" Type="Collection(graph.invitationParticipantInfo)" Nullable="false"/>
         <Parameter Name="clientContext" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.inviteParticipantsOperation"/>
-      </Action>
-      <Action Name="permanentDelete" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
       </Action>
       <Action Name="preview" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.driveItem"/>
@@ -35373,16 +39456,6 @@
         <Parameter Name="interval" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="Collection(graph.itemActivityStat)"/>
       </Function>
-      <Function Name="search" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.driveItem"/>
-        <Parameter Name="q" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Collection(graph.driveItem)"/>
-      </Function>
-      <Function Name="search" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.drive"/>
-        <Parameter Name="q" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Collection(graph.driveItem)"/>
-      </Function>
       <Action Name="associateWithHubSites" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="graph.contentType"/>
         <Parameter Name="hubSiteUrls" Type="Collection(Edm.String)" Nullable="false" Unicode="false"/>
@@ -35397,6 +39470,18 @@
         <Parameter Name="bindingParameter" Type="graph.contentType"/>
         <ReturnType Type="Edm.Boolean" Nullable="false"/>
       </Function>
+      <Action Name="getPositionOfWebPart" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.webPart"/>
+        <ReturnType Type="graph.webPartPosition"/>
+      </Action>
+      <Action Name="getWebPartsByPosition" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.sitePage"/>
+        <Parameter Name="webPartIndex" Type="Edm.Double"/>
+        <Parameter Name="horizontalSectionId" Type="Edm.Double"/>
+        <Parameter Name="isInVerticalSection" Type="Edm.Boolean"/>
+        <Parameter Name="columnId" Type="Edm.Double"/>
+        <ReturnType Type="Collection(graph.webPart)"/>
+      </Action>
       <Action Name="grant" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.permission"/>
         <Parameter Name="roles" Type="Collection(Edm.String)" Unicode="false"/>
@@ -35431,6 +39516,16 @@
         <Parameter Name="bindingParameter" Type="graph.drive"/>
         <ReturnType Type="Collection(graph.driveItem)"/>
       </Function>
+      <Action Name="sendVirtualAppointmentReminderSms" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.onlineMeeting"/>
+        <Parameter Name="remindBeforeTimeInMinutesType" Type="graph.remindBeforeTimeInMinutesType"/>
+        <Parameter Name="attendees" Type="Collection(graph.attendeeNotificationInfo)"/>
+      </Action>
+      <Action Name="sendVirtualAppointmentSms" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.onlineMeeting"/>
+        <Parameter Name="messageType" Type="graph.virtualAppointmentMessageType"/>
+        <Parameter Name="attendees" Type="Collection(graph.attendeeNotificationInfo)"/>
+      </Action>
       <Function Name="getVirtualAppointmentJoinWebUrl" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.onlineMeeting"/>
         <ReturnType Type="Edm.String" Unicode="false"/>
@@ -35690,44 +39785,6 @@
         <Parameter Name="incompatibleAccessPackageId" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="Collection(graph.accessPackageAssignment)"/>
       </Function>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.managedDeviceMobileAppConfiguration"/>
-        <Parameter Name="assignments" Type="Collection(graph.managedDeviceMobileAppConfigurationAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.mobileApp"/>
-        <Parameter Name="mobileAppAssignments" Type="Collection(graph.mobileAppAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.managedEBook"/>
-        <Parameter Name="managedEBookAssignments" Type="Collection(graph.managedEBookAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceCompliancePolicy"/>
-        <Parameter Name="assignments" Type="Collection(graph.deviceCompliancePolicyAssignment)"/>
-        <ReturnType Type="Collection(graph.deviceCompliancePolicyAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceConfiguration"/>
-        <Parameter Name="assignments" Type="Collection(graph.deviceConfigurationAssignment)"/>
-        <ReturnType Type="Collection(graph.deviceConfigurationAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceEnrollmentConfiguration"/>
-        <Parameter Name="enrollmentConfigurationAssignments" Type="Collection(graph.enrollmentConfigurationAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.targetedManagedAppConfiguration"/>
-        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.targetedManagedAppProtection"/>
-        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
-      </Action>
-      <Action Name="assign" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.windowsInformationProtection"/>
-        <Parameter Name="assignments" Type="Collection(graph.targetedManagedAppPolicyAssignment)"/>
-      </Action>
       <Action Name="commit" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.mobileAppContentFile"/>
         <Parameter Name="fileEncryptionInfo" Type="graph.fileEncryptionInfo"/>
@@ -35735,11 +39792,532 @@
       <Action Name="renewUpload" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.mobileAppContentFile"/>
       </Action>
-      <Function Name="getAuditActivityTypes" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Collection(graph.auditEvent)"/>
-        <Parameter Name="category" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Collection(Edm.String)" Unicode="false"/>
-      </Function>
+      <Action Name="retrieveDeviceAppInstallationStatusReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
+        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
+        <Parameter Name="skip" Type="Edm.Int32"/>
+        <Parameter Name="top" Type="Edm.Int32"/>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getCachedReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="id" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getCompliancePolicyNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getCompliancePolicyNonComplianceSummaryReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getComplianceSettingNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getConfigurationPolicyNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getConfigurationPolicyNonComplianceSummaryReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getConfigurationSettingNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getDeviceManagementIntentPerSettingContributingProfiles" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getDeviceManagementIntentSettingsReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getDeviceNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getDevicesWithoutCompliancePolicyReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getHistoricalReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getNoncompliantDevicesAndSettingsReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getPolicyNonComplianceMetadata" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getPolicyNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getPolicyNonComplianceSummaryReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getReportFilters" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
+      <Action Name="getSettingNonComplianceReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
+        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="search" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="skip" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="top" Type="Edm.Int32">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="sessionId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="filter" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Edm.Stream"/>
+      </Action>
       <Function Name="getAuditCategories" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.auditEvent)"/>
         <ReturnType Type="Collection(Edm.String)" Unicode="false"/>
@@ -35752,513 +40330,6 @@
         <Parameter Name="bindingParameter" Type="graph.deviceConfiguration"/>
         <Parameter Name="secretReferenceValueId" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="Edm.String" Unicode="false"/>
-      </Function>
-      <Function Name="deviceConfigurationDeviceActivity" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="deviceConfigurationUserActivity" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="managedDeviceEnrollmentFailureDetails" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="skipToken" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="managedDeviceEnrollmentTopFailures" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Function>
-      <Function Name="getEmailActivityCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailActivityUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailActivityUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailActivityUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailAppUsageAppsUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailAppUsageUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailAppUsageUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailAppUsageUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getEmailAppUsageVersionsUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getM365AppPlatformUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getM365AppUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getM365AppUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getM365AppUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getMailboxUsageDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getMailboxUsageMailboxCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getMailboxUsageQuotaStatusMailboxCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getMailboxUsageStorage" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActivationCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActivationsUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActivationsUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActiveUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ActiveUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityFileCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityGroupCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365GroupsActivityStorage" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOffice365ServicesUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveActivityFileCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveUsageAccountCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveUsageAccountDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveUsageFileCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getOneDriveUsageStorage" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointActivityFileCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointActivityPages" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsageDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsageFileCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsagePages" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsageSiteCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSharePointSiteUsageStorage" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessDeviceUsageUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessDeviceUsageUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessOrganizerActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessOrganizerActivityMinuteCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessOrganizerActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessParticipantActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessParticipantActivityMinuteCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessParticipantActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessPeerToPeerActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessPeerToPeerActivityMinuteCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getSkypeForBusinessPeerToPeerActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsDeviceUsageDistributionUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsDeviceUsageUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsDeviceUsageUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsTeamActivityCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsTeamActivityDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsTeamActivityDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsTeamActivityDistributionCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsTeamCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsUserActivityCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsUserActivityUserCounts" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsUserActivityUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getTeamsUserActivityUserDetail" IsBound="true">
-        <Parameter Name="reportRoot" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerActivityUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerActivityUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerDeviceUsageDistributionUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerDeviceUsageUserCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerDeviceUsageUserDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerGroupsActivityCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="date" Type="Edm.Date" Nullable="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerGroupsActivityDetail" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getYammerGroupsActivityGroupCounts" IsBound="true" IsComposable="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="period" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <ReturnType Type="Edm.Stream" Nullable="false"/>
-      </Function>
-      <Function Name="getGroupArchivedPrintJobs" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="groupId" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
-        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
-        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
-      </Function>
-      <Function Name="getPrinterArchivedPrintJobs" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="printerId" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
-        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
-        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
-      </Function>
-      <Function Name="getUserArchivedPrintJobs" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.reportRoot"/>
-        <Parameter Name="userId" Type="Edm.String" Nullable="false" Unicode="false"/>
-        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
-        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
-        <ReturnType Type="Collection(graph.archivedPrintJob)"/>
       </Function>
       <Action Name="setPriority" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.deviceEnrollmentConfiguration"/>
@@ -36422,241 +40493,14 @@
       <Action Name="disconnect" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.remoteAssistancePartner"/>
       </Action>
-      <Action Name="getCachedReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="id" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getCompliancePolicyNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getCompliancePolicyNonComplianceSummaryReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getComplianceSettingNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getConfigurationPolicyNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getConfigurationPolicyNonComplianceSummaryReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getConfigurationSettingNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getDeviceManagementIntentPerSettingContributingProfiles" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getDeviceManagementIntentSettingsReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getDeviceNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getDevicesWithoutCompliancePolicyReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getHistoricalReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getNoncompliantDevicesAndSettingsReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getPolicyNonComplianceMetadata" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getPolicyNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getPolicyNonComplianceSummaryReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getReportFilters" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
-      <Action Name="getSettingNonComplianceReport" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.deviceManagementReports"/>
-        <Parameter Name="name" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="select" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="search" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="groupBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="orderBy" Type="Collection(Edm.String)" Unicode="false"/>
-        <Parameter Name="skip" Type="Edm.Int32"/>
-        <Parameter Name="top" Type="Edm.Int32"/>
-        <Parameter Name="sessionId" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="filter" Type="Edm.String" Unicode="false"/>
-        <ReturnType Type="Edm.Stream"/>
-      </Action>
       <Action Name="archive" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.serviceUpdateMessage)"/>
         <Parameter Name="messageIds" Type="Collection(Edm.String)" Unicode="false"/>
         <ReturnType Type="Edm.Boolean"/>
+      </Action>
+      <Action Name="archive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.channel"/>
+        <Parameter Name="shouldSetSpoSiteReadOnlyForMembers" Type="Edm.Boolean"/>
       </Action>
       <Action Name="archive" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.team"/>
@@ -36681,6 +40525,9 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.serviceUpdateMessage)"/>
         <Parameter Name="messageIds" Type="Collection(Edm.String)" Unicode="false"/>
         <ReturnType Type="Edm.Boolean"/>
+      </Action>
+      <Action Name="unarchive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.channel"/>
       </Action>
       <Action Name="unarchive" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.team"/>
@@ -36849,6 +40696,13 @@
         <Parameter Name="reason" Type="graph.rejectReason"/>
         <Parameter Name="callbackUri" Type="Edm.String" Unicode="false"/>
       </Action>
+      <Action Name="sendDtmfTones" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.call"/>
+        <Parameter Name="tones" Type="Collection(graph.tone)" Nullable="false"/>
+        <Parameter Name="delayBetweenTonesMs" Type="Edm.Int32"/>
+        <Parameter Name="clientContext" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="graph.sendDtmfTonesOperation"/>
+      </Action>
       <Action Name="subscribeToTone" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.call"/>
         <Parameter Name="clientContext" Type="Edm.String" Unicode="false"/>
@@ -36871,6 +40725,10 @@
         <Parameter Name="status" Type="graph.recordingStatus" Nullable="false"/>
         <Parameter Name="clientContext" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.updateRecordingStatusOperation"/>
+      </Action>
+      <Action Name="setExternalEventInformation" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.virtualEvent"/>
+        <Parameter Name="externalEventId" Type="Edm.String" Unicode="false"/>
       </Action>
       <Action Name="clearPresence" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.presence"/>
@@ -36906,6 +40764,32 @@
         <Parameter Name="subject" Type="Edm.String" Unicode="false"/>
         <ReturnType Type="graph.onlineMeeting"/>
       </Action>
+      <Function Name="getAllRecordings" IsBound="true" EntitySetPath="bindingParameter/recordings" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.onlineMeeting)"/>
+        <Parameter Name="meetingOrganizerUserId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Collection(graph.callRecording)"/>
+      </Function>
+      <Function Name="getAllTranscripts" IsBound="true" EntitySetPath="bindingParameter/transcripts" IsComposable="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.onlineMeeting)"/>
+        <Parameter Name="meetingOrganizerUserId" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="startDateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <Parameter Name="endDateTime" Type="Edm.DateTimeOffset">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="Collection(graph.callTranscript)"/>
+      </Function>
       <Action Name="getPresencesByUserId" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.cloudCommunications"/>
         <Parameter Name="ids" Type="Collection(Edm.String)" Nullable="false" Unicode="false"/>
@@ -36927,10 +40811,21 @@
         <ReturnType Type="graph.stopHoldMusicOperation"/>
       </Action>
       <Function Name="getByUserIdAndRole" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.virtualEventTownhall)"/>
+        <Parameter Name="userId" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <Parameter Name="role" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Collection(graph.virtualEventTownhall)"/>
+      </Function>
+      <Function Name="getByUserIdAndRole" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.virtualEventWebinar)"/>
         <Parameter Name="userId" Type="Edm.String" Nullable="false" Unicode="false"/>
         <Parameter Name="role" Type="Edm.String" Nullable="false" Unicode="false"/>
         <ReturnType Type="Collection(graph.virtualEventWebinar)"/>
+      </Function>
+      <Function Name="getByUserRole" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.virtualEventTownhall)"/>
+        <Parameter Name="role" Type="Edm.String" Nullable="false" Unicode="false"/>
+        <ReturnType Type="Collection(graph.virtualEventTownhall)"/>
       </Function>
       <Function Name="getByUserRole" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.virtualEventWebinar)"/>
@@ -36951,46 +40846,11 @@
       <Action Name="reauthorize" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.subscription"/>
       </Action>
-      <Action Name="clone" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.team"/>
-        <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="description" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="mailNickname" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="classification" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="visibility" Type="graph.teamVisibilityType" Nullable="false"/>
-        <Parameter Name="partsToClone" Type="graph.clonableTeamParts" Nullable="false"/>
-      </Action>
-      <Action Name="completeMigration" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.team"/>
-      </Action>
       <Action Name="completeMigration" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.channel"/>
       </Action>
-      <Action Name="sendActivityNotification" IsBound="true">
+      <Action Name="completeMigration" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.team"/>
-        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
-        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="chainId" Type="Edm.Int64"/>
-        <Parameter Name="previewText" Type="graph.itemBody"/>
-        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
-        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
-      </Action>
-      <Action Name="sendActivityNotification" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.chat"/>
-        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
-        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="chainId" Type="Edm.Int64"/>
-        <Parameter Name="previewText" Type="graph.itemBody"/>
-        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
-        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
-      </Action>
-      <Action Name="sendActivityNotification" IsBound="true">
-        <Parameter Name="bindingParameter" Type="graph.userTeamwork"/>
-        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
-        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
-        <Parameter Name="chainId" Type="Edm.Int64"/>
-        <Parameter Name="previewText" Type="graph.itemBody"/>
-        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
       </Action>
       <Action Name="provisionEmail" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.channel"/>
@@ -37012,6 +40872,44 @@
         </Parameter>
         <ReturnType Type="Edm.Boolean" Nullable="false"/>
       </Function>
+      <Action Name="clone" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.team"/>
+        <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="description" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="mailNickname" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="classification" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="visibility" Type="graph.teamVisibilityType" Nullable="false"/>
+        <Parameter Name="partsToClone" Type="graph.clonableTeamParts" Nullable="false"/>
+      </Action>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.team"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
+        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
+        <Parameter Name="teamsAppId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
+        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
+      </Action>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.chat"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
+        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
+        <Parameter Name="teamsAppId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
+        <Parameter Name="recipient" Type="graph.teamworkNotificationRecipient"/>
+      </Action>
+      <Action Name="sendActivityNotification" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.userTeamwork"/>
+        <Parameter Name="topic" Type="graph.teamworkActivityTopic"/>
+        <Parameter Name="activityType" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="chainId" Type="Edm.Int64"/>
+        <Parameter Name="previewText" Type="graph.itemBody"/>
+        <Parameter Name="teamsAppId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="templateParameters" Type="Collection(graph.keyValuePair)"/>
+      </Action>
       <Action Name="hideForUser" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.chat"/>
         <Parameter Name="user" Type="graph.teamworkUserIdentity"/>
@@ -37053,6 +40951,9 @@
         <Parameter Name="bindingParameter" Type="graph.chatMessage"/>
         <Parameter Name="reactionType" Type="Edm.String" Unicode="false"/>
       </Action>
+      <Action Name="undoDelete" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.deletedChat"/>
+      </Action>
       <Action Name="upgrade" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.teamsAppInstallation"/>
         <Parameter Name="consentedPermissionSet" Type="graph.teamsAppPermissionSet"/>
@@ -37065,7 +40966,7 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.channel)"/>
         <ReturnType Type="Collection(graph.chatMessage)"/>
       </Function>
-      <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/messages">
+      <Function Name="getAllMessages" IsBound="true" EntitySetPath="bindingParameter/messages" IsComposable="true">
         <Parameter Name="bindingParameter" Type="Collection(graph.chat)"/>
         <ReturnType Type="Collection(graph.chatMessage)"/>
       </Function>
@@ -37073,9 +40974,49 @@
         <Parameter Name="bindingParameter" Type="Collection(graph.deletedTeam)"/>
         <ReturnType Type="Collection(graph.chatMessage)"/>
       </Function>
+      <Function Name="getAllRetainedMessages" IsBound="true" EntitySetPath="bindingParameter/messages">
+        <Parameter Name="bindingParameter" Type="Collection(graph.channel)"/>
+        <ReturnType Type="Collection(graph.chatMessage)"/>
+      </Function>
+      <Function Name="getAllRetainedMessages" IsBound="true" EntitySetPath="bindingParameter/messages">
+        <Parameter Name="bindingParameter" Type="Collection(graph.chat)"/>
+        <ReturnType Type="Collection(graph.chatMessage)"/>
+      </Function>
+      <Function Name="getTeamsLicensingDetails" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.licenseDetails)"/>
+        <ReturnType Type="graph.teamsLicensingDetails"/>
+      </Function>
       <Action Name="approve" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.scheduleChangeRequest"/>
         <Parameter Name="message" Type="Edm.String" Unicode="false"/>
+      </Action>
+      <Action Name="clockIn" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.timeCard)"/>
+        <Parameter Name="isAtApprovedLocation" Type="Edm.Boolean"/>
+        <Parameter Name="notes" Type="graph.itemBody"/>
+        <ReturnType Type="graph.timeCard"/>
+      </Action>
+      <Action Name="clockOut" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.timeCard"/>
+        <Parameter Name="isAtApprovedLocation" Type="Edm.Boolean"/>
+        <Parameter Name="notes" Type="graph.itemBody"/>
+        <ReturnType Type="graph.timeCard"/>
+      </Action>
+      <Action Name="confirm" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.timeCard"/>
+        <ReturnType Type="graph.timeCard"/>
+      </Action>
+      <Action Name="endBreak" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.timeCard"/>
+        <Parameter Name="isAtApprovedLocation" Type="Edm.Boolean"/>
+        <Parameter Name="notes" Type="graph.itemBody"/>
+        <ReturnType Type="graph.timeCard"/>
+      </Action>
+      <Action Name="startBreak" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.timeCard"/>
+        <Parameter Name="isAtApprovedLocation" Type="Edm.Boolean"/>
+        <Parameter Name="notes" Type="graph.itemBody"/>
+        <ReturnType Type="graph.timeCard"/>
       </Action>
       <Action Name="share" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.schedule"/>
@@ -37083,9 +41024,20 @@
         <Parameter Name="startDateTime" Type="Edm.DateTimeOffset"/>
         <Parameter Name="endDateTime" Type="Edm.DateTimeOffset"/>
       </Action>
+      <Action Name="stageForDeletion" IsBound="true">
+        <Parameter Name="bindingParameter" Type="graph.changeTrackedEntity"/>
+      </Action>
+      <Action Name="endWorkingTime" IsBound="true">
+        <Parameter Name="bindparameter" Type="graph.workingTimeSchedule" Nullable="false"/>
+      </Action>
+      <Action Name="startWorkingTime" IsBound="true">
+        <Parameter Name="bindparameter" Type="graph.workingTimeSchedule" Nullable="false"/>
+      </Action>
       <EntityContainer Name="GraphService">
+        <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject"/>
         <EntitySet Name="invitations" EntityType="microsoft.graph.invitation">
           <NavigationPropertyBinding Path="invitedUser" Target="users"/>
+          <NavigationPropertyBinding Path="invitedUserSponsors" Target="directoryObjects"/>
         </EntitySet>
         <EntitySet Name="users" EntityType="microsoft.graph.user">
           <NavigationPropertyBinding Path="createdObjects" Target="directoryObjects"/>
@@ -37096,6 +41048,7 @@
           <NavigationPropertyBinding Path="ownedDevices" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="ownedObjects" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="registeredDevices" Target="directoryObjects"/>
+          <NavigationPropertyBinding Path="sponsors" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects"/>
         </EntitySet>
         <EntitySet Name="applicationTemplates" EntityType="microsoft.graph.applicationTemplate"/>
@@ -37106,6 +41059,7 @@
           <NavigationPropertyBinding Path="createdOnBehalfOf" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="owners" Target="directoryObjects"/>
         </EntitySet>
+        <EntitySet Name="appRoleAssignments" EntityType="microsoft.graph.appRoleAssignment"/>
         <EntitySet Name="certificateBasedAuthConfiguration" EntityType="microsoft.graph.certificateBasedAuthConfiguration"/>
         <EntitySet Name="contacts" EntityType="microsoft.graph.orgContact">
           <NavigationPropertyBinding Path="directReports" Target="directoryObjects"/>
@@ -37119,7 +41073,6 @@
           <NavigationPropertyBinding Path="registeredUsers" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects"/>
         </EntitySet>
-        <EntitySet Name="directoryObjects" EntityType="microsoft.graph.directoryObject"/>
         <EntitySet Name="directoryRoles" EntityType="microsoft.graph.directoryRole">
           <NavigationPropertyBinding Path="members" Target="directoryObjects"/>
         </EntitySet>
@@ -37127,6 +41080,7 @@
         <EntitySet Name="domainDnsRecords" EntityType="microsoft.graph.domainDnsRecord"/>
         <EntitySet Name="domains" EntityType="microsoft.graph.domain">
           <NavigationPropertyBinding Path="domainNameReferences" Target="directoryObjects"/>
+          <NavigationPropertyBinding Path="rootDomain" Target="domains"/>
         </EntitySet>
         <EntitySet Name="groups" EntityType="microsoft.graph.group">
           <NavigationPropertyBinding Path="createdOnBehalfOf" Target="directoryObjects"/>
@@ -37177,7 +41131,15 @@
         <Singleton Name="auditLogs" Type="microsoft.graph.auditLogRoot"/>
         <Singleton Name="reports" Type="microsoft.graph.reportRoot"/>
         <Singleton Name="authenticationMethodsPolicy" Type="microsoft.graph.authenticationMethodsPolicy"/>
-        <Singleton Name="solutions" Type="microsoft.graph.solutionsRoot"/>
+        <Singleton Name="solutions" Type="microsoft.graph.solutionsRoot">
+          <NavigationPropertyBinding Path="backupRestore/exchangeProtectionPolicies/mailboxInclusionRules" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/mailboxInclusionRules"/>
+          <NavigationPropertyBinding Path="backupRestore/exchangeProtectionPolicies/mailboxProtectionUnits" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/mailboxProtectionUnits"/>
+          <NavigationPropertyBinding Path="backupRestore/oneDriveForBusinessProtectionPolicies/driveInclusionRules" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/driveInclusionRules"/>
+          <NavigationPropertyBinding Path="backupRestore/oneDriveForBusinessProtectionPolicies/driveProtectionUnits" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/driveProtectionUnits"/>
+          <NavigationPropertyBinding Path="backupRestore/sharePointProtectionPolicies/siteInclusionRules" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/siteInclusionRules"/>
+          <NavigationPropertyBinding Path="backupRestore/sharePointProtectionPolicies/siteProtectionUnits" Target="solutions/microsoft.graph.backupRestoreRoot/backupRestore/siteProtectionUnits"/>
+        </Singleton>
+        <Singleton Name="deviceManagement" Type="microsoft.graph.deviceManagement"/>
         <Singleton Name="privacy" Type="microsoft.graph.privacy"/>
         <Singleton Name="security" Type="microsoft.graph.security">
           <NavigationPropertyBinding Path="threatIntelligence/hosts/childHostPairs" Target="security/microsoft.graph.security.threatIntelligence/threatIntelligence/hostPairs"/>
@@ -37207,6 +41169,7 @@
           <NavigationPropertyBinding Path="ownedDevices" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="ownedObjects" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="registeredDevices" Target="directoryObjects"/>
+          <NavigationPropertyBinding Path="sponsors" Target="directoryObjects"/>
           <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects"/>
         </Singleton>
         <Singleton Name="policies" Type="microsoft.graph.policyRoot"/>
@@ -37231,10 +41194,10 @@
         </Singleton>
         <Singleton Name="roleManagement" Type="microsoft.graph.roleManagement"/>
         <Singleton Name="drive" Type="microsoft.graph.drive"/>
+        <Singleton Name="storage" Type="microsoft.graph.storage"/>
         <Singleton Name="communications" Type="microsoft.graph.cloudCommunications"/>
         <Singleton Name="identityProtection" Type="microsoft.graph.identityProtectionRoot"/>
         <Singleton Name="deviceAppManagement" Type="microsoft.graph.deviceAppManagement"/>
-        <Singleton Name="deviceManagement" Type="microsoft.graph.deviceManagement"/>
         <Singleton Name="search" Type="microsoft.graph.searchEntity"/>
         <Singleton Name="planner" Type="microsoft.graph.planner">
           <NavigationPropertyBinding Path="buckets/tasks" Target="planner/tasks"/>
@@ -37255,6 +41218,15 @@
         <Member Name="linkedFiles" Value="2"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
+      <EnumType Name="additionalOptions" IsFlags="true">
+        <Member Name="none" Value="0"/>
+        <Member Name="teamsAndYammerConversations" Value="1"/>
+        <Member Name="cloudAttachments" Value="2"/>
+        <Member Name="allDocumentVersions" Value="4"/>
+        <Member Name="subfolderContents" Value="8"/>
+        <Member Name="listAttachments" Value="16"/>
+        <Member Name="unknownFutureValue" Value="32"/>
+      </EnumType>
       <EnumType Name="caseAction">
         <Member Name="contentExport" Value="0"/>
         <Member Name="applyTags" Value="1"/>
@@ -37265,6 +41237,8 @@
         <Member Name="holdUpdate" Value="6"/>
         <Member Name="unknownFutureValue" Value="7"/>
         <Member Name="purgeData" Value="8"/>
+        <Member Name="exportReport" Value="9"/>
+        <Member Name="exportResult" Value="10"/>
       </EnumType>
       <EnumType Name="caseOperationStatus">
         <Member Name="notStarted" Value="0"/>
@@ -37310,11 +41284,27 @@
         <Member Name="allCaseNoncustodialDataSources" Value="8"/>
         <Member Name="unknownFutureValue" Value="16"/>
       </EnumType>
+      <EnumType Name="exportCriteria" IsFlags="true">
+        <Member Name="searchHits" Value="1"/>
+        <Member Name="partiallyIndexed" Value="2"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
       <EnumType Name="exportFileStructure">
         <Member Name="none" Value="0"/>
         <Member Name="directory" Value="1"/>
         <Member Name="pst" Value="2"/>
         <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="exportFormat">
+        <Member Name="pst" Value="0"/>
+        <Member Name="msg" Value="1"/>
+        <Member Name="eml" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="exportLocation" IsFlags="true">
+        <Member Name="responsiveLocations" Value="1"/>
+        <Member Name="nonresponsiveLocations" Value="2"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="exportOptions" IsFlags="true">
         <Member Name="originalFiles" Value="1"/>
@@ -37330,13 +41320,57 @@
       </EnumType>
       <EnumType Name="purgeType">
         <Member Name="recoverable" Value="0"/>
-        <Member Name="permanentlyDeleted" Value="1"/>
-        <Member Name="unknownFutureValue" Value="2"/>
+        <Member Name="unknownFutureValue" Value="1"/>
+        <Member Name="permanentlyDelete" Value="2"/>
       </EnumType>
       <EnumType Name="sourceType" IsFlags="true">
         <Member Name="mailbox" Value="1"/>
         <Member Name="site" Value="2"/>
         <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="deploymentStatus">
+        <Member Name="upToDate" Value="1"/>
+        <Member Name="outdated" Value="2"/>
+        <Member Name="updating" Value="3"/>
+        <Member Name="updateFailed" Value="4"/>
+        <Member Name="notConfigured" Value="5"/>
+        <Member Name="unreachable" Value="6"/>
+        <Member Name="disconnected" Value="7"/>
+        <Member Name="startFailure" Value="8"/>
+        <Member Name="syncing" Value="9"/>
+        <Member Name="unknownFutureValue" Value="10"/>
+      </EnumType>
+      <EnumType Name="healthIssueSeverity">
+        <Member Name="low" Value="1"/>
+        <Member Name="medium" Value="2"/>
+        <Member Name="high" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="healthIssueStatus">
+        <Member Name="open" Value="1"/>
+        <Member Name="closed" Value="2"/>
+        <Member Name="suppressed" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="healthIssueType">
+        <Member Name="sensor" Value="1"/>
+        <Member Name="global" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="sensorHealthStatus">
+        <Member Name="healthy" Value="1"/>
+        <Member Name="notHealthyLow" Value="2"/>
+        <Member Name="notHealthyMedium" Value="3"/>
+        <Member Name="notHealthyHigh" Value="4"/>
+        <Member Name="unknownFutureValue" Value="5"/>
+      </EnumType>
+      <EnumType Name="sensorType">
+        <Member Name="adConnectIntegrated" Value="1"/>
+        <Member Name="adcsIntegrated" Value="2"/>
+        <Member Name="adfsIntegrated" Value="3"/>
+        <Member Name="domainControllerIntegrated" Value="4"/>
+        <Member Name="domainControllerStandalone" Value="5"/>
+        <Member Name="unknownFutureValue" Value="6"/>
       </EnumType>
       <EnumType Name="behaviorDuringRetentionPeriod">
         <Member Name="doNotRetain" Value="0"/>
@@ -37383,6 +41417,13 @@
         <Member Name="new" Value="2"/>
         <Member Name="inProgress" Value="4"/>
         <Member Name="resolved" Value="8"/>
+        <Member Name="unknownFutureValue" Value="31"/>
+      </EnumType>
+      <EnumType Name="antispamTeamsDirection">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="inbound" Value="1"/>
+        <Member Name="outbound" Value="2"/>
+        <Member Name="intraorg" Value="3"/>
         <Member Name="unknownFutureValue" Value="31"/>
       </EnumType>
       <EnumType Name="containerPortProtocol">
@@ -37435,6 +41476,7 @@
         <Member Name="scheduledAlerts" Value="1073741845"/>
         <Member Name="microsoftDefenderThreatIntelligenceAnalytics" Value="1073741846"/>
         <Member Name="builtInMl" Value="1073741847"/>
+        <Member Name="microsoftInsiderRiskManagement" Value="1073741848"/>
         <Member Name="microsoftSentinel" Value="268435456"/>
       </EnumType>
       <EnumType Name="detectionStatus">
@@ -37467,6 +41509,12 @@
         <Member Name="blocked" Value="3"/>
         <Member Name="notFound" Value="4"/>
         <Member Name="unknownFutureValue" Value="5"/>
+        <Member Name="active" Value="6"/>
+        <Member Name="pendingApproval" Value="7"/>
+        <Member Name="declined" Value="8"/>
+        <Member Name="unremediated" Value="9"/>
+        <Member Name="running" Value="10"/>
+        <Member Name="partiallyRemediated" Value="11"/>
       </EnumType>
       <EnumType Name="evidenceRole">
         <Member Name="unknown" Value="0"/>
@@ -37516,6 +41564,13 @@
         <Member Name="unknownFutureValue" Value="127"/>
         <Member Name="awaitingAction" Value="128"/>
       </EnumType>
+      <EnumType Name="ioTDeviceImportanceType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="low" Value="1"/>
+        <Member Name="normal" Value="2"/>
+        <Member Name="high" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
       <EnumType Name="kubernetesPlatform">
         <Member Name="unknown" Value="0"/>
         <Member Name="aks" Value="1"/>
@@ -37532,12 +41587,32 @@
         <Member Name="loadBalancer" Value="4"/>
         <Member Name="unknownFutureValue" Value="31"/>
       </EnumType>
+      <EnumType Name="mailboxConfigurationType">
+        <Member Name="mailForwardingRule" Value="0"/>
+        <Member Name="owaSettings" Value="1"/>
+        <Member Name="ewsSettings" Value="2"/>
+        <Member Name="mailDelegation" Value="3"/>
+        <Member Name="userInboxRule" Value="4"/>
+        <Member Name="unknownFutureValue" Value="31"/>
+      </EnumType>
       <EnumType Name="onboardingStatus">
         <Member Name="insufficientInfo" Value="0"/>
         <Member Name="onboarded" Value="1"/>
         <Member Name="canBeOnboarded" Value="2"/>
         <Member Name="unsupported" Value="3"/>
         <Member Name="unknownFutureValue" Value="31"/>
+      </EnumType>
+      <EnumType Name="protocolType">
+        <Member Name="tcp" Value="0"/>
+        <Member Name="udp" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
+      </EnumType>
+      <EnumType Name="servicePrincipalType">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="application" Value="1"/>
+        <Member Name="managedIdentity" Value="2"/>
+        <Member Name="legacy" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>
       <EnumType Name="serviceSource">
         <Member Name="unknown" Value="0"/>
@@ -37552,11 +41627,39 @@
         <Member Name="unknownFutureValue" Value="255"/>
         <Member Name="microsoftDefenderForCloud" Value="256"/>
         <Member Name="microsoftSentinel" Value="512"/>
+        <Member Name="microsoftInsiderRiskManagement" Value="1024"/>
+      </EnumType>
+      <EnumType Name="teamsDeliveryLocation">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="teams" Value="1"/>
+        <Member Name="quarantine" Value="2"/>
+        <Member Name="failed" Value="3"/>
+        <Member Name="unknownFutureValue" Value="31"/>
+      </EnumType>
+      <EnumType Name="teamsMessageDeliveryAction">
+        <Member Name="unknown" Value="0"/>
+        <Member Name="deliveredAsSpam" Value="1"/>
+        <Member Name="delivered" Value="2"/>
+        <Member Name="blocked" Value="3"/>
+        <Member Name="replaced" Value="4"/>
+        <Member Name="unknownFutureValue" Value="31"/>
       </EnumType>
       <EnumType Name="vmCloudProvider">
         <Member Name="unknown" Value="0"/>
         <Member Name="azure" Value="1"/>
         <Member Name="unknownFutureValue" Value="15"/>
+      </EnumType>
+      <EnumType Name="actionAfterRetentionPeriod">
+        <Member Name="none" Value="0"/>
+        <Member Name="delete" Value="1"/>
+        <Member Name="startDispositionReview" Value="2"/>
+        <Member Name="relabel" Value="3"/>
+        <Member Name="unknownFutureValue" Value="4"/>
+      </EnumType>
+      <EnumType Name="defaultRecordBehavior">
+        <Member Name="startLocked" Value="0"/>
+        <Member Name="startUnlocked" Value="1"/>
+        <Member Name="unknownFutureValue" Value="2"/>
       </EnumType>
       <EnumType Name="eventPropagationStatus">
         <Member Name="none" Value="0"/>
@@ -37645,6 +41748,10 @@
       <EntityType Name="casesRoot" BaseType="graph.entity">
         <NavigationProperty Name="ediscoveryCases" Type="Collection(microsoft.graph.security.ediscoveryCase)" ContainsTarget="true"/>
       </EntityType>
+      <EntityType Name="identityContainer" BaseType="graph.entity">
+        <NavigationProperty Name="healthIssues" Type="Collection(microsoft.graph.security.healthIssue)" ContainsTarget="true"/>
+        <NavigationProperty Name="sensors" Type="Collection(microsoft.graph.security.sensor)" ContainsTarget="true"/>
+      </EntityType>
       <EntityType Name="alert" BaseType="graph.entity">
         <Property Name="actorDisplayName" Type="Edm.String"/>
         <Property Name="additionalData" Type="microsoft.graph.security.dictionary"/>
@@ -37673,6 +41780,7 @@
         <Property Name="serviceSource" Type="microsoft.graph.security.serviceSource" Nullable="false"/>
         <Property Name="severity" Type="microsoft.graph.security.alertSeverity" Nullable="false"/>
         <Property Name="status" Type="microsoft.graph.security.alertStatus" Nullable="false"/>
+        <Property Name="systemTags" Type="Collection(Edm.String)"/>
         <Property Name="tenantId" Type="Edm.String"/>
         <Property Name="threatDisplayName" Type="Edm.String"/>
         <Property Name="threatFamilyName" Type="Edm.String"/>
@@ -37691,11 +41799,21 @@
         <Property Name="lastModifiedBy" Type="Edm.String"/>
         <Property Name="lastUpdateDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="redirectIncidentId" Type="Edm.String"/>
+        <Property Name="resolvingComment" Type="Edm.String"/>
         <Property Name="severity" Type="microsoft.graph.security.alertSeverity" Nullable="false"/>
         <Property Name="status" Type="microsoft.graph.security.incidentStatus" Nullable="false"/>
+        <Property Name="summary" Type="Edm.String"/>
         <Property Name="systemTags" Type="Collection(Edm.String)"/>
         <Property Name="tenantId" Type="Edm.String"/>
         <NavigationProperty Name="alerts" Type="Collection(microsoft.graph.security.alert)"/>
+      </EntityType>
+      <EntityType Name="labelsRoot" BaseType="graph.entity">
+        <NavigationProperty Name="authorities" Type="Collection(microsoft.graph.security.authorityTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="categories" Type="Collection(microsoft.graph.security.categoryTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="citations" Type="Collection(microsoft.graph.security.citationTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="departments" Type="Collection(microsoft.graph.security.departmentTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="filePlanReferences" Type="Collection(microsoft.graph.security.filePlanReferenceTemplate)" ContainsTarget="true"/>
+        <NavigationProperty Name="retentionLabels" Type="Collection(microsoft.graph.security.retentionLabel)" ContainsTarget="true"/>
       </EntityType>
       <EntityType Name="triggersRoot" BaseType="graph.entity">
         <NavigationProperty Name="retentionEvents" Type="Collection(microsoft.graph.security.retentionEvent)" ContainsTarget="true"/>
@@ -37777,6 +41895,7 @@
       <EntityType Name="dataSet" BaseType="graph.entity" Abstract="true">
         <Property Name="createdBy" Type="graph.identitySet"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="description" Type="Edm.String"/>
         <Property Name="displayName" Type="Edm.String"/>
       </EntityType>
       <EntityType Name="dataSource" BaseType="graph.entity" Abstract="true">
@@ -37879,7 +41998,62 @@
       <EntityType Name="ediscoveryReviewSetQuery" BaseType="microsoft.graph.security.search"/>
       <EntityType Name="ediscoveryHoldOperation" BaseType="microsoft.graph.security.caseOperation"/>
       <EntityType Name="ediscoveryPurgeDataOperation" BaseType="microsoft.graph.security.caseOperation"/>
+      <EntityType Name="ediscoverySearchExportOperation" BaseType="microsoft.graph.security.caseOperation">
+        <Property Name="additionalOptions" Type="microsoft.graph.security.additionalOptions"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="exportCriteria" Type="microsoft.graph.security.exportCriteria"/>
+        <Property Name="exportFileMetadata" Type="Collection(microsoft.graph.security.exportFileMetadata)"/>
+        <Property Name="exportFormat" Type="microsoft.graph.security.exportFormat"/>
+        <Property Name="exportLocation" Type="microsoft.graph.security.exportLocation"/>
+        <Property Name="exportSingleItems" Type="Edm.Boolean"/>
+        <NavigationProperty Name="search" Type="microsoft.graph.security.ediscoverySearch"/>
+      </EntityType>
       <EntityType Name="ediscoveryTagOperation" BaseType="microsoft.graph.security.caseOperation"/>
+      <ComplexType Name="deploymentAccessKeyType">
+        <Property Name="deploymentAccessKey" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="sensorDeploymentPackage">
+        <Property Name="downloadUrl" Type="Edm.String" Nullable="false"/>
+        <Property Name="version" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="sensorSettings">
+        <Property Name="description" Type="Edm.String" Nullable="false"/>
+        <Property Name="domainControllerDnsNames" Type="Collection(Edm.String)"/>
+        <Property Name="isDelayedDeploymentEnabled" Type="Edm.Boolean"/>
+        <NavigationProperty Name="networkAdapters" Type="Collection(microsoft.graph.security.networkAdapter)" ContainsTarget="true"/>
+      </ComplexType>
+      <EntityType Name="networkAdapter" BaseType="graph.entity">
+        <Property Name="isEnabled" Type="Edm.Boolean"/>
+        <Property Name="name" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="healthIssue" BaseType="graph.entity">
+        <Property Name="additionalInformation" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="description" Type="Edm.String" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="domainNames" Type="Collection(Edm.String)"/>
+        <Property Name="healthIssueType" Type="microsoft.graph.security.healthIssueType"/>
+        <Property Name="issueTypeId" Type="Edm.String"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="recommendations" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="recommendedActionCommands" Type="Collection(Edm.String)" Nullable="false"/>
+        <Property Name="sensorDNSNames" Type="Collection(Edm.String)"/>
+        <Property Name="severity" Type="microsoft.graph.security.healthIssueSeverity"/>
+        <Property Name="status" Type="microsoft.graph.security.healthIssueStatus"/>
+      </EntityType>
+      <EntityType Name="sensor" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="deploymentStatus" Type="microsoft.graph.security.deploymentStatus" Nullable="false"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="domainName" Type="Edm.String" Nullable="false"/>
+        <Property Name="healthStatus" Type="microsoft.graph.security.sensorHealthStatus" Nullable="false"/>
+        <Property Name="openHealthIssuesCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="sensorType" Type="microsoft.graph.security.sensorType" Nullable="false"/>
+        <Property Name="settings" Type="microsoft.graph.security.sensorSettings" Nullable="false"/>
+        <Property Name="version" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="healthIssues" Type="Collection(microsoft.graph.security.healthIssue)"/>
+      </EntityType>
       <ComplexType Name="alertComment">
         <Property Name="comment" Type="Edm.String"/>
         <Property Name="createdByDisplayName" Type="Edm.String"/>
@@ -37952,6 +42126,28 @@
         <Property Name="instanceId" Type="Edm.Int64"/>
         <Property Name="instanceName" Type="Edm.String"/>
         <Property Name="saasAppId" Type="Edm.Int64"/>
+        <Property Name="stream" Type="microsoft.graph.security.stream"/>
+      </ComplexType>
+      <ComplexType Name="stream">
+        <Property Name="name" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudLogonRequestEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="requestId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="cloudLogonSessionEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="account" Type="microsoft.graph.security.userEvidence"/>
+        <Property Name="browser" Type="Edm.String"/>
+        <Property Name="deviceName" Type="Edm.String"/>
+        <Property Name="operatingSystem" Type="Edm.String"/>
+        <Property Name="previousLogonDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="protocol" Type="Edm.String"/>
+        <Property Name="sessionId" Type="Edm.String"/>
+        <Property Name="startUtcDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="userAgent" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="userEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="stream" Type="microsoft.graph.security.stream"/>
+        <Property Name="userAccount" Type="microsoft.graph.security.userAccount"/>
       </ComplexType>
       <ComplexType Name="containerEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="args" Type="Collection(Edm.String)"/>
@@ -37985,11 +42181,16 @@
         <Property Name="azureAdDeviceId" Type="Edm.String"/>
         <Property Name="defenderAvStatus" Type="microsoft.graph.security.defenderAvStatus"/>
         <Property Name="deviceDnsName" Type="Edm.String"/>
+        <Property Name="dnsDomain" Type="Edm.String"/>
         <Property Name="firstSeenDateTime" Type="Edm.DateTimeOffset"/>
         <Property Name="healthStatus" Type="microsoft.graph.security.deviceHealthStatus"/>
+        <Property Name="hostName" Type="Edm.String"/>
         <Property Name="ipInterfaces" Type="Collection(Edm.String)"/>
+        <Property Name="lastExternalIpAddress" Type="Edm.String"/>
+        <Property Name="lastIpAddress" Type="Edm.String"/>
         <Property Name="loggedOnUsers" Type="Collection(microsoft.graph.security.loggedOnUser)"/>
         <Property Name="mdeDeviceId" Type="Edm.String"/>
+        <Property Name="ntDomain" Type="Edm.String"/>
         <Property Name="onboardingStatus" Type="microsoft.graph.security.onboardingStatus"/>
         <Property Name="osBuild" Type="Edm.Int64"/>
         <Property Name="osPlatform" Type="Edm.String"/>
@@ -38010,6 +42211,18 @@
         <Property Name="vmId" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="dictionary" OpenType="true"/>
+      <ComplexType Name="dnsEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="dnsServerIp" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="domainName" Type="Edm.String"/>
+        <Property Name="hostIpAddress" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="ipAddresses" Type="Collection(microsoft.graph.security.ipEvidence)"/>
+      </ComplexType>
+      <ComplexType Name="ipEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="countryLetterCode" Type="Edm.String"/>
+        <Property Name="ipAddress" Type="Edm.String"/>
+        <Property Name="location" Type="microsoft.graph.security.geoLocation"/>
+        <Property Name="stream" Type="microsoft.graph.security.stream"/>
+      </ComplexType>
       <ComplexType Name="dynamicColumnValue" OpenType="true"/>
       <ComplexType Name="fileDetails">
         <Property Name="fileName" Type="Edm.String"/>
@@ -38026,13 +42239,54 @@
         <Property Name="fileDetails" Type="microsoft.graph.security.fileDetails"/>
         <Property Name="mdeDeviceId" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="fileHashEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="algorithm" Type="microsoft.graph.security.fileHashAlgorithm" Nullable="false"/>
+        <Property Name="value" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="geoLocation">
+        <Property Name="city" Type="Edm.String"/>
+        <Property Name="countryName" Type="Edm.String"/>
+        <Property Name="latitude" Type="Edm.Double"/>
+        <Property Name="longitude" Type="Edm.Double"/>
+        <Property Name="state" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="gitHubOrganizationEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="company" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="email" Type="Edm.String"/>
+        <Property Name="login" Type="Edm.String"/>
+        <Property Name="orgId" Type="Edm.String"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="gitHubRepoEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="baseUrl" Type="Edm.String"/>
+        <Property Name="login" Type="Edm.String"/>
+        <Property Name="owner" Type="Edm.String"/>
+        <Property Name="ownerType" Type="Edm.String"/>
+        <Property Name="repoId" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="gitHubUserEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="email" Type="Edm.String"/>
+        <Property Name="login" Type="Edm.String"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="userId" Type="Edm.String"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="googleCloudResourceEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="fullResourceName" Type="Edm.String"/>
         <Property Name="location" Type="Edm.String"/>
         <Property Name="locationType" Type="microsoft.graph.security.googleCloudLocationType"/>
         <Property Name="projectId" Type="Edm.String"/>
         <Property Name="projectNumber" Type="Edm.Int64"/>
         <Property Name="resourceName" Type="Edm.String"/>
         <Property Name="resourceType" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="hostLogonSessionEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="account" Type="microsoft.graph.security.userEvidence"/>
+        <Property Name="endUtcDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="host" Type="microsoft.graph.security.deviceEvidence"/>
+        <Property Name="sessionId" Type="Edm.String"/>
+        <Property Name="startUtcDateTime" Type="Edm.DateTimeOffset"/>
       </ComplexType>
       <ComplexType Name="huntingQueryResults">
         <Property Name="results" Type="Collection(microsoft.graph.security.huntingRowResult)"/>
@@ -38043,9 +42297,41 @@
         <Property Name="name" Type="Edm.String"/>
         <Property Name="type" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="ipEvidence" BaseType="microsoft.graph.security.alertEvidence">
-        <Property Name="countryLetterCode" Type="Edm.String"/>
-        <Property Name="ipAddress" Type="Edm.String"/>
+      <ComplexType Name="ioTDeviceEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="deviceId" Type="Edm.String"/>
+        <Property Name="deviceName" Type="Edm.String"/>
+        <Property Name="devicePageLink" Type="Edm.String"/>
+        <Property Name="deviceSubType" Type="Edm.String"/>
+        <Property Name="deviceType" Type="Edm.String"/>
+        <Property Name="importance" Type="microsoft.graph.security.ioTDeviceImportanceType"/>
+        <Property Name="ioTHub" Type="microsoft.graph.security.azureResourceEvidence"/>
+        <Property Name="ioTSecurityAgentId" Type="Edm.String"/>
+        <Property Name="ipAddress" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="isAuthorized" Type="Edm.Boolean"/>
+        <Property Name="isProgramming" Type="Edm.Boolean"/>
+        <Property Name="isScanner" Type="Edm.Boolean"/>
+        <Property Name="macAddress" Type="Edm.String"/>
+        <Property Name="manufacturer" Type="Edm.String"/>
+        <Property Name="model" Type="Edm.String"/>
+        <Property Name="nics" Type="Collection(microsoft.graph.security.nicEvidence)"/>
+        <Property Name="operatingSystem" Type="Edm.String"/>
+        <Property Name="owners" Type="Collection(Edm.String)"/>
+        <Property Name="protocols" Type="Collection(Edm.String)"/>
+        <Property Name="purdueLayer" Type="Edm.String"/>
+        <Property Name="sensor" Type="Edm.String"/>
+        <Property Name="serialNumber" Type="Edm.String"/>
+        <Property Name="site" Type="Edm.String"/>
+        <Property Name="source" Type="Edm.String"/>
+        <Property Name="sourceRef" Type="microsoft.graph.security.urlEvidence"/>
+        <Property Name="zone" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="nicEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="ipAddress" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="macAddress" Type="Edm.String"/>
+        <Property Name="vlans" Type="Collection(Edm.String)"/>
+      </ComplexType>
+      <ComplexType Name="urlEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="url" Type="Edm.String"/>
       </ComplexType>
       <ComplexType Name="kubernetesClusterEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="cloudResource" Type="microsoft.graph.security.alertEvidence"/>
@@ -38092,9 +42378,18 @@
         <Property Name="protocol" Type="microsoft.graph.security.containerPortProtocol"/>
         <Property Name="targetPort" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="mailboxConfigurationEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="configurationId" Type="Edm.String"/>
+        <Property Name="configurationType" Type="microsoft.graph.security.mailboxConfigurationType"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="externalDirectoryObjectId" Type="Edm.Guid"/>
+        <Property Name="mailboxPrimaryAddress" Type="Edm.String"/>
+        <Property Name="upn" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="mailboxEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="primaryAddress" Type="Edm.String"/>
+        <Property Name="upn" Type="Edm.String"/>
         <Property Name="userAccount" Type="microsoft.graph.security.userAccount"/>
       </ComplexType>
       <ComplexType Name="userAccount">
@@ -38113,11 +42408,11 @@
         <Property Name="query" Type="Edm.String"/>
         <Property Name="urn" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="oauthApplicationEvidence" BaseType="microsoft.graph.security.alertEvidence">
-        <Property Name="appId" Type="Edm.String"/>
-        <Property Name="displayName" Type="Edm.String"/>
-        <Property Name="objectId" Type="Edm.String"/>
-        <Property Name="publisher" Type="Edm.String"/>
+      <ComplexType Name="malwareEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="category" Type="Edm.String"/>
+        <Property Name="files" Type="Collection(microsoft.graph.security.fileEvidence)"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="processes" Type="Collection(microsoft.graph.security.processEvidence)"/>
       </ComplexType>
       <ComplexType Name="processEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="detectionStatus" Type="microsoft.graph.security.detectionStatus"/>
@@ -38131,6 +42426,19 @@
         <Property Name="processId" Type="Edm.Int64"/>
         <Property Name="userAccount" Type="microsoft.graph.security.userAccount"/>
       </ComplexType>
+      <ComplexType Name="networkConnectionEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="destinationAddress" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="destinationPort" Type="Edm.Int32"/>
+        <Property Name="protocol" Type="microsoft.graph.security.protocolType"/>
+        <Property Name="sourceAddress" Type="microsoft.graph.security.ipEvidence"/>
+        <Property Name="sourcePort" Type="Edm.Int32"/>
+      </ComplexType>
+      <ComplexType Name="oauthApplicationEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="appId" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="objectId" Type="Edm.String"/>
+        <Property Name="publisher" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="registryKeyEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="registryHive" Type="Edm.String"/>
         <Property Name="registryKey" Type="Edm.String"/>
@@ -38143,15 +42451,66 @@
         <Property Name="registryValueName" Type="Edm.String"/>
         <Property Name="registryValueType" Type="Edm.String"/>
       </ComplexType>
+      <ComplexType Name="sasTokenEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="allowedIpAddresses" Type="Edm.String"/>
+        <Property Name="allowedResourceTypes" Type="Collection(Edm.String)"/>
+        <Property Name="allowedServices" Type="Collection(Edm.String)"/>
+        <Property Name="expiryDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="permissions" Type="Collection(Edm.String)"/>
+        <Property Name="protocol" Type="Edm.String"/>
+        <Property Name="signatureHash" Type="Edm.String"/>
+        <Property Name="signedWith" Type="Edm.String"/>
+        <Property Name="startDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="storageResource" Type="microsoft.graph.security.azureResourceEvidence"/>
+      </ComplexType>
       <ComplexType Name="securityGroupEvidence" BaseType="microsoft.graph.security.alertEvidence">
         <Property Name="displayName" Type="Edm.String"/>
         <Property Name="securityGroupId" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="urlEvidence" BaseType="microsoft.graph.security.alertEvidence">
-        <Property Name="url" Type="Edm.String"/>
+      <ComplexType Name="servicePrincipalEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="appId" Type="Edm.String"/>
+        <Property Name="appOwnerTenantId" Type="Edm.String"/>
+        <Property Name="servicePrincipalName" Type="Edm.String"/>
+        <Property Name="servicePrincipalObjectId" Type="Edm.String"/>
+        <Property Name="servicePrincipalType" Type="microsoft.graph.security.servicePrincipalType"/>
+        <Property Name="tenantId" Type="Edm.String"/>
       </ComplexType>
-      <ComplexType Name="userEvidence" BaseType="microsoft.graph.security.alertEvidence">
-        <Property Name="userAccount" Type="microsoft.graph.security.userAccount"/>
+      <ComplexType Name="submissionMailEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="networkMessageId" Type="Edm.String"/>
+        <Property Name="recipient" Type="Edm.String"/>
+        <Property Name="reportType" Type="Edm.String"/>
+        <Property Name="sender" Type="Edm.String"/>
+        <Property Name="senderIp" Type="Edm.String"/>
+        <Property Name="subject" Type="Edm.String"/>
+        <Property Name="submissionDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="submissionId" Type="Edm.String"/>
+        <Property Name="submitter" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="teamsMessageEvidence" BaseType="microsoft.graph.security.alertEvidence">
+        <Property Name="campaignId" Type="Edm.String"/>
+        <Property Name="channelId" Type="Edm.String"/>
+        <Property Name="deliveryAction" Type="microsoft.graph.security.teamsMessageDeliveryAction"/>
+        <Property Name="deliveryLocation" Type="microsoft.graph.security.teamsDeliveryLocation"/>
+        <Property Name="files" Type="Collection(microsoft.graph.security.fileEvidence)"/>
+        <Property Name="groupId" Type="Edm.String"/>
+        <Property Name="isExternal" Type="Edm.Boolean"/>
+        <Property Name="isOwned" Type="Edm.Boolean"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="messageDirection" Type="microsoft.graph.security.antispamTeamsDirection"/>
+        <Property Name="messageId" Type="Edm.String"/>
+        <Property Name="owningTenantId" Type="Edm.Guid"/>
+        <Property Name="parentMessageId" Type="Edm.String"/>
+        <Property Name="receivedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="recipients" Type="Collection(Edm.String)"/>
+        <Property Name="senderFromAddress" Type="Edm.String"/>
+        <Property Name="senderIP" Type="Edm.String"/>
+        <Property Name="sourceAppName" Type="Edm.String"/>
+        <Property Name="sourceId" Type="Edm.String"/>
+        <Property Name="subject" Type="Edm.String"/>
+        <Property Name="suspiciousRecipients" Type="Collection(Edm.String)"/>
+        <Property Name="threadId" Type="Edm.String"/>
+        <Property Name="threadType" Type="Edm.String"/>
+        <Property Name="urls" Type="Collection(microsoft.graph.security.urlEvidence)"/>
       </ComplexType>
       <ComplexType Name="eventPropagationResult">
         <Property Name="location" Type="Edm.String"/>
@@ -38163,10 +42522,84 @@
         <Property Name="query" Type="Edm.String" Nullable="false"/>
         <Property Name="queryType" Type="microsoft.graph.security.queryType"/>
       </ComplexType>
+      <ComplexType Name="filePlanDescriptorBase">
+        <Property Name="displayName" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="filePlanAppliedCategory" BaseType="microsoft.graph.security.filePlanDescriptorBase">
+        <Property Name="subcategory" Type="microsoft.graph.security.filePlanSubcategory"/>
+      </ComplexType>
+      <ComplexType Name="filePlanSubcategory" BaseType="microsoft.graph.security.filePlanDescriptorBase"/>
+      <ComplexType Name="filePlanAuthority" BaseType="microsoft.graph.security.filePlanDescriptorBase"/>
+      <ComplexType Name="filePlanCitation" BaseType="microsoft.graph.security.filePlanDescriptorBase">
+        <Property Name="citationJurisdiction" Type="Edm.String"/>
+        <Property Name="citationUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="filePlanDepartment" BaseType="microsoft.graph.security.filePlanDescriptorBase"/>
+      <ComplexType Name="filePlanReference" BaseType="microsoft.graph.security.filePlanDescriptorBase"/>
+      <ComplexType Name="retentionDuration" Abstract="true"/>
+      <ComplexType Name="retentionDurationForever" BaseType="microsoft.graph.security.retentionDuration"/>
+      <ComplexType Name="retentionDurationInDays" BaseType="microsoft.graph.security.retentionDuration">
+        <Property Name="days" Type="Edm.Int32"/>
+      </ComplexType>
       <ComplexType Name="retentionEventStatus">
         <Property Name="error" Type="graph.publicError"/>
         <Property Name="status" Type="microsoft.graph.security.eventStatusType"/>
       </ComplexType>
+      <EntityType Name="filePlanDescriptorTemplate" BaseType="graph.entity">
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="displayName" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="authorityTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate"/>
+      <EntityType Name="categoryTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate">
+        <NavigationProperty Name="subcategories" Type="Collection(microsoft.graph.security.subcategoryTemplate)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="subcategoryTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate"/>
+      <EntityType Name="citationTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate">
+        <Property Name="citationJurisdiction" Type="Edm.String"/>
+        <Property Name="citationUrl" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="departmentTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate"/>
+      <EntityType Name="dispositionReviewStage">
+        <Key>
+          <PropertyRef Name="stageNumber"/>
+        </Key>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="reviewersEmailAddresses" Type="Collection(Edm.String)"/>
+        <Property Name="stageNumber" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="filePlanDescriptor" BaseType="graph.entity">
+        <Property Name="authority" Type="microsoft.graph.security.filePlanAuthority"/>
+        <Property Name="category" Type="microsoft.graph.security.filePlanAppliedCategory"/>
+        <Property Name="citation" Type="microsoft.graph.security.filePlanCitation"/>
+        <Property Name="department" Type="microsoft.graph.security.filePlanDepartment"/>
+        <Property Name="filePlanReference" Type="microsoft.graph.security.filePlanReference"/>
+        <NavigationProperty Name="authorityTemplate" Type="microsoft.graph.security.authorityTemplate"/>
+        <NavigationProperty Name="categoryTemplate" Type="microsoft.graph.security.categoryTemplate"/>
+        <NavigationProperty Name="citationTemplate" Type="microsoft.graph.security.citationTemplate"/>
+        <NavigationProperty Name="departmentTemplate" Type="microsoft.graph.security.departmentTemplate"/>
+        <NavigationProperty Name="filePlanReferenceTemplate" Type="microsoft.graph.security.filePlanReferenceTemplate"/>
+      </EntityType>
+      <EntityType Name="filePlanReferenceTemplate" BaseType="microsoft.graph.security.filePlanDescriptorTemplate"/>
+      <EntityType Name="retentionLabel" BaseType="graph.entity">
+        <Property Name="actionAfterRetentionPeriod" Type="microsoft.graph.security.actionAfterRetentionPeriod"/>
+        <Property Name="behaviorDuringRetentionPeriod" Type="microsoft.graph.security.behaviorDuringRetentionPeriod"/>
+        <Property Name="createdBy" Type="graph.identitySet"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="defaultRecordBehavior" Type="microsoft.graph.security.defaultRecordBehavior"/>
+        <Property Name="descriptionForAdmins" Type="Edm.String"/>
+        <Property Name="descriptionForUsers" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="isInUse" Type="Edm.Boolean"/>
+        <Property Name="labelToBeApplied" Type="Edm.String"/>
+        <Property Name="lastModifiedBy" Type="graph.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="retentionDuration" Type="microsoft.graph.security.retentionDuration"/>
+        <Property Name="retentionTrigger" Type="microsoft.graph.security.retentionTrigger"/>
+        <NavigationProperty Name="descriptors" Type="microsoft.graph.security.filePlanDescriptor" ContainsTarget="true"/>
+        <NavigationProperty Name="dispositionReviewStages" Type="Collection(microsoft.graph.security.dispositionReviewStage)" ContainsTarget="true"/>
+        <NavigationProperty Name="retentionEventType" Type="microsoft.graph.security.retentionEventType"/>
+      </EntityType>
       <EntityType Name="retentionEvent" BaseType="graph.entity">
         <Property Name="createdBy" Type="graph.identitySet"/>
         <Property Name="createdDateTime" Type="Edm.DateTimeOffset"/>
@@ -38524,6 +42957,24 @@
       <Action Name="estimateStatistics" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.security.ediscoverySearch"/>
       </Action>
+      <Action Name="exportReport" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.security.ediscoverySearch"/>
+        <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="description" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="exportCriteria" Type="microsoft.graph.security.exportCriteria"/>
+        <Parameter Name="exportLocation" Type="microsoft.graph.security.exportLocation"/>
+        <Parameter Name="additionalOptions" Type="microsoft.graph.security.additionalOptions"/>
+      </Action>
+      <Action Name="exportResult" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.security.ediscoverySearch"/>
+        <Parameter Name="displayName" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="description" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="exportCriteria" Type="microsoft.graph.security.exportCriteria"/>
+        <Parameter Name="exportLocation" Type="microsoft.graph.security.exportLocation"/>
+        <Parameter Name="additionalOptions" Type="microsoft.graph.security.additionalOptions"/>
+        <Parameter Name="exportFormat" Type="microsoft.graph.security.exportFormat"/>
+        <Parameter Name="exportSingleItems" Type="Edm.Boolean"/>
+      </Action>
       <Action Name="purgeData" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.security.ediscoverySearch"/>
         <Parameter Name="purgeType" Type="microsoft.graph.security.purgeType">
@@ -38540,9 +42991,24 @@
         <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.security.ediscoveryReviewTag)"/>
         <ReturnType Type="Collection(microsoft.graph.security.ediscoveryReviewTag)"/>
       </Function>
+      <Action Name="regenerateDeploymentAccessKey" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.security.sensor)"/>
+        <ReturnType Type="microsoft.graph.security.deploymentAccessKeyType"/>
+      </Action>
+      <Function Name="getDeploymentAccessKey" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.security.sensor)"/>
+        <ReturnType Type="microsoft.graph.security.deploymentAccessKeyType"/>
+      </Function>
+      <Function Name="getDeploymentPackageUri" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(microsoft.graph.security.sensor)"/>
+        <ReturnType Type="microsoft.graph.security.sensorDeploymentPackage"/>
+      </Function>
       <Action Name="runHuntingQuery" IsBound="true">
         <Parameter Name="bindingParameter" Type="graph.security"/>
         <Parameter Name="query" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="timespan" Type="Edm.String" Unicode="false">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
         <ReturnType Type="microsoft.graph.security.huntingQueryResults"/>
       </Action>
     </Schema>
@@ -38775,8 +43241,13 @@
         <Property Name="startDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
         <Property Name="type" Type="microsoft.graph.callRecords.callType" Nullable="false"/>
         <Property Name="version" Type="Edm.Int64" Nullable="false"/>
+        <NavigationProperty Name="organizer_v2" Type="microsoft.graph.callRecords.organizer" ContainsTarget="true"/>
+        <NavigationProperty Name="participants_v2" Type="Collection(microsoft.graph.callRecords.participant)" ContainsTarget="true"/>
         <NavigationProperty Name="sessions" Type="Collection(microsoft.graph.callRecords.session)" ContainsTarget="true"/>
       </EntityType>
+      <ComplexType Name="administrativeUnitInfo">
+        <Property Name="id" Type="Edm.String"/>
+      </ComplexType>
       <ComplexType Name="userAgent" Abstract="true">
         <Property Name="applicationVersion" Type="Edm.String"/>
         <Property Name="headerValue" Type="Edm.String"/>
@@ -38915,6 +43386,7 @@
         <Property Name="roundTripTime" Type="Edm.Duration"/>
       </ComplexType>
       <ComplexType Name="participantEndpoint" BaseType="microsoft.graph.callRecords.endpoint">
+        <Property Name="associatedIdentity" Type="graph.identity"/>
         <Property Name="cpuCoresCount" Type="Edm.Int32"/>
         <Property Name="cpuName" Type="Edm.String"/>
         <Property Name="cpuProcessorSpeedInMhz" Type="Edm.Int32"/>
@@ -38933,9 +43405,9 @@
         <Property Name="callerNumber" Type="Edm.String"/>
         <Property Name="callId" Type="Edm.String"/>
         <Property Name="callType" Type="Edm.String"/>
-        <Property Name="charge" Type="Edm.Decimal" Scale="Variable"/>
+        <Property Name="charge" Type="Edm.Decimal" Scale="variable"/>
         <Property Name="conferenceId" Type="Edm.String"/>
-        <Property Name="connectionCharge" Type="Edm.Decimal" Scale="Variable"/>
+        <Property Name="connectionCharge" Type="Edm.Decimal" Scale="variable"/>
         <Property Name="currency" Type="Edm.String"/>
         <Property Name="destinationContext" Type="Edm.String"/>
         <Property Name="destinationName" Type="Edm.String"/>
@@ -38956,6 +43428,15 @@
       <ComplexType Name="serviceUserAgent" BaseType="microsoft.graph.callRecords.userAgent">
         <Property Name="role" Type="microsoft.graph.callRecords.serviceRole" Nullable="false"/>
       </ComplexType>
+      <ComplexType Name="userIdentity" BaseType="graph.identity" OpenType="true">
+        <Property Name="userPrincipalName" Type="Edm.String"/>
+      </ComplexType>
+      <EntityType Name="participantBase" BaseType="graph.entity" Abstract="true">
+        <Property Name="administrativeUnitInfos" Type="Collection(microsoft.graph.callRecords.administrativeUnitInfo)"/>
+        <Property Name="identity" Type="graph.communicationsIdentitySet"/>
+      </EntityType>
+      <EntityType Name="organizer" BaseType="microsoft.graph.callRecords.participantBase"/>
+      <EntityType Name="participant" BaseType="microsoft.graph.callRecords.participantBase"/>
       <EntityType Name="session" BaseType="graph.entity">
         <Property Name="callee" Type="microsoft.graph.callRecords.endpoint"/>
         <Property Name="caller" Type="microsoft.graph.callRecords.endpoint"/>
@@ -38986,6 +43467,147 @@
         <Parameter Name="toDateTime" Type="Edm.DateTimeOffset"/>
         <ReturnType Type="Collection(microsoft.graph.callRecords.pstnCallLogRow)"/>
       </Function>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph.partners.billing">
+      <EnumType Name="attributeSet">
+        <Member Name="full" Value="1"/>
+        <Member Name="basic" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EnumType Name="billingPeriod">
+        <Member Name="current" Value="1"/>
+        <Member Name="last" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EntityType Name="billing" BaseType="graph.entity">
+        <NavigationProperty Name="manifests" Type="Collection(microsoft.graph.partners.billing.manifest)" ContainsTarget="true"/>
+        <NavigationProperty Name="operations" Type="Collection(microsoft.graph.partners.billing.operation)" ContainsTarget="true"/>
+        <NavigationProperty Name="reconciliation" Type="microsoft.graph.partners.billing.billingReconciliation" Nullable="false" ContainsTarget="true"/>
+        <NavigationProperty Name="usage" Type="microsoft.graph.partners.billing.azureUsage" Nullable="false" ContainsTarget="true"/>
+      </EntityType>
+      <ComplexType Name="blob">
+        <Property Name="name" Type="Edm.String" Nullable="false"/>
+        <Property Name="partitionValue" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+      <EntityType Name="azureUsage" BaseType="graph.entity">
+        <NavigationProperty Name="billed" Type="microsoft.graph.partners.billing.billedUsage" Nullable="false" ContainsTarget="true"/>
+        <NavigationProperty Name="unbilled" Type="microsoft.graph.partners.billing.unbilledUsage" Nullable="false" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="billedUsage" BaseType="graph.entity"/>
+      <EntityType Name="unbilledUsage" BaseType="graph.entity"/>
+      <EntityType Name="billedReconciliation" BaseType="graph.entity"/>
+      <EntityType Name="manifest" BaseType="graph.entity">
+        <Property Name="blobCount" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="blobs" Type="Collection(microsoft.graph.partners.billing.blob)" Nullable="false"/>
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="dataFormat" Type="Edm.String" Nullable="false"/>
+        <Property Name="eTag" Type="Edm.String" Nullable="false"/>
+        <Property Name="partitionType" Type="Edm.String" Nullable="false"/>
+        <Property Name="partnerTenantId" Type="Edm.String" Nullable="false"/>
+        <Property Name="rootDirectory" Type="Edm.String" Nullable="false"/>
+        <Property Name="sasToken" Type="Edm.String" Nullable="false"/>
+        <Property Name="schemaVersion" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="operation" BaseType="graph.entity">
+        <Property Name="createdDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="lastActionDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="status" Type="graph.longRunningOperationStatus"/>
+      </EntityType>
+      <EntityType Name="billingReconciliation" BaseType="graph.entity">
+        <NavigationProperty Name="billed" Type="microsoft.graph.partners.billing.billedReconciliation" Nullable="false" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="exportSuccessOperation" BaseType="microsoft.graph.partners.billing.operation">
+        <NavigationProperty Name="resourceLocation" Type="microsoft.graph.partners.billing.manifest" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="failedOperation" BaseType="microsoft.graph.partners.billing.operation">
+        <Property Name="error" Type="graph.publicError" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="runningOperation" BaseType="microsoft.graph.partners.billing.operation"/>
+      <Action Name="export" IsBound="true">
+        <Parameter Name="this" Type="microsoft.graph.partners.billing.billedReconciliation"/>
+        <Parameter Name="invoiceId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="attributeSet" Type="microsoft.graph.partners.billing.attributeSet">
+          <Annotation Term="Org.OData.Core.V1.OptionalParameter"/>
+        </Parameter>
+        <ReturnType Type="microsoft.graph.partners.billing.operation"/>
+      </Action>
+      <Action Name="export" IsBound="true">
+        <Parameter Name="this" Type="microsoft.graph.partners.billing.billedUsage"/>
+        <Parameter Name="invoiceId" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="attributeSet" Type="microsoft.graph.partners.billing.attributeSet"/>
+        <ReturnType Type="microsoft.graph.partners.billing.operation"/>
+      </Action>
+      <Action Name="export" IsBound="true">
+        <Parameter Name="this" Type="microsoft.graph.partners.billing.unbilledUsage"/>
+        <Parameter Name="currencyCode" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="billingPeriod" Type="microsoft.graph.partners.billing.billingPeriod"/>
+        <Parameter Name="attributeSet" Type="microsoft.graph.partners.billing.attributeSet"/>
+        <ReturnType Type="microsoft.graph.partners.billing.operation"/>
+      </Action>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph.search">
+      <EnumType Name="answerState">
+        <Member Name="published" Value="0"/>
+        <Member Name="draft" Value="1"/>
+        <Member Name="excluded" Value="2"/>
+        <Member Name="unknownFutureValue" Value="3"/>
+      </EnumType>
+      <EntityType Name="searchAnswer" BaseType="graph.entity">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String" Nullable="false"/>
+        <Property Name="lastModifiedBy" Type="microsoft.graph.search.identitySet"/>
+        <Property Name="lastModifiedDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="acronym" BaseType="microsoft.graph.search.searchAnswer">
+        <Property Name="standsFor" Type="Edm.String"/>
+        <Property Name="state" Type="microsoft.graph.search.answerState" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="bookmark" BaseType="microsoft.graph.search.searchAnswer">
+        <Property Name="availabilityEndDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="availabilityStartDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="categories" Type="Collection(Edm.String)"/>
+        <Property Name="groupIds" Type="Collection(Edm.String)"/>
+        <Property Name="isSuggested" Type="Edm.Boolean"/>
+        <Property Name="keywords" Type="microsoft.graph.search.answerKeyword"/>
+        <Property Name="languageTags" Type="Collection(Edm.String)"/>
+        <Property Name="platforms" Type="Collection(graph.devicePlatformType)" Nullable="false"/>
+        <Property Name="powerAppIds" Type="Collection(Edm.String)"/>
+        <Property Name="state" Type="microsoft.graph.search.answerState" Nullable="false"/>
+        <Property Name="targetedVariations" Type="Collection(microsoft.graph.search.answerVariant)"/>
+      </EntityType>
+      <EntityType Name="qna" BaseType="microsoft.graph.search.searchAnswer">
+        <Property Name="availabilityEndDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="availabilityStartDateTime" Type="Edm.DateTimeOffset"/>
+        <Property Name="groupIds" Type="Collection(Edm.String)"/>
+        <Property Name="isSuggested" Type="Edm.Boolean"/>
+        <Property Name="keywords" Type="microsoft.graph.search.answerKeyword"/>
+        <Property Name="languageTags" Type="Collection(Edm.String)"/>
+        <Property Name="platforms" Type="Collection(graph.devicePlatformType)" Nullable="false"/>
+        <Property Name="state" Type="microsoft.graph.search.answerState" Nullable="false"/>
+        <Property Name="targetedVariations" Type="Collection(microsoft.graph.search.answerVariant)"/>
+      </EntityType>
+      <ComplexType Name="answerKeyword">
+        <Property Name="keywords" Type="Collection(Edm.String)"/>
+        <Property Name="matchSimilarKeywords" Type="Edm.Boolean"/>
+        <Property Name="reservedKeywords" Type="Collection(Edm.String)"/>
+      </ComplexType>
+      <ComplexType Name="answerVariant">
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="languageTag" Type="Edm.String"/>
+        <Property Name="platform" Type="graph.devicePlatformType"/>
+        <Property Name="webUrl" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="identity" OpenType="true">
+        <Property Name="displayName" Type="Edm.String"/>
+        <Property Name="id" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="identitySet" OpenType="true">
+        <Property Name="application" Type="microsoft.graph.search.identity"/>
+        <Property Name="device" Type="microsoft.graph.search.identity"/>
+        <Property Name="user" Type="microsoft.graph.search.identity"/>
+      </ComplexType>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph.externalConnectors">
       <EnumType Name="accessType">

--- a/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
+++ b/odata-client-generator/src/test/java/com/github/davidmoten/odata/client/generator/GeneratorTest.java
@@ -8,10 +8,11 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.junit.Test;
@@ -19,6 +20,10 @@ import org.oasisopen.odata.csdl.v4.TDataServices;
 import org.oasisopen.odata.csdl.v4.TEdmx;
 
 import com.github.davidmoten.guavamini.Lists;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 public class GeneratorTest {
 
@@ -28,32 +33,27 @@ public class GeneratorTest {
     public void testGenerateMsgraph() throws JAXBException, IOException {
         JAXBContext c = JAXBContext.newInstance(TDataServices.class);
         Unmarshaller unmarshaller = c.createUnmarshaller();
-        TEdmx t = unmarshaller.unmarshal(
-                new StreamSource(new FileInputStream("src/main/odata/msgraph-metadata.xml")),
-                TEdmx.class).getValue();
-        SchemaOptions o1 = new SchemaOptions("microsoft.graph",
-                "microsoft.graph.generated");
-        SchemaOptions o2 = new SchemaOptions("microsoft.graph.callRecords",
-                "microsoft.graph.callrecords.generated");
-        SchemaOptions o3 = new SchemaOptions("microsoft.graph.externalConnectors", 
-                "microsoft.graph.externalconnectors.generated");
-        SchemaOptions o4 = new SchemaOptions("microsoft.graph.ediscovery", 
-                "microsoft.graph.ediscovery.generated");
-        SchemaOptions o5 = new SchemaOptions("microsoft.graph.termStore", 
-                "microsoft.graph.termstore.generated");
-        SchemaOptions o6 = new SchemaOptions("microsoft.graph.security", 
-                "microsoft.graph.security");
-        SchemaOptions o7 = new SchemaOptions("microsoft.graph.industryData", 
-                        "microsoft.graph.industrydata");
-        SchemaOptions o8 = new SchemaOptions("microsoft.graph.identityGovernance", 
-                "microsoft.graph.identitygovernance");
-        SchemaOptions o9 = new SchemaOptions("microsoft.graph.search", 
-                "microsoft.graph.searchs");
-        SchemaOptions o10 = new SchemaOptions("microsoft.graph.partners.billing", 
-                "microsoft.graph.partnersbilling");
-        Options options = new Options(GENERATED, Lists.newArrayList(o1, o2, o3, o4, o5, o6, o7, o8, o9, o10));
-        Generator g = new Generator(options,
-                t.getDataServices().getSchema());
+        TEdmx t = unmarshaller
+                .unmarshal(new StreamSource(new FileInputStream("src/main/odata/msgraph-metadata.xml")), TEdmx.class)
+                .getValue();
+
+        Map<String, String> schemas = new HashMap<>();
+        schemas.put("microsoft.graph", "microsoft.graph.generated");
+        schemas.put("microsoft.graph.callRecords", "microsoft.graph.callrecords.generated");
+        schemas.put("microsoft.graph.externalConnectors", "microsoft.graph.externalconnectors.generated");
+        schemas.put("microsoft.graph.ediscovery", "microsoft.graph.ediscovery.generated");
+        schemas.put("microsoft.graph.termStore", "microsoft.graph.termstore.generated");
+        schemas.put("microsoft.graph.security", "microsoft.graph.security");
+        schemas.put("microsoft.graph.industryData", "microsoft.graph.industrydata");
+        schemas.put("microsoft.graph.identityGovernance", "microsoft.graph.identitygovernance");
+        schemas.put("microsoft.graph.search", "microsoft.graph.searchs");
+        schemas.put("microsoft.graph.partners.billing", "microsoft.graph.partnersbilling");
+        List<SchemaOptions> list = schemas.entrySet().stream() //
+                .map(entry -> new SchemaOptions(entry.getKey(), entry.getValue())) //
+                .collect(Collectors.toList());
+        Options options = new Options(GENERATED, list);
+
+        Generator g = new Generator(options, t.getDataServices().getSchema());
         g.generate();
         File file = new File(GENERATED + "/microsoft/graph/generated/entity/FileAttachment.java");
         Files.copy(file.toPath(), new File("../src/docs/FileAttachment.java").toPath(),
@@ -65,37 +65,35 @@ public class GeneratorTest {
         JAXBContext c = JAXBContext.newInstance(TDataServices.class);
         Unmarshaller unmarshaller = c.createUnmarshaller();
         TEdmx t = unmarshaller.unmarshal(
-                new StreamSource(new FileInputStream(
-                        "../odata-client-msgraph-beta/src/main/odata/msgraph-beta-metadata.xml")),
+                new StreamSource(
+                        new FileInputStream("../odata-client-msgraph-beta/src/main/odata/msgraph-beta-metadata.xml")),
                 TEdmx.class).getValue();
         t.getDataServices().getSchema().forEach(s -> System.out.println(s.getNamespace()));
-        SchemaOptions o1 = new SchemaOptions("microsoft.graph",
-                "microsoft.graph.beta.generated");
-        SchemaOptions o2 = new SchemaOptions("microsoft.graph.callRecords",
-                "microsoft.graph.beta.callRecords.generated");
-        SchemaOptions o3 = new SchemaOptions("microsoft.graph.termStore",
-                "microsoft.graph.beta.termStore.generated");
-        SchemaOptions o4 = new SchemaOptions("microsoft.graph.ediscovery",
-                "microsoft.graph.beta.ediscovery.generated");
-        SchemaOptions o5 = new SchemaOptions("microsoft.graph.externalConnectors",
-                "microsoft.graph.beta.external.connectors");
-        SchemaOptions o6 = new SchemaOptions("microsoft.graph.windowsUpdates",
-                "microsoft.graph.beta.windows.updates");
-        // microsoft.graph.managedTenants
-        SchemaOptions o7 = new SchemaOptions("microsoft.graph.managedTenants",
-                "microsoft.graph.beta.managed.tenants");
-        SchemaOptions o8 = new SchemaOptions("microsoft.graph.search",
-                "microsoft.graph.beta.search");
-        SchemaOptions o9 = new SchemaOptions("microsoft.graph.security",
-                "microsoft.graph.beta.security");
-        SchemaOptions o10 = new SchemaOptions("microsoft.graph.identityGovernance",
-                "microsoft.graph.beta.identity.governance");
-        SchemaOptions o11 = new SchemaOptions("microsoft.graph.deviceManagement",
-                "microsoft.graph.beta.device.management");
-        SchemaOptions o12 = new SchemaOptions("microsoft.graph.tenantAdmin",
-                "microsoft.graph.beta.tenant.admin");
-        Options options = new Options(GENERATED, Arrays.asList(o1, o2,
-                o3, o4, o5, o6, o7, o8, o9, o10, o11, o12));
+        Map<String, String> schemas = new HashMap<>();
+        schemas.put("microsoft.graph", "microsoft.graph.beta.generated");
+        schemas.put("microsoft.graph.callRecords", "microsoft.graph.beta.callRecords.generated");
+        schemas.put("microsoft.graph.termStore", "microsoft.graph.beta.termStore.generated");
+        schemas.put("microsoft.graph.ediscovery", "microsoft.graph.beta.ediscovery.generated");
+        schemas.put("microsoft.graph.externalConnectors", "microsoft.graph.beta.external.connectors");
+        schemas.put("microsoft.graph.windowsUpdates", "microsoft.graph.beta.windows.updates");
+        schemas.put("microsoft.graph.managedTenants", "microsoft.graph.beta.managed.tenants");
+        schemas.put("microsoft.graph.search", "microsoft.graph.beta.search");
+        schemas.put("microsoft.graph.security", "microsoft.graph.beta.security");
+        schemas.put("microsoft.graph.identityGovernance", "microsoft.graph.beta.identity.governance");
+        schemas.put("microsoft.graph.deviceManagement", "microsoft.graph.beta.device.management");
+        schemas.put("microsoft.graph.tenantAdmin", "microsoft.graph.beta.tenant.admin");
+        schemas.put("microsoft.graph.healthMonitoring", "microsoft.graph.beta.health.monitoring");
+        schemas.put("microsoft.graph.networkaccess", "microsoft.graph.beta.networkaccess");
+        schemas.put("microsoft.graph.cloudLicensing", "microsoft.graph.beta.cloud.licencing");
+        schemas.put("microsoft.graph.teamsAdministration", "microsoft.graph.beta.teams.administration");
+        schemas.put("microsoft.graph.industryData", "microsoft.graph.beta.industry.data");
+        schemas.put("microsoft.graph.partners.billing", "microsoft.graph.beta.partners.billing");
+        schemas.put("microsoft.graph.partners.security", "microsoft.graph.beta.partners.security");
+        schemas.put("microsoft.graph.partner.security", "microsoft.graph.beta.partner.security");
+        List<SchemaOptions> list = schemas.entrySet().stream() //
+                .map(entry -> new SchemaOptions(entry.getKey(), entry.getValue())) //
+                .collect(Collectors.toList());
+        Options options = new Options(GENERATED, list);
         Generator g = new Generator(options, t.getDataServices().getSchema());
         g.generate();
     }

--- a/odata-client-msgraph/pom.xml
+++ b/odata-client-msgraph/pom.xml
@@ -99,6 +99,10 @@
                                     <namespace>microsoft.graph.termStore</namespace>
                                     <packageName>odata.msgraph.client.termstore</packageName>
                                 </schema>
+                                <schema>
+                                    <namespace>microsoft.graph.partners.billing</namespace>
+                                    <packageName>odata.msgraph.client.partners.billing</packageName>
+                                </schema>
                             </schemas>
                         </configuration>
                     </execution>


### PR DESCRIPTION
identically named base types from different schemas were being picked up into the builders of types from other schemas. This PR fixes that issue.