### PR TITLE
Field name conflicts when property names differ by case only

### DIFF
--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1655,12 +1655,12 @@ public final class Generator {
     private void printPropertyGetterAndSetters(Structure<?> structure, Imports imports, Indent indent, PrintWriter p,
             String simpleClassName, String fullType, boolean ofEntity, Set<String> methodNames, String propertyName,
             String t, boolean isCollection, boolean isStream, boolean isUnicode) {
-        String fieldName = Names.getIdentifier(propertyName);
+        String fieldName = names.fieldName(structure, propertyName).getFieldName();
         structure.printPropertyJavadoc(p, indent, propertyName, "property " + propertyName,
         		Collections.emptyMap());
         addPropertyAnnotation(imports, indent, p, propertyName);
         p.format("\n%s@%s\n", indent, imports.add(JsonIgnore.class));
-        String methodName = Names.getGetterMethod(propertyName);
+        String methodName = Names.getGetterMethod(fieldName);
         methodNames.add(methodName);
         if (isCollection) {
         	String inner = names.getInnerType(t);

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Generator.java
@@ -1655,7 +1655,7 @@ public final class Generator {
     private void printPropertyGetterAndSetters(Structure<?> structure, Imports imports, Indent indent, PrintWriter p,
             String simpleClassName, String fullType, boolean ofEntity, Set<String> methodNames, String propertyName,
             String t, boolean isCollection, boolean isStream, boolean isUnicode) {
-        String fieldName = names.fieldName(structure, propertyName).getFieldName();
+        String fieldName = names.property(structure, propertyName).getFieldName();
         structure.printPropertyJavadoc(p, indent, propertyName, "property " + propertyName,
         		Collections.emptyMap());
         addPropertyAnnotation(imports, indent, p, propertyName);

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
@@ -671,7 +671,7 @@ public final class Names {
         return method.toString().toLowerCase(Locale.ENGLISH) + "Chunked" +  upperFirst(name);
     }
     
-    public Property fieldName(Structure<?> structure, String propertyName) {
+    public Property property(Structure<?> structure, String propertyName) {
         NamedStructure s = new NamedStructure(structure, propertyName);
         PropertyWithFieldName v = structureProperties.get(s);
         if (v == null) {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/Names.java
@@ -2,6 +2,7 @@ package com.github.davidmoten.odata.client.generator;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -25,6 +26,8 @@ import com.github.davidmoten.guavamini.Sets;
 import com.github.davidmoten.odata.client.CollectionPageEntityRequest;
 import com.github.davidmoten.odata.client.HttpMethod;
 import com.github.davidmoten.odata.client.generator.model.EntityType;
+import com.github.davidmoten.odata.client.generator.model.Property;
+import com.github.davidmoten.odata.client.generator.model.Structure;
 import com.github.davidmoten.odata.client.internal.EdmSchemaInfo;
 
 public final class Names {
@@ -664,4 +667,35 @@ public final class Names {
         return method.toString().toLowerCase(Locale.ENGLISH) + "Chunked" +  upperFirst(name);
     }
 
+    public Property fieldName(Structure<?> structure, String propertyName) {
+        // field name to property/fieldName
+        Set<String> fieldNames = new HashSet<>();
+        // property name to field name
+        Map<String, PropertyWithFieldName> properties = new HashMap<>();
+        structure.getHeirarchy()
+                .stream() //
+                .flatMap(x -> x.getProperties().stream()) //
+                .sorted((a, b) -> a.getName().compareTo(b.getName())) //
+                .forEach(p -> {
+                    String fieldName = Names.getIdentifier(p.getName());
+                    while (fieldNames.contains(fieldName)) {
+                        fieldName += "_";
+                    }
+                    fieldNames.add(fieldName);
+                    properties.put(p.getName(), new PropertyWithFieldName(p, fieldName));
+                });
+        PropertyWithFieldName p = properties.get(propertyName);
+        return new Property(((TProperty) p.property), p.fieldName, this);
+    }
+    
+    private static final class PropertyWithFieldName {
+        final Object property;
+        final String fieldName;
+        
+        PropertyWithFieldName(Object property, String fieldName) {
+            this.property = property;
+            this.fieldName = fieldName;
+        }
+    }
+    
 }

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Property.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Property.java
@@ -4,15 +4,16 @@ import org.oasisopen.odata.csdl.v4.TProperty;
 
 import com.github.davidmoten.odata.client.generator.Imports;
 import com.github.davidmoten.odata.client.generator.Names;
-import com.github.davidmoten.odata.client.internal.EdmSchemaInfo;
 
 public final class Property {
 
     private final TProperty p;
+    private final String fieldName;
     private final Names names;
 
-    public Property(TProperty p, Names names) {
+    public Property(TProperty p, String fieldName, Names names) {
         this.p = p;
+        this.fieldName = fieldName;
         this.names = names;
     }
 
@@ -25,7 +26,7 @@ public final class Property {
     }
     
     public String getFieldName() {
-        return Names.getIdentifier(p.getName());
+        return fieldName;
     }
 
     public String getName() {

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/PropertyRef.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/PropertyRef.java
@@ -33,6 +33,6 @@ public class PropertyRef {
     }
 
     public Property getReferredProperty() {
-        return names.fieldName(entityType, getName());
+        return names.property(entityType, getName());
     }
 }

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/PropertyRef.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/PropertyRef.java
@@ -1,5 +1,9 @@
 package com.github.davidmoten.odata.client.generator.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.oasisopen.odata.csdl.v4.TProperty;
 import org.oasisopen.odata.csdl.v4.TPropertyRef;
 
 import com.github.davidmoten.odata.client.generator.Names;
@@ -9,7 +13,7 @@ public class PropertyRef {
     private final TPropertyRef value;
     private final EntityType entityType;
     private final Names names;
-
+    
     public PropertyRef(TPropertyRef value, EntityType entityType, Names names) {
         this.value = value;
         this.entityType = entityType;
@@ -29,14 +33,6 @@ public class PropertyRef {
     }
 
     public Property getReferredProperty() {
-        return entityType //
-                .getHeirarchy() //
-                .stream() //
-                .flatMap(x -> x.getProperties().stream()) //
-                .filter(x -> x.getName().equals(getName())) //
-                .map(x -> new Property(x, names)) //
-                .findFirst() //
-                .get();
+        return names.fieldName(entityType, getName());
     }
-
 }

--- a/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Structure.java
+++ b/odata-client-generator/src/main/java/com/github/davidmoten/odata/client/generator/model/Structure.java
@@ -58,7 +58,7 @@ public abstract class Structure<T> {
 
     public abstract boolean isEntityType();
 
-    public final List<? extends Structure<T>> getHeirarchy() {
+    public final List<Structure<T>> getHeirarchy() {
         List<Structure<T>> a = new LinkedList<>();
         a.add(create(schema(), value));
         Structure<T> st = this;

--- a/odata-client-test-unit/src/main/odata/metadata1.xml
+++ b/odata-client-test-unit/src/main/odata/metadata1.xml
@@ -11,6 +11,7 @@
                 <Property Name="ID" Type="Edm.Int32"
                     Nullable="false" />
                 <Property Name="Name" Type="Edm.String" />
+                <Property Name="package" Type = "Edm.String" />
                 <NavigationProperty Name="Package" Type="Test1.A.Package" />
             </EntityType>
             <EntityType Name="Package">


### PR DESCRIPTION
As discussed in #531 a property `package` and a navigation property `Package` have distinct names but generate to compile errors because of naming conflict. This PR fixes that issue so that conflicting properties have 1 or more underscores suffixed to their field/getter names.